### PR TITLE
feat(a2x): add protocol version config and response mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const executor = new AgentExecutor({
 const taskStore = new InMemoryTaskStore();
 
 // 3. Create A2XAgent — name, description, and streaming are auto-extracted
-const a2xAgent = new A2XAgent(taskStore, executor)
+const a2xAgent = new A2XAgent({ taskStore, executor })
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .addSkill({
     id: 'chat',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint packages/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "cli:install": "pnpm --filter @a2x/cli build && npm install -g ./packages/cli"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -39,10 +39,90 @@ function createA2XAgent(
   });
   const taskStore = new InMemoryTaskStore();
 
-  return new A2XAgent(taskStore, executor);
+  return new A2XAgent({ taskStore, executor });
 }
 
 describe('Layer 3: A2XAgent', () => {
+  describe('Constructor - options object', () => {
+    it('should construct with required options', () => {
+      const a2x = createA2XAgent();
+      expect(a2x).toBeDefined();
+      expect(a2x.protocolVersion).toBe('1.0');
+    });
+
+    it('should accept protocolVersion 0.3', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const taskStore = new InMemoryTaskStore();
+
+      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      expect(a2x.protocolVersion).toBe('0.3');
+    });
+
+    it('should accept protocolVersion 1.0', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const taskStore = new InMemoryTaskStore();
+
+      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' });
+      expect(a2x.protocolVersion).toBe('1.0');
+    });
+
+    it('should default protocolVersion to 1.0 when omitted', () => {
+      const a2x = createA2XAgent();
+      expect(a2x.protocolVersion).toBe('1.0');
+    });
+
+    it('should throw for unsupported protocolVersion', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const taskStore = new InMemoryTaskStore();
+
+      expect(
+        () => new A2XAgent({ taskStore, executor, protocolVersion: '2.0' as '0.3' }),
+      ).toThrow("unsupported protocolVersion '2.0'");
+    });
+
+    it('should throw when taskStore is missing', () => {
+      expect(
+        () => new A2XAgent({ taskStore: null as never, executor: {} as never }),
+      ).toThrow('taskStore is required');
+    });
+
+    it('should throw when executor is missing', () => {
+      expect(
+        () => new A2XAgent({ taskStore: {} as never, executor: null as never }),
+      ).toThrow('executor is required');
+    });
+  });
+
   describe('Builder methods', () => {
     it('should chain builder methods', () => {
       const a2x = createA2XAgent();
@@ -216,6 +296,50 @@ describe('Layer 3: A2XAgent', () => {
     });
   });
 
+  describe('getAgentCard - default version from config', () => {
+    it('should use configured protocolVersion when no argument is given', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test desc',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const taskStore = new InMemoryTaskStore();
+
+      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      a2x.setDefaultUrl('https://example.com/a2a');
+
+      const card = a2x.getAgentCard() as AgentCardV03;
+      expect(card.protocolVersion).toBe('0.3.0');
+    });
+
+    it('should allow explicit version to override configured protocolVersion', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test desc',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const taskStore = new InMemoryTaskStore();
+
+      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      a2x.setDefaultUrl('https://example.com/a2a');
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.supportedInterfaces).toBeDefined();
+    });
+  });
+
   describe('getAgentCard - validation', () => {
     it('should throw when name is missing', () => {
       const agent = new LlmAgent({
@@ -229,7 +353,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent(new InMemoryTaskStore(), executor);
+      const a2x = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor });
 
       expect(() => a2x.getAgentCard()).toThrow('name is required');
     });
@@ -246,7 +370,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent(new InMemoryTaskStore(), executor);
+      const a2x = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor });
 
       expect(() => a2x.getAgentCard()).toThrow('description is required');
     });

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { DefaultRequestHandler } from '../transport/request-handler.js';
 import { A2XAgent } from '../a2x/a2x-agent.js';
+import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
@@ -20,7 +21,7 @@ const mockProvider = new (class extends BaseLlmProvider {
   }
 })();
 
-function createHandler(): DefaultRequestHandler {
+function createHandler(protocolVersion?: ProtocolVersion): DefaultRequestHandler {
   const agent = new LlmAgent({
     name: 'test-agent',
     provider: mockProvider,
@@ -34,7 +35,7 @@ function createHandler(): DefaultRequestHandler {
     runConfig: { streamingMode: StreamingMode.SSE },
   });
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent(taskStore, executor);
+  const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion });
   a2xAgent.setDefaultUrl('https://example.com/a2a');
 
   return new DefaultRequestHandler(a2xAgent);
@@ -118,7 +119,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect('result' in rpc).toBe(true);
       const task = (rpc as { result: unknown }).result as { id: string; status: { state: string } };
       expect(task.id).toBeDefined();
-      expect(task.status.state).toBe('completed');
+      // Default is v1.0, so state should be UPPER_SNAKE_CASE
+      expect(task.status.state).toBe('TASK_STATE_COMPLETED');
     });
 
     it('should return invalid params when message is missing', async () => {
@@ -136,6 +138,104 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.INVALID_PARAMS,
       );
+    });
+  });
+
+  describe('message/send - v0.3 response format', () => {
+    it('should include kind discriminators in v0.3 mode', async () => {
+      const handler = createHandler('0.3');
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('result' in rpc).toBe(true);
+      const task = (rpc as { result: unknown }).result as Record<string, unknown>;
+
+      // Task-level kind
+      expect(task.kind).toBe('task');
+
+      // State should be lowercase
+      expect((task.status as Record<string, unknown>).state).toBe('completed');
+
+      // History should include the user message with kind discriminators
+      const history = task.history as Array<Record<string, unknown>>;
+      expect(history).toBeDefined();
+      expect(history.length).toBeGreaterThanOrEqual(1);
+      expect(history[0].kind).toBe('message');
+      expect(history[0].role).toBe('user');
+
+      const parts = history[0].parts as Array<Record<string, unknown>>;
+      expect(parts[0].kind).toBe('text');
+    });
+
+    it('should default artifact name to "response" in v0.3 mode', async () => {
+      const handler = createHandler('0.3');
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      const rpc = response as JSONRPCResponse;
+      const task = (rpc as { result: unknown }).result as Record<string, unknown>;
+      const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
+
+      if (artifacts && artifacts.length > 0) {
+        // Each artifact should have a name (defaulting to "response")
+        for (const artifact of artifacts) {
+          expect(artifact.name).toBeDefined();
+        }
+      }
+    });
+  });
+
+  describe('message/send - v1.0 response format', () => {
+    it('should NOT include kind discriminators in v1.0 mode', async () => {
+      const handler = createHandler('1.0');
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('result' in rpc).toBe(true);
+      const task = (rpc as { result: unknown }).result as Record<string, unknown>;
+
+      // No kind field
+      expect(task.kind).toBeUndefined();
+
+      // State should be UPPER_SNAKE_CASE
+      expect((task.status as Record<string, unknown>).state).toBe('TASK_STATE_COMPLETED');
+
+      // No injected history
+      expect(task.history).toBeUndefined();
     });
   });
 
@@ -190,6 +290,76 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const retrieved = (rpc as { result: unknown }).result as { id: string };
       expect(retrieved.id).toBe(task.id);
     });
+
+    it('should apply v1.0 mapping to tasks/get response', async () => {
+      const handler = createHandler('1.0');
+
+      // Create a task
+      const sendResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      const task = ((sendResponse as JSONRPCResponse) as { result: unknown }).result as { id: string };
+
+      // Get the task
+      const getResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tasks/get',
+        params: { id: task.id },
+      });
+
+      const rpc = getResponse as JSONRPCResponse;
+      const retrieved = (rpc as { result: unknown }).result as Record<string, unknown>;
+
+      // v1.0: no kind, UPPER_SNAKE_CASE state
+      expect(retrieved.kind).toBeUndefined();
+      expect((retrieved.status as Record<string, unknown>).state).toBe('TASK_STATE_COMPLETED');
+    });
+
+    it('should apply v0.3 mapping to tasks/get response', async () => {
+      const handler = createHandler('0.3');
+
+      // Create a task
+      const sendResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      const task = ((sendResponse as JSONRPCResponse) as { result: unknown }).result as { id: string };
+
+      // Get the task
+      const getResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tasks/get',
+        params: { id: task.id },
+      });
+
+      const rpc = getResponse as JSONRPCResponse;
+      const retrieved = (rpc as { result: unknown }).result as Record<string, unknown>;
+
+      // v0.3: has kind, lowercase state
+      expect(retrieved.kind).toBe('task');
+      expect((retrieved.status as Record<string, unknown>).state).toBe('completed');
+    });
   });
 
   describe('tasks/cancel', () => {
@@ -230,7 +400,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect(isAsyncGenerator(result)).toBe(true);
 
       // Consume the async generator and collect events
-      const generator = result as AsyncGenerator<{ status?: { state: string } }>;
+      const generator = result as AsyncGenerator<Record<string, unknown>>;
       const events: unknown[] = [];
 
       for await (const event of generator) {
@@ -240,16 +410,94 @@ describe('Layer 4: DefaultRequestHandler', () => {
       // Should have received events (status_update + artifact_updates + final status)
       expect(events.length).toBeGreaterThan(0);
 
-      // First event should be a working status update
-      const first = events[0] as { status?: { state: string } };
-      expect(first.status?.state).toBe('working');
+      // Default is v1.0: status state should be UPPER_SNAKE_CASE
+      const first = events[0] as Record<string, unknown>;
+      const firstStatus = first.status as Record<string, unknown> | undefined;
+      if (firstStatus) {
+        expect(firstStatus.state).toBe('TASK_STATE_WORKING');
+      }
 
       // Last status event should be completed
       const statusEvents = events.filter(
-        (e) => (e as { status?: unknown }).status !== undefined,
+        (e) => (e as Record<string, unknown>).status !== undefined,
       );
       const lastStatus = statusEvents[statusEvents.length - 1] as { status: { state: string } };
-      expect(lastStatus.status.state).toBe('completed');
+      expect(lastStatus.status.state).toBe('TASK_STATE_COMPLETED');
+    });
+
+    it('should apply v0.3 mapping to streaming events', async () => {
+      const handler = createHandler('0.3');
+      const result = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/stream',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      expect(isAsyncGenerator(result)).toBe(true);
+
+      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+
+      for await (const event of generator) {
+        events.push(event as Record<string, unknown>);
+      }
+
+      expect(events.length).toBeGreaterThan(0);
+
+      // Status events should have kind: "status-update"
+      const statusEvents = events.filter((e) => e.status !== undefined);
+      for (const event of statusEvents) {
+        expect(event.kind).toBe('status-update');
+      }
+
+      // Artifact events should have kind: "artifact-update"
+      const artifactEvents = events.filter((e) => e.artifact !== undefined);
+      for (const event of artifactEvents) {
+        expect(event.kind).toBe('artifact-update');
+      }
+
+      // First status event should use lowercase state
+      if (statusEvents.length > 0) {
+        const firstStatus = statusEvents[0].status as Record<string, unknown>;
+        expect(firstStatus.state).toBe('working');
+      }
+    });
+
+    it('should NOT include kind in v1.0 streaming events', async () => {
+      const handler = createHandler('1.0');
+      const result = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/stream',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      expect(isAsyncGenerator(result)).toBe(true);
+
+      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+
+      for await (const event of generator) {
+        events.push(event as Record<string, unknown>);
+      }
+
+      // No event should have a kind field
+      for (const event of events) {
+        expect(event.kind).toBeUndefined();
+      }
     });
   });
 

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -18,9 +18,25 @@ import { AgentExecutor, StreamingMode } from './agent-executor.js';
 import { AgentCardMapperFactory } from './agent-card-mapper.js';
 import type { TaskStore } from './task-store.js';
 
+// ─── Protocol Version ───
+
+export type ProtocolVersion = '0.3' | '1.0';
+
+const SUPPORTED_PROTOCOL_VERSIONS: ReadonlySet<string> = new Set<string>([
+  '0.3',
+  '1.0',
+]);
+
+export interface A2XAgentOptions {
+  taskStore: TaskStore;
+  executor: AgentExecutor;
+  protocolVersion?: ProtocolVersion;
+}
+
 export class A2XAgent {
   private readonly _taskStore: TaskStore;
   private readonly _agentExecutor: AgentExecutor;
+  private readonly _protocolVersion: ProtocolVersion;
 
   // ─── Internal mutable state (builder pattern) ───
   private _name?: string;
@@ -42,9 +58,25 @@ export class A2XAgent {
   // ─── AgentCard cache ───
   private _cardCache = new Map<string, AgentCardV03 | AgentCardV10>();
 
-  constructor(taskStore: TaskStore, agentExecutor: AgentExecutor) {
-    this._taskStore = taskStore;
-    this._agentExecutor = agentExecutor;
+  constructor(options: A2XAgentOptions) {
+    if (!options.taskStore) {
+      throw new Error('A2XAgent: taskStore is required');
+    }
+    if (!options.executor) {
+      throw new Error('A2XAgent: executor is required');
+    }
+    if (
+      options.protocolVersion !== undefined &&
+      !SUPPORTED_PROTOCOL_VERSIONS.has(options.protocolVersion)
+    ) {
+      throw new Error(
+        `A2XAgent: unsupported protocolVersion '${options.protocolVersion}'. Supported versions: ${Array.from(SUPPORTED_PROTOCOL_VERSIONS).join(', ')}`,
+      );
+    }
+
+    this._taskStore = options.taskStore;
+    this._agentExecutor = options.executor;
+    this._protocolVersion = options.protocolVersion ?? '1.0';
   }
 
   // ─── Builder Methods (return this for chaining) ───
@@ -149,8 +181,7 @@ export class A2XAgent {
   // ─── Core Method ───
 
   getAgentCard(version?: string): AgentCardV03 | AgentCardV10 {
-    const resolvedVersion =
-      version ?? AgentCardMapperFactory.DEFAULT_VERSION;
+    const resolvedVersion = version ?? this._protocolVersion;
 
     // Check cache
     const cached = this._cardCache.get(resolvedVersion);
@@ -210,6 +241,10 @@ export class A2XAgent {
   }
 
   // ─── Accessors ───
+
+  get protocolVersion(): ProtocolVersion {
+    return this._protocolVersion;
+  }
 
   get taskStore(): TaskStore {
     return this._taskStore;

--- a/packages/a2x/src/a2x/index.ts
+++ b/packages/a2x/src/a2x/index.ts
@@ -6,10 +6,15 @@
 export { AgentExecutor, StreamingMode } from './agent-executor.js';
 export type { AgentExecutorOptions, RunConfig } from './agent-executor.js';
 export { A2XAgent } from './a2x-agent.js';
+export type { ProtocolVersion, A2XAgentOptions } from './a2x-agent.js';
 export { AgentCardMapperFactory } from './agent-card-mapper.js';
 export type { AgentCardMapper } from './agent-card-mapper.js';
 export { V03AgentCardMapper } from './v03-mapper.js';
 export { V10AgentCardMapper } from './v10-mapper.js';
+export { ResponseMapperFactory } from './response-mapper.js';
+export type { ResponseMapper } from './response-mapper.js';
+export { V03ResponseMapper } from './v03-response-mapper.js';
+export { V10ResponseMapper } from './v10-response-mapper.js';
 export { InMemoryTaskStore } from './task-store.js';
 export type {
   TaskStore,
@@ -17,7 +22,7 @@ export type {
   TaskUpdate,
 } from './task-store.js';
 
-// ─── Register default mappers ───
+// ─── Register default agent-card mappers ───
 
 import { AgentCardMapperFactory } from './agent-card-mapper.js';
 import { V03AgentCardMapper } from './v03-mapper.js';
@@ -25,3 +30,12 @@ import { V10AgentCardMapper } from './v10-mapper.js';
 
 AgentCardMapperFactory.register('0.3', new V03AgentCardMapper());
 AgentCardMapperFactory.register('1.0', new V10AgentCardMapper());
+
+// ─── Register default response mappers ───
+
+import { ResponseMapperFactory } from './response-mapper.js';
+import { V03ResponseMapper } from './v03-response-mapper.js';
+import { V10ResponseMapper } from './v10-response-mapper.js';
+
+ResponseMapperFactory.register('0.3', new V03ResponseMapper());
+ResponseMapperFactory.register('1.0', new V10ResponseMapper());

--- a/packages/a2x/src/a2x/response-mapper.ts
+++ b/packages/a2x/src/a2x/response-mapper.ts
@@ -1,0 +1,57 @@
+/**
+ * Layer 3: ResponseMapper interface and factory.
+ *
+ * Mirrors the AgentCardMapper / AgentCardMapperFactory pattern
+ * for version-specific JSON-RPC response and SSE event mapping.
+ */
+
+import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../types/task.js';
+import type { Message } from '../types/common.js';
+
+// ─── ResponseMapper Interface ───
+
+export interface ResponseMapper {
+  readonly version: string;
+
+  /**
+   * Map an internal Task to its version-specific output representation.
+   * @param task - The internal Task object.
+   * @param userMessage - The user's original message (for v0.3 history injection).
+   */
+  mapTask(task: Task, userMessage?: Message): unknown;
+
+  /**
+   * Map an internal TaskStatusUpdateEvent to its version-specific output.
+   */
+  mapStatusUpdateEvent(event: TaskStatusUpdateEvent): unknown;
+
+  /**
+   * Map an internal TaskArtifactUpdateEvent to its version-specific output.
+   */
+  mapArtifactUpdateEvent(event: TaskArtifactUpdateEvent): unknown;
+}
+
+// ─── ResponseMapperFactory ───
+
+export class ResponseMapperFactory {
+  private static readonly mappers = new Map<string, ResponseMapper>();
+
+  static register(version: string, mapper: ResponseMapper): void {
+    ResponseMapperFactory.mappers.set(version, mapper);
+  }
+
+  static getMapper(version: string): ResponseMapper {
+    const mapper = ResponseMapperFactory.mappers.get(version);
+    if (!mapper) {
+      throw new Error(
+        `ResponseMapperFactory: no mapper registered for version '${version}'. ` +
+          `Supported versions: ${ResponseMapperFactory.getSupportedVersions().join(', ')}`,
+      );
+    }
+    return mapper;
+  }
+
+  static getSupportedVersions(): string[] {
+    return Array.from(ResponseMapperFactory.mappers.keys());
+  }
+}

--- a/packages/a2x/src/a2x/v03-response-mapper.ts
+++ b/packages/a2x/src/a2x/v03-response-mapper.ts
@@ -1,0 +1,173 @@
+/**
+ * Layer 3: V03ResponseMapper - maps internal response objects to v0.3 format.
+ *
+ * Adds `kind` discriminators to Task, Message, Part, and streaming events.
+ * Populates `history` with the user message when available.
+ * Defaults artifact `name` to "response" when absent.
+ * TaskState values remain lowercase (matching v0.3 spec).
+ */
+
+import type {
+  Task,
+  TaskStatus,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../types/task.js';
+import type { Message, Part, Artifact } from '../types/common.js';
+import { isTextPart, isFilePart, isDataPart } from '../types/common.js';
+import type { ResponseMapper } from './response-mapper.js';
+
+export class V03ResponseMapper implements ResponseMapper {
+  readonly version = '0.3';
+
+  mapTask(task: Task, userMessage?: Message): unknown {
+    const mapped: Record<string, unknown> = {
+      kind: 'task',
+      id: task.id,
+      ...(task.contextId !== undefined ? { contextId: task.contextId } : {}),
+      status: this._mapStatus(task.status),
+    };
+
+    // Build history with user message if available
+    if (userMessage) {
+      mapped.history = [this._mapMessage(userMessage)];
+    } else if (task.history && task.history.length > 0) {
+      mapped.history = task.history.map((msg) => this._mapMessage(msg));
+    }
+
+    // Map artifacts
+    if (task.artifacts && task.artifacts.length > 0) {
+      mapped.artifacts = task.artifacts.map((a) => this._mapArtifact(a));
+    }
+
+    if (task.metadata !== undefined) {
+      mapped.metadata = task.metadata;
+    }
+
+    return mapped;
+  }
+
+  mapStatusUpdateEvent(event: TaskStatusUpdateEvent): unknown {
+    const mapped: Record<string, unknown> = {
+      kind: 'status-update',
+      taskId: event.taskId,
+      contextId: event.contextId,
+      status: this._mapStatus(event.status),
+    };
+
+    if (event.metadata !== undefined) {
+      mapped.metadata = event.metadata;
+    }
+
+    return mapped;
+  }
+
+  mapArtifactUpdateEvent(event: TaskArtifactUpdateEvent): unknown {
+    const mapped: Record<string, unknown> = {
+      kind: 'artifact-update',
+      taskId: event.taskId,
+      contextId: event.contextId,
+      artifact: this._mapArtifact(event.artifact),
+    };
+
+    if (event.append !== undefined) {
+      mapped.append = event.append;
+    }
+    if (event.lastChunk !== undefined) {
+      mapped.lastChunk = event.lastChunk;
+    }
+    if (event.metadata !== undefined) {
+      mapped.metadata = event.metadata;
+    }
+
+    return mapped;
+  }
+
+  // ─── Private Helpers ───
+
+  private _mapStatus(status: TaskStatus): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      state: status.state, // already lowercase (internal format matches v0.3)
+    };
+    if (status.message) {
+      mapped.message = this._mapMessage(status.message);
+    }
+    if (status.timestamp !== undefined) {
+      mapped.timestamp = status.timestamp;
+    }
+    return mapped;
+  }
+
+  private _mapMessage(message: Message): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      kind: 'message',
+      messageId: message.messageId,
+      role: message.role,
+      parts: message.parts.map((p) => this._mapPart(p)),
+    };
+
+    if (message.contextId !== undefined) {
+      mapped.contextId = message.contextId;
+    }
+    if (message.taskId !== undefined) {
+      mapped.taskId = message.taskId;
+    }
+    if (message.metadata !== undefined) {
+      mapped.metadata = message.metadata;
+    }
+    if (message.extensions !== undefined) {
+      mapped.extensions = message.extensions;
+    }
+    if (message.referenceTaskIds !== undefined) {
+      mapped.referenceTaskIds = message.referenceTaskIds;
+    }
+
+    return mapped;
+  }
+
+  private _mapPart(part: Part): Record<string, unknown> {
+    if (isTextPart(part)) {
+      const mapped: Record<string, unknown> = { kind: 'text', text: part.text };
+      if (part.mediaType !== undefined) mapped.mediaType = part.mediaType;
+      if (part.metadata !== undefined) mapped.metadata = part.metadata;
+      return mapped;
+    }
+    if (isFilePart(part)) {
+      const mapped: Record<string, unknown> = { kind: 'file' };
+      if (part.raw !== undefined) mapped.raw = part.raw;
+      if (part.url !== undefined) mapped.url = part.url;
+      if (part.filename !== undefined) mapped.filename = part.filename;
+      if (part.mediaType !== undefined) mapped.mediaType = part.mediaType;
+      if (part.metadata !== undefined) mapped.metadata = part.metadata;
+      return mapped;
+    }
+    if (isDataPart(part)) {
+      const mapped: Record<string, unknown> = { kind: 'data', data: part.data };
+      if (part.mediaType !== undefined) mapped.mediaType = part.mediaType;
+      if (part.metadata !== undefined) mapped.metadata = part.metadata;
+      return mapped;
+    }
+    // Fallback: return as-is (should not happen with valid Part)
+    return { ...(part as Record<string, unknown>) };
+  }
+
+  private _mapArtifact(artifact: Artifact): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      artifactId: artifact.artifactId,
+      name: artifact.name ?? 'response', // default name for v0.3
+      parts: artifact.parts.map((p) => this._mapPart(p)),
+    };
+
+    if (artifact.description !== undefined) {
+      mapped.description = artifact.description;
+    }
+    if (artifact.metadata !== undefined) {
+      mapped.metadata = artifact.metadata;
+    }
+    if (artifact.extensions !== undefined) {
+      mapped.extensions = artifact.extensions;
+    }
+
+    return mapped;
+  }
+}

--- a/packages/a2x/src/a2x/v10-response-mapper.ts
+++ b/packages/a2x/src/a2x/v10-response-mapper.ts
@@ -1,0 +1,157 @@
+/**
+ * Layer 3: V10ResponseMapper - maps internal response objects to v1.0 format.
+ *
+ * Transforms TaskState from lowercase to UPPER_SNAKE_CASE.
+ * Strips `kind` fields (defensive, in case they are accidentally present).
+ * Does not inject `history` or default artifact `name`.
+ */
+
+import type {
+  Task,
+  TaskStatus,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../types/task.js';
+import { TASK_STATE_TO_V10 } from '../types/task.js';
+import type { TaskState } from '../types/task.js';
+import type { Message, Part, Artifact } from '../types/common.js';
+import type { ResponseMapper } from './response-mapper.js';
+
+export class V10ResponseMapper implements ResponseMapper {
+  readonly version = '1.0';
+
+  mapTask(task: Task, _userMessage?: Message): unknown {
+    const mapped: Record<string, unknown> = {
+      id: task.id,
+      ...(task.contextId !== undefined ? { contextId: task.contextId } : {}),
+      status: this._mapStatus(task.status),
+    };
+
+    // Map artifacts (no default name injection)
+    if (task.artifacts && task.artifacts.length > 0) {
+      mapped.artifacts = task.artifacts.map((a) => this._mapArtifact(a));
+    }
+
+    // Pass through history if present (no injection)
+    if (task.history && task.history.length > 0) {
+      mapped.history = task.history.map((msg) => this._mapMessage(msg));
+    }
+
+    if (task.metadata !== undefined) {
+      mapped.metadata = task.metadata;
+    }
+
+    return mapped;
+  }
+
+  mapStatusUpdateEvent(event: TaskStatusUpdateEvent): unknown {
+    const mapped: Record<string, unknown> = {
+      taskId: event.taskId,
+      contextId: event.contextId,
+      status: this._mapStatus(event.status),
+    };
+
+    if (event.metadata !== undefined) {
+      mapped.metadata = event.metadata;
+    }
+
+    return mapped;
+  }
+
+  mapArtifactUpdateEvent(event: TaskArtifactUpdateEvent): unknown {
+    const mapped: Record<string, unknown> = {
+      taskId: event.taskId,
+      contextId: event.contextId,
+      artifact: this._mapArtifact(event.artifact),
+    };
+
+    if (event.append !== undefined) {
+      mapped.append = event.append;
+    }
+    if (event.lastChunk !== undefined) {
+      mapped.lastChunk = event.lastChunk;
+    }
+    if (event.metadata !== undefined) {
+      mapped.metadata = event.metadata;
+    }
+
+    return mapped;
+  }
+
+  // ─── Private Helpers ───
+
+  private _mapStateToV10(state: TaskState): string {
+    const v10State = TASK_STATE_TO_V10.get(state);
+    // Defensive: pass through if mapping is not found
+    return v10State ?? state;
+  }
+
+  private _mapStatus(status: TaskStatus): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      state: this._mapStateToV10(status.state),
+    };
+    if (status.message) {
+      mapped.message = this._mapMessage(status.message);
+    }
+    if (status.timestamp !== undefined) {
+      mapped.timestamp = status.timestamp;
+    }
+    return mapped;
+  }
+
+  private _mapMessage(message: Message): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      messageId: message.messageId,
+      role: message.role,
+      parts: message.parts.map((p) => this._mapPart(p)),
+    };
+
+    if (message.contextId !== undefined) {
+      mapped.contextId = message.contextId;
+    }
+    if (message.taskId !== undefined) {
+      mapped.taskId = message.taskId;
+    }
+    if (message.metadata !== undefined) {
+      mapped.metadata = message.metadata;
+    }
+    if (message.extensions !== undefined) {
+      mapped.extensions = message.extensions;
+    }
+    if (message.referenceTaskIds !== undefined) {
+      mapped.referenceTaskIds = message.referenceTaskIds;
+    }
+
+    return mapped;
+  }
+
+  private _mapPart(part: Part): Record<string, unknown> {
+    // Strip `kind` if accidentally present (defensive) and return clean object
+    const { ...rest } = part as Record<string, unknown>;
+    delete rest['kind'];
+    return rest;
+  }
+
+  private _mapArtifact(artifact: Artifact): Record<string, unknown> {
+    const mapped: Record<string, unknown> = {
+      artifactId: artifact.artifactId,
+      parts: artifact.parts.map((p) => this._mapPart(p)),
+    };
+
+    // Include name only if explicitly set (no default injection)
+    if (artifact.name !== undefined) {
+      mapped.name = artifact.name;
+    }
+    if (artifact.description !== undefined) {
+      mapped.description = artifact.description;
+    }
+    if (artifact.metadata !== undefined) {
+      mapped.metadata = artifact.metadata;
+    }
+    if (artifact.extensions !== undefined) {
+      mapped.extensions = artifact.extensions;
+    }
+
+    return mapped;
+  }
+}

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -34,19 +34,23 @@ import {
 } from '../types/errors.js';
 import { StreamingMode } from '../a2x/agent-executor.js';
 import { JsonRpcRouter } from './jsonrpc-router.js';
+import type { ResponseMapper } from '../a2x/response-mapper.js';
+import { ResponseMapperFactory } from '../a2x/response-mapper.js';
 
 /** Return type of `handle()`. */
 export type HandleResult =
   | JSONRPCResponse
-  | AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>;
+  | AsyncGenerator<unknown>;
 
 export class DefaultRequestHandler {
   private readonly a2xAgent: A2XAgent;
   private readonly router: JsonRpcRouter;
+  private readonly responseMapper: ResponseMapper;
 
   constructor(a2xAgent: A2XAgent) {
     this.a2xAgent = a2xAgent;
     this.router = new JsonRpcRouter();
+    this.responseMapper = ResponseMapperFactory.getMapper(a2xAgent.protocolVersion);
     this._registerRoutes();
   }
 
@@ -106,9 +110,7 @@ export class DefaultRequestHandler {
     // Streaming method → return AsyncGenerator
     if (this.router.isStreamMethod(request.method)) {
       try {
-        return this.router.routeStream(request) as AsyncGenerator<
-          TaskStatusUpdateEvent | TaskArtifactUpdateEvent
-        >;
+        return this.router.routeStream(request) as AsyncGenerator<unknown>;
       } catch (err) {
         return this._toErrorResponse(request.id, err);
       }
@@ -171,7 +173,7 @@ export class DefaultRequestHandler {
 
   // ─── Private: Method Handlers ───
 
-  private async _handleSendMessage(params: SendMessageParams): Promise<Task> {
+  private async _handleSendMessage(params: SendMessageParams): Promise<unknown> {
     const task = await this.a2xAgent.taskStore.createTask({
       contextId: params.message.contextId,
       metadata: params.metadata,
@@ -182,12 +184,12 @@ export class DefaultRequestHandler {
       params.message,
     );
 
-    return completedTask;
+    return this.responseMapper.mapTask(completedTask, params.message);
   }
 
   private async *_handleStreamMessage(
     params: SendMessageParams,
-  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+  ): AsyncGenerator<unknown> {
     if (
       this.a2xAgent.agentExecutor.runConfig.streamingMode ===
       StreamingMode.NONE
@@ -219,19 +221,23 @@ export class DefaultRequestHandler {
           status: event.status,
         });
       }
-      yield event;
+      if ('status' in event) {
+        yield this.responseMapper.mapStatusUpdateEvent(event as TaskStatusUpdateEvent);
+      } else {
+        yield this.responseMapper.mapArtifactUpdateEvent(event as TaskArtifactUpdateEvent);
+      }
     }
   }
 
-  private async _handleGetTask(params: TaskIdParams): Promise<Task> {
+  private async _handleGetTask(params: TaskIdParams): Promise<unknown> {
     const task = await this.a2xAgent.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
     }
-    return task;
+    return this.responseMapper.mapTask(task);
   }
 
-  private async _handleCancelTask(params: TaskIdParams): Promise<Task> {
+  private async _handleCancelTask(params: TaskIdParams): Promise<unknown> {
     const task = await this.a2xAgent.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
@@ -249,7 +255,7 @@ export class DefaultRequestHandler {
       status: canceledTask.status,
     });
 
-    return canceledTask;
+    return this.responseMapper.mapTask(canceledTask);
   }
 
   // ─── Private: Helpers ───

--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -6,6 +6,7 @@ import type { LlmAgent } from '../agent/llm-agent.js';
 import type { BaseSecurityScheme } from '../security/base.js';
 import type { A2XAgentSkill } from '../types/agent-card.js';
 import type { SecurityRequirement } from '../types/security.js';
+import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
@@ -20,6 +21,7 @@ export interface ToA2xOptions {
   streamingMode?: StreamingMode;
   securitySchemes?: Record<string, BaseSecurityScheme>;
   securityRequirements?: SecurityRequirement[];
+  protocolVersion?: ProtocolVersion;
 }
 
 export interface ToA2xResult {
@@ -48,7 +50,11 @@ export function toA2x(
   });
 
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent(taskStore, agentExecutor);
+  const a2xAgent = new A2XAgent({
+    taskStore,
+    executor: agentExecutor,
+    protocolVersion: options.protocolVersion,
+  });
 
   // Apply configuration
   a2xAgent.setDefaultUrl(options.defaultUrl);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@a2x/cli",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "CLI for the a2x A2A protocol SDK",
+  "bin": {
+    "a2x": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "a2x": "workspace:*",
+    "commander": "^13.0.0",
+    "chalk": "^5.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/cli/src/commands/agent-card.ts
+++ b/packages/cli/src/commands/agent-card.ts
@@ -1,0 +1,129 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+
+export const agentCardCommand = new Command('agent-card')
+  .description('Fetch and display an A2A agent card')
+  .argument('<url>', 'Agent URL or direct agent.json URL')
+  .option('--json', 'Output raw JSON')
+  .option(
+    '--protocol-version <version>',
+    'A2A protocol version (default: auto-detect)',
+  )
+  .action(async (url: string, opts: { json?: boolean; protocolVersion?: string }) => {
+    try {
+      const cardUrl = resolveAgentCardUrl(url);
+      const res = await fetch(cardUrl);
+
+      if (!res.ok) {
+        console.error(
+          chalk.red(`Failed to fetch agent card: ${res.status} ${res.statusText}`),
+        );
+        process.exit(1);
+      }
+
+      const card = (await res.json()) as Record<string, unknown>;
+
+      if (opts.json) {
+        console.log(JSON.stringify(card, null, 2));
+        return;
+      }
+
+      printAgentCard(card, opts.protocolVersion);
+    } catch (err) {
+      if (err instanceof TypeError && (err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
+        console.error(chalk.red(`Connection refused: ${url}`));
+      } else if (err instanceof SyntaxError) {
+        console.error(chalk.red('Invalid JSON response from server'));
+      } else {
+        console.error(
+          chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`),
+        );
+      }
+      process.exit(1);
+    }
+  });
+
+function resolveAgentCardUrl(url: string): string {
+  if (url.endsWith('.json')) {
+    return url;
+  }
+  const base = url.replace(/\/+$/, '');
+  return `${base}/.well-known/agent.json`;
+}
+
+function printAgentCard(card: Record<string, unknown>, protocolVersion?: string): void {
+  // Determine protocol version from card or option
+  const version =
+    protocolVersion ??
+    (card.protocolVersion as string | undefined) ??
+    detectProtocolVersion(card);
+
+  console.log(chalk.bold.cyan('Agent Card'));
+  console.log(chalk.gray('─'.repeat(40)));
+
+  if (card.name) {
+    console.log(`${chalk.bold('Name:')}         ${card.name}`);
+  }
+  if (card.description) {
+    console.log(`${chalk.bold('Description:')}  ${card.description}`);
+  }
+  if (card.version) {
+    console.log(`${chalk.bold('Version:')}      ${card.version}`);
+  }
+  console.log(`${chalk.bold('Protocol:')}     ${version ?? 'unknown'}`);
+
+  // URL(s)
+  if (card.url) {
+    console.log(`${chalk.bold('URL:')}          ${card.url}`);
+  }
+  const interfaces = (card.supportedInterfaces ?? card.additionalInterfaces) as
+    | Array<Record<string, string>>
+    | undefined;
+  if (interfaces?.length) {
+    console.log(chalk.bold('\nInterfaces:'));
+    for (const iface of interfaces) {
+      const binding = iface.protocolBinding ?? iface.transport ?? '';
+      console.log(`  ${chalk.green('•')} ${iface.url}${binding ? ` (${binding})` : ''}`);
+    }
+  }
+
+  // Capabilities
+  const caps = card.capabilities as Record<string, unknown> | undefined;
+  if (caps) {
+    console.log(chalk.bold('\nCapabilities:'));
+    if (caps.streaming) console.log(`  ${chalk.green('✓')} Streaming`);
+    if (caps.pushNotifications) console.log(`  ${chalk.green('✓')} Push Notifications`);
+    if (caps.stateTransitionHistory) console.log(`  ${chalk.green('✓')} State Transition History`);
+    if (caps.extendedAgentCard) console.log(`  ${chalk.green('✓')} Extended Agent Card`);
+  }
+
+  // Skills
+  const skills = card.skills as Array<Record<string, unknown>> | undefined;
+  if (skills?.length) {
+    console.log(chalk.bold('\nSkills:'));
+    for (const skill of skills) {
+      console.log(`  ${chalk.yellow(skill.name ?? skill.id)}`);
+      if (skill.description) {
+        console.log(`    ${chalk.gray(skill.description)}`);
+      }
+      const tags = skill.tags as string[] | undefined;
+      if (tags?.length) {
+        console.log(`    Tags: ${tags.map((t) => chalk.blue(t)).join(', ')}`);
+      }
+    }
+  }
+
+  // Provider
+  const provider = card.provider as Record<string, string> | undefined;
+  if (provider) {
+    console.log(chalk.bold('\nProvider:'));
+    console.log(`  ${provider.organization}${provider.url ? ` (${provider.url})` : ''}`);
+  }
+}
+
+function detectProtocolVersion(card: Record<string, unknown>): string | undefined {
+  if ('protocolVersion' in card) return card.protocolVersion as string;
+  if ('supportedInterfaces' in card) return '1.0';
+  if ('url' in card && 'skills' in card) return '0.3';
+  return undefined;
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,2 @@
+export { agentCardCommand } from './agent-card.js';
+export { sendCommand } from './send.js';

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -1,0 +1,206 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import crypto from 'node:crypto';
+
+export const sendCommand = new Command('send')
+  .description('Send a message to an A2A agent')
+  .argument('<url>', 'Agent JSON-RPC endpoint URL')
+  .argument('<message>', 'Message text to send')
+  .option('--task-id <id>', 'Continue an existing task')
+  .option('--json', 'Output raw JSON response')
+  .action(
+    async (
+      url: string,
+      message: string,
+      opts: { taskId?: string; json?: boolean },
+    ) => {
+      try {
+        const requestBody = buildRequest(message, opts.taskId);
+
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!res.ok) {
+          console.error(
+            chalk.red(
+              `HTTP error: ${res.status} ${res.statusText}`,
+            ),
+          );
+          process.exit(1);
+        }
+
+        const body = (await res.json()) as Record<string, unknown>;
+
+        if (opts.json) {
+          console.log(JSON.stringify(body, null, 2));
+          return;
+        }
+
+        if (body.error) {
+          printError(body.error as { code: number; message: string; data?: unknown });
+          process.exit(1);
+        }
+
+        printResult(body.result as Record<string, unknown>);
+      } catch (err) {
+        if (
+          err instanceof TypeError &&
+          (err as NodeJS.ErrnoException).code === 'ECONNREFUSED'
+        ) {
+          console.error(chalk.red(`Connection refused: ${url}`));
+        } else {
+          console.error(
+            chalk.red(
+              `Error: ${err instanceof Error ? err.message : String(err)}`,
+            ),
+          );
+        }
+        process.exit(1);
+      }
+    },
+  );
+
+interface JSONRPCRequest {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params: {
+    message: {
+      messageId: string;
+      role: 'user';
+      parts: Array<{ kind: 'text'; text: string }>;
+      taskId?: string;
+    };
+  };
+}
+
+function buildRequest(message: string, taskId?: string): JSONRPCRequest {
+  const msg: JSONRPCRequest['params']['message'] = {
+    messageId: crypto.randomUUID(),
+    role: 'user',
+    parts: [{ kind: 'text', text: message }],
+  };
+
+  if (taskId) {
+    msg.taskId = taskId;
+  }
+
+  return {
+    jsonrpc: '2.0',
+    id: crypto.randomUUID(),
+    method: 'message/send',
+    params: { message: msg },
+  };
+}
+
+function printError(error: { code: number; message: string; data?: unknown }): void {
+  console.error(chalk.red.bold('JSON-RPC Error'));
+  console.error(chalk.red(`  Code:    ${error.code}`));
+  console.error(chalk.red(`  Message: ${error.message}`));
+  if (error.data) {
+    console.error(chalk.red(`  Data:    ${JSON.stringify(error.data)}`));
+  }
+}
+
+function printResult(result: Record<string, unknown>): void {
+  console.log(chalk.bold.cyan('Response'));
+  console.log(chalk.gray('─'.repeat(40)));
+
+  // Task info
+  if (result.id) {
+    console.log(`${chalk.bold('Task ID:')}  ${result.id}`);
+  }
+  if (result.contextId) {
+    console.log(`${chalk.bold('Context:')}  ${result.contextId}`);
+  }
+
+  // Status
+  const status = result.status as Record<string, unknown> | undefined;
+  if (status) {
+    const state = (status.state as string) ?? 'unknown';
+    const stateColor = getStateColor(state);
+    console.log(`${chalk.bold('Status:')}   ${stateColor(state)}`);
+  }
+
+  // Artifacts
+  const artifacts = result.artifacts as
+    | Array<Record<string, unknown>>
+    | undefined;
+  if (artifacts?.length) {
+    console.log(chalk.bold('\nArtifacts:'));
+    for (const artifact of artifacts) {
+      if (artifact.name) {
+        console.log(`  ${chalk.yellow(artifact.name as string)}`);
+      }
+      const parts = artifact.parts as Array<Record<string, unknown>> | undefined;
+      if (parts) {
+        printParts(parts);
+      }
+    }
+  }
+
+  // Status message (agent response)
+  if (status?.message) {
+    const msg = status.message as Record<string, unknown>;
+    const parts = msg.parts as Array<Record<string, unknown>> | undefined;
+    if (parts?.length) {
+      console.log(chalk.bold('\nAgent Message:'));
+      printParts(parts);
+    }
+  }
+
+  // History
+  const history = result.history as Array<Record<string, unknown>> | undefined;
+  if (history?.length) {
+    console.log(chalk.bold('\nHistory:'));
+    for (const msg of history) {
+      const role = msg.role as string;
+      const roleLabel = role === 'agent' ? chalk.green('Agent') : chalk.blue('User');
+      console.log(`  ${roleLabel}:`);
+      const parts = msg.parts as Array<Record<string, unknown>> | undefined;
+      if (parts) {
+        printParts(parts, '    ');
+      }
+    }
+  }
+}
+
+function printParts(
+  parts: Array<Record<string, unknown>>,
+  indent = '  ',
+): void {
+  for (const part of parts) {
+    if ('text' in part) {
+      console.log(`${indent}${part.text}`);
+    } else if ('data' in part) {
+      console.log(`${indent}${chalk.gray(JSON.stringify(part.data))}`);
+    } else if ('url' in part || 'raw' in part) {
+      const label = (part.filename as string) ?? (part.url as string) ?? '[file]';
+      console.log(`${indent}${chalk.underline(label)}`);
+    }
+  }
+}
+
+function getStateColor(state: string): (text: string) => string {
+  switch (state.toLowerCase().replace('task_state_', '')) {
+    case 'completed':
+      return chalk.green;
+    case 'working':
+    case 'submitted':
+      return chalk.yellow;
+    case 'failed':
+    case 'canceled':
+    case 'rejected':
+      return chalk.red;
+    case 'input-required':
+    case 'input_required':
+    case 'auth-required':
+    case 'auth_required':
+      return chalk.magenta;
+    default:
+      return chalk.white;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,12 @@
+import { program } from 'commander';
+import { agentCardCommand, sendCommand } from './commands/index.js';
+
+program
+  .name('a2x')
+  .description('CLI for the a2x A2A protocol SDK')
+  .version('0.1.0');
+
+program.addCommand(agentCardCommand);
+program.addCommand(sendCommand);
+
+program.parse();

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -16,10 +17,10 @@
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "rootDir": "src",
+    "outDir": "dist"
   },
-  "references": [
-    { "path": "./packages/a2x" },
-    { "path": "./packages/cli" }
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node20',
+  clean: true,
+  sourcemap: true,
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+});

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -33,7 +33,11 @@ const agentExecutor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 const taskStore = new InMemoryTaskStore();
-const a2xAgent = new A2XAgent(taskStore, agentExecutor);
+const a2xAgent = new A2XAgent({
+  taskStore,
+  executor: agentExecutor,
+  protocolVersion: '0.3',
+});
 
 a2xAgent.setDefaultUrl(`${process.env.BASE_URL}/a2a`);
 a2xAgent.addSkill({
@@ -54,7 +58,7 @@ app.use(express.json());
 // Agent Card
 app.get('/.well-known/agent.json', (req, res) => {
   try {
-    const card = handler.getAgentCard('0.3');
+    const card = handler.getAgentCard();
     res.json(card);
   } catch (error) {
     res.status(500).json({

--- a/samples/nextjs/src/app/.well-known/handler.ts
+++ b/samples/nextjs/src/app/.well-known/handler.ts
@@ -1,12 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { a2xAgent } from "@/lib/a2x-setup";
 
-export async function AgentCardHandler(request: NextRequest) {
-  const version =
-    request.nextUrl.searchParams.get("version") ?? undefined;
-
+export async function AgentCardHandler(_: NextRequest) {
   try {
-    const card = a2xAgent.getAgentCard(version);
+    const card = a2xAgent.getAgentCard();
     return NextResponse.json(card);
   } catch (error) {
     return NextResponse.json(

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -26,7 +26,7 @@ const executor = new AgentExecutor({
 
 const taskStore = new InMemoryTaskStore();
 
-export const a2xAgent = new A2XAgent(taskStore, executor)
+export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
   .setDefaultUrl("http://localhost:3000/api/a2a")
   .addSkill({
     id: "chat",


### PR DESCRIPTION
## Summary
- Add `protocolVersion` option to `A2XAgent` constructor (options object pattern) with `'0.3'` and `'1.0'` support (default: `'1.0'`)
- Introduce `ResponseMapper` interface with `V03ResponseMapper` and `V10ResponseMapper` for version-specific JSON-RPC response and SSE event mapping
- Add `packages/cli` — commander-based CLI package for agent card inspection and message sending

## Changes
- **A2XAgent**: refactor constructor from `(taskStore, executor)` to `{ taskStore, executor, protocolVersion? }` options object
- **V03ResponseMapper**: adds `kind` discriminators, injects user message into history, defaults artifact name to `"response"`, lowercase `TaskState`
- **V10ResponseMapper**: maps `TaskState` to `UPPER_SNAKE_CASE`, strips `kind` fields, no history injection
- **DefaultRequestHandler**: uses `ResponseMapper` to transform all outgoing Task/event payloads
- **`getAgentCard()`**: defaults to configured `protocolVersion` instead of hardcoded value
- Samples (Express, Next.js) and tests updated for new constructor and response format

## Test plan
- [ ] `pnpm test` passes for `packages/a2x`
- [ ] Verify v0.3 response includes `kind` discriminators and lowercase state
- [ ] Verify v1.0 response uses `UPPER_SNAKE_CASE` state without `kind` fields
- [ ] Confirm `getAgentCard()` returns correct version based on configured `protocolVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)