### PR TITLE
feat(a2x): add client SDK and refactor CLI to use A2XClient

### DIFF
--- a/packages/a2x/package.json
+++ b/packages/a2x/package.json
@@ -9,6 +9,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js",
+      "require": "./dist/client/index.cjs"
+    },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js",

--- a/packages/a2x/src/__tests__/client.test.ts
+++ b/packages/a2x/src/__tests__/client.test.ts
@@ -1,0 +1,625 @@
+import { describe, it, expect, vi } from 'vitest';
+import { A2XClient } from '../client/a2x-client.js';
+import {
+  resolveAgentCard,
+  detectProtocolVersion,
+  getAgentEndpointUrl,
+  AGENT_CARD_WELL_KNOWN_PATH,
+} from '../client/agent-card-resolver.js';
+import { getResponseParser } from '../client/response-parser.js';
+import { parseSSEStream } from '../client/sse-parser.js';
+import { TaskState } from '../types/task.js';
+import { A2A_ERROR_CODES } from '../types/errors.js';
+import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
+
+// ─── Test Fixtures ───
+
+const V03_CARD: AgentCardV03 = {
+  name: 'Test Agent',
+  description: 'A test agent',
+  version: '1.0.0',
+  url: 'http://localhost:4000/a2a',
+  protocolVersion: '0.3.0',
+  preferredTransport: 'JSONRPC',
+  capabilities: { streaming: true },
+  skills: [],
+  defaultInputModes: ['text/plain'],
+  defaultOutputModes: ['text/plain'],
+};
+
+const V10_CARD: AgentCardV10 = {
+  name: 'Test Agent',
+  description: 'A test agent',
+  version: '1.0.0',
+  supportedInterfaces: [
+    { url: 'http://localhost:4000/a2a', protocolBinding: 'JSONRPC', protocolVersion: '1.0' },
+  ],
+  capabilities: { streaming: true },
+  skills: [],
+  defaultInputModes: ['text/plain'],
+  defaultOutputModes: ['text/plain'],
+};
+
+function createJsonRpcSuccess(result: unknown) {
+  return { jsonrpc: '2.0', id: 1, result };
+}
+
+function createJsonRpcError(code: number, message: string) {
+  return { jsonrpc: '2.0', id: 1, error: { code, message } };
+}
+
+function createMockFetch(responseBody: unknown, options?: { status?: number; contentType?: string }) {
+  return vi.fn().mockResolvedValue({
+    ok: (options?.status ?? 200) < 400,
+    status: options?.status ?? 200,
+    statusText: options?.status === 404 ? 'Not Found' : 'OK',
+    json: () => Promise.resolve(responseBody),
+    headers: new Headers({ 'Content-Type': options?.contentType ?? 'application/json' }),
+  });
+}
+
+function createSSEResponse(events: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(events));
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: stream,
+    headers: new Headers({ 'Content-Type': 'text/event-stream' }),
+  } as unknown as Response;
+}
+
+function createSendMessageParams(text: string) {
+  return {
+    message: {
+      messageId: 'msg-1',
+      role: 'user' as const,
+      parts: [{ text }],
+    },
+  };
+}
+
+// ═══ AgentCardResolver Tests ═══
+
+describe('AgentCardResolver', () => {
+  describe('detectProtocolVersion', () => {
+    it('should detect v0.3 from top-level url field', () => {
+      expect(detectProtocolVersion({ url: 'http://localhost', protocolVersion: '0.3.0' })).toBe('0.3');
+    });
+
+    it('should detect v1.0 from supportedInterfaces', () => {
+      expect(detectProtocolVersion({ supportedInterfaces: [{ url: 'http://localhost' }] })).toBe('1.0');
+    });
+
+    it('should default to 1.0 for ambiguous structure', () => {
+      expect(detectProtocolVersion({})).toBe('1.0');
+    });
+
+    it('should prefer v1.0 when both url and supportedInterfaces exist', () => {
+      expect(detectProtocolVersion({
+        url: 'http://localhost',
+        supportedInterfaces: [{ url: 'http://localhost' }],
+      })).toBe('1.0');
+    });
+  });
+
+  describe('getAgentEndpointUrl', () => {
+    it('should return url from v0.3 card', () => {
+      expect(getAgentEndpointUrl(V03_CARD, '0.3')).toBe('http://localhost:4000/a2a');
+    });
+
+    it('should return JSONRPC interface url from v1.0 card', () => {
+      expect(getAgentEndpointUrl(V10_CARD, '1.0')).toBe('http://localhost:4000/a2a');
+    });
+
+    it('should prefer JSONRPC binding in v1.0 card with multiple interfaces', () => {
+      const card: AgentCardV10 = {
+        ...V10_CARD,
+        supportedInterfaces: [
+          { url: 'http://localhost/grpc', protocolBinding: 'GRPC', protocolVersion: '1.0' },
+          { url: 'http://localhost/jsonrpc', protocolBinding: 'JSONRPC', protocolVersion: '1.0' },
+        ],
+      };
+      expect(getAgentEndpointUrl(card, '1.0')).toBe('http://localhost/jsonrpc');
+    });
+
+    it('should fallback to first interface if no JSONRPC in v1.0', () => {
+      const card: AgentCardV10 = {
+        ...V10_CARD,
+        supportedInterfaces: [
+          { url: 'http://localhost/grpc', protocolBinding: 'GRPC', protocolVersion: '1.0' },
+        ],
+      };
+      expect(getAgentEndpointUrl(card, '1.0')).toBe('http://localhost/grpc');
+    });
+
+    it('should throw for v0.3 card without url', () => {
+      const card = { ...V03_CARD, url: '' };
+      expect(() => getAgentEndpointUrl(card, '0.3')).toThrow('missing required "url"');
+    });
+
+    it('should throw for v1.0 card with empty supportedInterfaces', () => {
+      const card = { ...V10_CARD, supportedInterfaces: [] };
+      expect(() => getAgentEndpointUrl(card, '1.0')).toThrow('no supportedInterfaces');
+    });
+  });
+
+  describe('resolveAgentCard', () => {
+    it('should fetch and resolve a v0.3 card', async () => {
+      const mockFetch = createMockFetch(V03_CARD);
+      const result = await resolveAgentCard('http://localhost:4000', { fetch: mockFetch });
+
+      expect(result.version).toBe('0.3');
+      expect(result.card).toEqual(V03_CARD);
+      expect(result.baseUrl).toBe('http://localhost:4000');
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:4000${AGENT_CARD_WELL_KNOWN_PATH}`,
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('should fetch and resolve a v1.0 card', async () => {
+      const mockFetch = createMockFetch(V10_CARD);
+      const result = await resolveAgentCard('http://localhost:4000', { fetch: mockFetch });
+
+      expect(result.version).toBe('1.0');
+      expect(result.card).toEqual(V10_CARD);
+    });
+
+    it('should strip trailing slash from baseUrl', async () => {
+      const mockFetch = createMockFetch(V10_CARD);
+      await resolveAgentCard('http://localhost:4000/', { fetch: mockFetch });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:4000${AGENT_CARD_WELL_KNOWN_PATH}`,
+        expect.any(Object),
+      );
+    });
+
+    it('should support custom path', async () => {
+      const mockFetch = createMockFetch(V10_CARD);
+      await resolveAgentCard('http://localhost:4000', { fetch: mockFetch, path: '/custom/card.json' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/custom/card.json',
+        expect.any(Object),
+      );
+    });
+
+    it('should throw on HTTP error', async () => {
+      const mockFetch = createMockFetch({}, { status: 404 });
+      await expect(
+        resolveAgentCard('http://localhost:4000', { fetch: mockFetch }),
+      ).rejects.toThrow('Failed to fetch AgentCard');
+    });
+
+    it('should pass custom headers', async () => {
+      const mockFetch = createMockFetch(V10_CARD);
+      await resolveAgentCard('http://localhost:4000', {
+        fetch: mockFetch,
+        headers: { Authorization: 'Bearer token123' },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer token123' }),
+        }),
+      );
+    });
+  });
+});
+
+// ═══ ResponseParser Tests ═══
+
+describe('ResponseParser', () => {
+  describe('V03ResponseParser', () => {
+    const parser = getResponseParser('0.3');
+
+    it('should strip kind from task', () => {
+      const raw = {
+        kind: 'task',
+        id: 'task-1',
+        status: { state: 'working', message: { kind: 'message', messageId: 'm1', role: 'agent', parts: [{ kind: 'text', text: 'hi' }] } },
+      };
+      const task = parser.parseTask(raw);
+      expect(task.id).toBe('task-1');
+      expect(task.status.state).toBe(TaskState.WORKING);
+      expect((task as Record<string, unknown>).kind).toBeUndefined();
+    });
+
+    it('should strip kind from artifacts in task', () => {
+      const raw = {
+        kind: 'task',
+        id: 'task-1',
+        status: { state: 'completed' },
+        artifacts: [{ kind: 'artifact', artifactId: 'a1', name: 'response', parts: [{ kind: 'text', text: 'result' }] }],
+      };
+      const task = parser.parseTask(raw);
+      expect(task.artifacts![0].artifactId).toBe('a1');
+      expect((task.artifacts![0] as Record<string, unknown>).kind).toBeUndefined();
+      expect((task.artifacts![0].parts[0] as Record<string, unknown>).kind).toBeUndefined();
+    });
+
+    it('should strip kind from status update event', () => {
+      const raw = {
+        kind: 'status-update',
+        taskId: 'task-1',
+        contextId: 'ctx-1',
+        status: { state: 'working' },
+      };
+      const event = parser.parseStatusUpdateEvent(raw);
+      expect(event.taskId).toBe('task-1');
+      expect((event as Record<string, unknown>).kind).toBeUndefined();
+    });
+
+    it('should strip kind from artifact update event', () => {
+      const raw = {
+        kind: 'artifact-update',
+        taskId: 'task-1',
+        contextId: 'ctx-1',
+        artifact: { kind: 'artifact', artifactId: 'a1', parts: [{ kind: 'text', text: 'chunk' }] },
+      };
+      const event = parser.parseArtifactUpdateEvent(raw);
+      expect(event.artifact.artifactId).toBe('a1');
+      expect((event.artifact as Record<string, unknown>).kind).toBeUndefined();
+    });
+  });
+
+  describe('V10ResponseParser', () => {
+    const parser = getResponseParser('1.0');
+
+    it('should convert TASK_STATE_WORKING to working', () => {
+      const raw = { id: 'task-1', status: { state: 'TASK_STATE_WORKING' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.WORKING);
+    });
+
+    it('should convert TASK_STATE_COMPLETED to completed', () => {
+      const raw = { id: 'task-1', status: { state: 'TASK_STATE_COMPLETED' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.COMPLETED);
+    });
+
+    it('should convert TASK_STATE_FAILED to failed', () => {
+      const raw = { id: 'task-1', status: { state: 'TASK_STATE_FAILED' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.FAILED);
+    });
+
+    it('should pass through already lowercase states', () => {
+      const raw = { id: 'task-1', status: { state: 'completed' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.COMPLETED);
+    });
+
+    it('should throw on unknown state', () => {
+      const raw = { id: 'task-1', status: { state: 'INVALID_STATE' } };
+      expect(() => parser.parseTask(raw)).toThrow('Unknown task state');
+    });
+
+    it('should convert status update event state', () => {
+      const raw = { taskId: 'task-1', contextId: 'ctx-1', status: { state: 'TASK_STATE_SUBMITTED' } };
+      const event = parser.parseStatusUpdateEvent(raw);
+      expect(event.status.state).toBe(TaskState.SUBMITTED);
+    });
+
+    it('should pass through artifact update events unchanged', () => {
+      const raw = { taskId: 'task-1', contextId: 'ctx-1', artifact: { artifactId: 'a1', parts: [{ text: 'hi' }] } };
+      const event = parser.parseArtifactUpdateEvent(raw);
+      expect(event.artifact.parts[0]).toEqual({ text: 'hi' });
+    });
+  });
+});
+
+// ═══ SSE Parser Tests ═══
+
+describe('SSE Parser', () => {
+  const parser = getResponseParser('0.3');
+
+  it('should parse status_update and artifact_update events', async () => {
+    const sse = [
+      'event: status_update\ndata: {"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
+      'event: artifact_update\ndata: {"kind":"artifact-update","taskId":"t1","contextId":"c1","artifact":{"artifactId":"a1","parts":[{"kind":"text","text":"hello"}]}}\n\n',
+      'event: done\ndata: {}\n\n',
+    ].join('');
+
+    const response = createSSEResponse(sse);
+    const events: unknown[] = [];
+    for await (const event of parseSSEStream(response, parser)) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(2);
+    expect((events[0] as Record<string, unknown>).taskId).toBe('t1');
+    expect((events[1] as Record<string, unknown>).taskId).toBe('t1');
+  });
+
+  it('should stop on done event', async () => {
+    const sse = [
+      'event: status_update\ndata: {"taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
+      'event: done\ndata: {}\n\n',
+      'event: artifact_update\ndata: {"taskId":"t1","contextId":"c1","artifact":{"artifactId":"a1","parts":[]}}\n\n',
+    ].join('');
+
+    const response = createSSEResponse(sse);
+    const events: unknown[] = [];
+    for await (const event of parseSSEStream(response, parser)) {
+      events.push(event);
+    }
+
+    // Should only get 1 event (before done)
+    expect(events).toHaveLength(1);
+  });
+
+  it('should throw on error event', async () => {
+    const sse = 'event: error\ndata: {"error":"Something went wrong"}\n\n';
+    const response = createSSEResponse(sse);
+
+    await expect(async () => {
+      for await (const _event of parseSSEStream(response, parser)) {
+        // should not reach here
+      }
+    }).rejects.toThrow('Something went wrong');
+  });
+
+  it('should handle chunked SSE delivery', async () => {
+    const encoder = new TextEncoder();
+    const chunk1 = 'event: status_upd';
+    const chunk2 = 'ate\ndata: {"taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n';
+    const chunk3 = 'event: done\ndata: {}\n\n';
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(chunk1));
+        controller.enqueue(encoder.encode(chunk2));
+        controller.enqueue(encoder.encode(chunk3));
+        controller.close();
+      },
+    });
+
+    const response = { ok: true, body: stream } as unknown as Response;
+    const events: unknown[] = [];
+    for await (const event of parseSSEStream(response, parser)) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    expect((events[0] as Record<string, unknown>).taskId).toBe('t1');
+  });
+
+  it('should throw if response body is null', async () => {
+    const response = { ok: true, body: null } as unknown as Response;
+
+    await expect(async () => {
+      for await (const _event of parseSSEStream(response, parser)) { /* */ }
+    }).rejects.toThrow('Response body is null');
+  });
+});
+
+// ═══ A2XClient Tests ═══
+
+describe('A2XClient', () => {
+  describe('constructor', () => {
+    it('should accept a URL string', () => {
+      const client = new A2XClient('http://localhost:4000');
+      expect(client).toBeDefined();
+    });
+
+    it('should accept a v0.3 AgentCard', () => {
+      const client = new A2XClient(V03_CARD);
+      expect(client).toBeDefined();
+    });
+
+    it('should accept a v1.0 AgentCard', () => {
+      const client = new A2XClient(V10_CARD);
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('getAgentCard', () => {
+    it('should resolve and cache agent card from URL', async () => {
+      const mockFetch = createMockFetch(V10_CARD);
+      const client = new A2XClient('http://localhost:4000', { fetch: mockFetch });
+
+      const card = await client.getAgentCard();
+      expect(card).toEqual(V10_CARD);
+
+      // Second call should use cache (no additional fetch)
+      const card2 = await client.getAgentCard();
+      expect(card2).toEqual(V10_CARD);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return pre-provided AgentCard without fetch', async () => {
+      const mockFetch = vi.fn();
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      const card = await client.getAgentCard();
+      expect(card).toEqual(V03_CARD);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should send JSON-RPC request and parse v0.3 task response', async () => {
+      const v03Task = {
+        kind: 'task',
+        id: 'task-1',
+        status: { state: 'completed' },
+        artifacts: [{ kind: 'artifact', artifactId: 'a1', name: 'response', parts: [{ kind: 'text', text: 'Hello!' }] }],
+      };
+
+      const mockFetch = createMockFetch(createJsonRpcSuccess(v03Task));
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      const task = await client.sendMessage(createSendMessageParams('Hi'));
+      expect(task.id).toBe('task-1');
+      expect(task.status.state).toBe(TaskState.COMPLETED);
+      expect((task as Record<string, unknown>).kind).toBeUndefined();
+      expect(task.artifacts![0].parts[0]).toEqual({ text: 'Hello!' });
+    });
+
+    it('should send JSON-RPC request and parse v1.0 task response', async () => {
+      const v10Task = {
+        id: 'task-1',
+        status: { state: 'TASK_STATE_COMPLETED' },
+        artifacts: [{ artifactId: 'a1', parts: [{ text: 'Hello!' }] }],
+      };
+
+      const mockFetch = createMockFetch(createJsonRpcSuccess(v10Task));
+      const client = new A2XClient(V10_CARD, { fetch: mockFetch });
+
+      const task = await client.sendMessage(createSendMessageParams('Hi'));
+      expect(task.id).toBe('task-1');
+      expect(task.status.state).toBe(TaskState.COMPLETED);
+    });
+
+    it('should build correct JSON-RPC request', async () => {
+      const mockFetch = createMockFetch(createJsonRpcSuccess({ id: 't1', status: { state: 'completed' } }));
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      await client.sendMessage(createSendMessageParams('Test'));
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body.jsonrpc).toBe('2.0');
+      expect(body.method).toBe('message/send');
+      expect(body.params.message.parts[0].text).toBe('Test');
+      expect(typeof body.id).toBe('number');
+    });
+
+    it('should throw TaskNotFoundError on -32001 error', async () => {
+      const mockFetch = createMockFetch(createJsonRpcError(A2A_ERROR_CODES.TASK_NOT_FOUND, 'Task not found'));
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      await expect(client.sendMessage(createSendMessageParams('Hi'))).rejects.toThrow('Task not found');
+    });
+
+    it('should throw InternalError on HTTP failure', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      await expect(client.sendMessage(createSendMessageParams('Hi'))).rejects.toThrow('HTTP 500');
+    });
+
+    it('should pass custom headers', async () => {
+      const mockFetch = createMockFetch(createJsonRpcSuccess({ id: 't1', status: { state: 'completed' } }));
+      const client = new A2XClient(V03_CARD, {
+        fetch: mockFetch,
+        headers: { Authorization: 'Bearer secret' },
+      });
+
+      await client.sendMessage(createSendMessageParams('Hi'));
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers.Authorization).toBe('Bearer secret');
+    });
+  });
+
+  describe('sendMessageStream', () => {
+    it('should stream events from v0.3 server', async () => {
+      // First call: resolveAgentCard (URL-based), but using AgentCard directly
+      const sseText = [
+        'event: status_update\ndata: {"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
+        'event: artifact_update\ndata: {"kind":"artifact-update","taskId":"t1","contextId":"c1","artifact":{"kind":"artifact","artifactId":"a1","parts":[{"kind":"text","text":"Hi!"}]}}\n\n',
+        'event: done\ndata: {}\n\n',
+      ].join('');
+
+      const sseResponse = createSSEResponse(sseText);
+      const mockFetch = vi.fn().mockResolvedValue(sseResponse);
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      const events: unknown[] = [];
+      for await (const event of client.sendMessageStream(createSendMessageParams('Hi'))) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(2);
+    });
+
+    it('should include Accept header for SSE', async () => {
+      const sseResponse = createSSEResponse('event: done\ndata: {}\n\n');
+      const mockFetch = vi.fn().mockResolvedValue(sseResponse);
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      for await (const _event of client.sendMessageStream(createSendMessageParams('Hi'))) { /* */ }
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers.Accept).toBe('text/event-stream');
+    });
+  });
+
+  describe('getTask', () => {
+    it('should retrieve and parse task', async () => {
+      const mockFetch = createMockFetch(
+        createJsonRpcSuccess({ id: 'task-1', status: { state: 'completed' }, artifacts: [] }),
+      );
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      const task = await client.getTask('task-1');
+      expect(task.id).toBe('task-1');
+      expect(task.status.state).toBe(TaskState.COMPLETED);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.method).toBe('tasks/get');
+      expect(body.params.id).toBe('task-1');
+    });
+  });
+
+  describe('cancelTask', () => {
+    it('should cancel and parse task', async () => {
+      const mockFetch = createMockFetch(
+        createJsonRpcSuccess({ id: 'task-1', status: { state: 'canceled' } }),
+      );
+      const client = new A2XClient(V03_CARD, { fetch: mockFetch });
+
+      const task = await client.cancelTask('task-1');
+      expect(task.id).toBe('task-1');
+      expect(task.status.state).toBe(TaskState.CANCELED);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.method).toBe('tasks/cancel');
+    });
+  });
+
+  describe('URL-based resolution', () => {
+    it('should resolve agent card from URL on first method call', async () => {
+      let callCount = 0;
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        callCount++;
+        if (url.includes('.well-known')) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(V03_CARD),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(
+            createJsonRpcSuccess({ id: 'task-1', status: { state: 'completed' } }),
+          ),
+        });
+      });
+
+      const client = new A2XClient('http://localhost:4000', { fetch: mockFetch });
+      const task = await client.sendMessage(createSendMessageParams('Hi'));
+
+      expect(task.id).toBe('task-1');
+      // First call: agent card resolution, second call: sendMessage
+      expect(callCount).toBe(2);
+    });
+  });
+});

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -1,0 +1,312 @@
+/**
+ * A2XClient — Client for communicating with remote A2A agents.
+ *
+ * Supports both v0.3 and v1.0 protocol versions with auto-detection.
+ * Protocol version is determined from the AgentCard structure.
+ */
+
+import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
+import type { Task } from '../types/task.js';
+import type {
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../types/task.js';
+import type { SendMessageParams, JSONRPCRequest } from '../types/jsonrpc.js';
+import type { JSONRPCResponse } from '../types/jsonrpc.js';
+import { A2A_METHODS } from '../types/jsonrpc.js';
+import type { A2AError } from '../types/errors.js';
+import {
+  TaskNotFoundError,
+  TaskNotCancelableError,
+  InternalError,
+  InvalidParamsError,
+  InvalidRequestError,
+  MethodNotFoundError,
+  JSONParseError,
+  PushNotificationNotSupportedError,
+  UnsupportedOperationError,
+  ContentTypeNotSupportedError,
+  InvalidAgentResponseError,
+  AuthenticatedExtendedCardNotConfiguredError,
+  A2A_ERROR_CODES,
+} from '../types/errors.js';
+import type { ResolvedAgentCard } from './agent-card-resolver.js';
+import {
+  resolveAgentCard,
+  detectProtocolVersion,
+  getAgentEndpointUrl,
+} from './agent-card-resolver.js';
+import { getResponseParser } from './response-parser.js';
+import type { ResponseParser } from './response-parser.js';
+import { parseSSEStream } from './sse-parser.js';
+
+// ─── Types ───
+
+export interface A2XClientOptions {
+  fetch?: typeof globalThis.fetch;
+  headers?: Record<string, string>;
+}
+
+// ─── Error Code → Error Class Mapping ───
+
+const ERROR_CODE_MAP: Record<number, new (message?: string, data?: unknown) => A2AError> = {
+  [A2A_ERROR_CODES.JSON_PARSE_ERROR]: JSONParseError,
+  [A2A_ERROR_CODES.INVALID_REQUEST]: InvalidRequestError,
+  [A2A_ERROR_CODES.METHOD_NOT_FOUND]: MethodNotFoundError,
+  [A2A_ERROR_CODES.INVALID_PARAMS]: InvalidParamsError,
+  [A2A_ERROR_CODES.INTERNAL_ERROR]: InternalError,
+  [A2A_ERROR_CODES.TASK_NOT_FOUND]: TaskNotFoundError,
+  [A2A_ERROR_CODES.TASK_NOT_CANCELABLE]: TaskNotCancelableError,
+  [A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED]: PushNotificationNotSupportedError,
+  [A2A_ERROR_CODES.UNSUPPORTED_OPERATION]: UnsupportedOperationError,
+  [A2A_ERROR_CODES.CONTENT_TYPE_NOT_SUPPORTED]: ContentTypeNotSupportedError,
+  [A2A_ERROR_CODES.INVALID_AGENT_RESPONSE]: InvalidAgentResponseError,
+  [A2A_ERROR_CODES.AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED]: AuthenticatedExtendedCardNotConfiguredError,
+};
+
+// ─── v0.3 Request Formatting ───
+
+/**
+ * Convert internal Part format to v0.3 wire format.
+ *
+ * v0.3 TextPart: { kind: "text", text: "..." }
+ * v0.3 FilePart: { kind: "file", file: { uri?, bytes?, mimeType?, name? } }
+ * v0.3 DataPart: { kind: "data", data: {...} }
+ */
+function formatPartToV03(part: Record<string, unknown>): Record<string, unknown> {
+  // TextPart
+  if ('text' in part) {
+    const result: Record<string, unknown> = { kind: 'text', text: part.text };
+    if (part.metadata) result.metadata = part.metadata;
+    return result;
+  }
+
+  // DataPart
+  if ('data' in part) {
+    const result: Record<string, unknown> = { kind: 'data', data: part.data };
+    if (part.metadata) result.metadata = part.metadata;
+    return result;
+  }
+
+  // FilePart: flatten → nested { file: { uri/bytes, mimeType, name } }
+  if ('raw' in part || 'url' in part) {
+    const file: Record<string, unknown> = {};
+    if (part.raw) file.bytes = part.raw;
+    if (part.url) file.uri = part.url;
+    if (part.mediaType) file.mimeType = part.mediaType;
+    if (part.filename) file.name = part.filename;
+
+    const result: Record<string, unknown> = { kind: 'file', file };
+    if (part.metadata) result.metadata = part.metadata;
+    return result;
+  }
+
+  // Unknown part — pass through with kind
+  if (!part.kind) part.kind = 'text';
+  return part;
+}
+
+// ─── A2XClient ───
+
+export class A2XClient {
+  private readonly _urlOrCard: string | AgentCardV03 | AgentCardV10;
+  private readonly _fetchImpl: typeof globalThis.fetch;
+  private readonly _headers: Record<string, string>;
+  private _resolved: ResolvedAgentCard | null = null;
+  private _parser: ResponseParser | null = null;
+  private _endpointUrl: string | null = null;
+  private _requestId = 0;
+
+  constructor(
+    urlOrAgentCard: string | AgentCardV03 | AgentCardV10,
+    options?: A2XClientOptions,
+  ) {
+    this._urlOrCard = urlOrAgentCard;
+    this._fetchImpl = options?.fetch ?? globalThis.fetch;
+    this._headers = options?.headers ?? {};
+  }
+
+  // ─── Public Methods ───
+
+  /**
+   * Send a message and wait for the complete response.
+   * Uses JSON-RPC method `message/send`.
+   */
+  async sendMessage(params: SendMessageParams): Promise<Task> {
+    await this._ensureResolved();
+    const formatted = this._formatParams(params);
+    const request = this._buildJsonRpcRequest(A2A_METHODS.SEND_MESSAGE, formatted);
+    const result = await this._postJsonRpc(request);
+    return this._parser!.parseTask(result);
+  }
+
+  /**
+   * Send a message and stream the response via SSE.
+   * Uses JSON-RPC method `message/stream`.
+   */
+  async *sendMessageStream(
+    params: SendMessageParams,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+    await this._ensureResolved();
+    const formatted = this._formatParams(params);
+    const request = this._buildJsonRpcRequest(
+      A2A_METHODS.STREAM_MESSAGE,
+      formatted,
+    );
+
+    const response = await this._fetchImpl(this._endpointUrl!, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        ...this._headers,
+      },
+      body: JSON.stringify(request),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw new InternalError(
+        `HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    yield* parseSSEStream(response, this._parser!);
+  }
+
+  /**
+   * Retrieve the current state of a task.
+   * Uses JSON-RPC method `tasks/get`.
+   */
+  async getTask(taskId: string): Promise<Task> {
+    await this._ensureResolved();
+    const request = this._buildJsonRpcRequest(A2A_METHODS.GET_TASK, {
+      id: taskId,
+    });
+    const result = await this._postJsonRpc(request);
+    return this._parser!.parseTask(result);
+  }
+
+  /**
+   * Request cancellation of a task.
+   * Uses JSON-RPC method `tasks/cancel`.
+   */
+  async cancelTask(taskId: string): Promise<Task> {
+    await this._ensureResolved();
+    const request = this._buildJsonRpcRequest(A2A_METHODS.CANCEL_TASK, {
+      id: taskId,
+    });
+    const result = await this._postJsonRpc(request);
+    return this._parser!.parseTask(result);
+  }
+
+  /**
+   * Get the resolved AgentCard. Fetches from the server if not already cached.
+   */
+  async getAgentCard(): Promise<AgentCardV03 | AgentCardV10> {
+    await this._ensureResolved();
+    return this._resolved!.card;
+  }
+
+  // ─── Private Methods ───
+
+  private async _ensureResolved(): Promise<void> {
+    if (this._resolved) return;
+
+    if (typeof this._urlOrCard === 'string') {
+      this._resolved = await resolveAgentCard(this._urlOrCard, {
+        fetch: this._fetchImpl,
+        headers: this._headers,
+      });
+    } else {
+      // AgentCard object provided directly
+      const card = this._urlOrCard;
+      const version = detectProtocolVersion(
+        card as unknown as Record<string, unknown>,
+      );
+      const endpointUrl = getAgentEndpointUrl(card, version);
+
+      this._resolved = {
+        card,
+        version,
+        baseUrl: new URL(endpointUrl).origin,
+      };
+    }
+
+    this._parser = getResponseParser(this._resolved!.version);
+    this._endpointUrl = getAgentEndpointUrl(
+      this._resolved!.card,
+      this._resolved.version,
+    );
+  }
+
+  /**
+   * Format SendMessageParams for the target protocol version.
+   * v0.3 servers expect `kind` discriminators and different field structures.
+   */
+  private _formatParams(params: SendMessageParams): unknown {
+    if (this._resolved?.version !== '0.3') return params;
+
+    // Deep clone to avoid mutating the original
+    const formatted = JSON.parse(JSON.stringify(params)) as Record<string, unknown>;
+
+    // Format message
+    const message = formatted.message as Record<string, unknown> | undefined;
+    if (message) {
+      if (!message.kind) message.kind = 'message';
+      const parts = message.parts as Array<Record<string, unknown>> | undefined;
+      if (parts) {
+        message.parts = parts.map(formatPartToV03);
+      }
+    }
+
+    // Format configuration: returnImmediately → blocking (inverted semantics)
+    const config = formatted.configuration as Record<string, unknown> | undefined;
+    if (config && 'returnImmediately' in config) {
+      config.blocking = !config.returnImmediately;
+      delete config.returnImmediately;
+    }
+
+    return formatted;
+  }
+
+  private _buildJsonRpcRequest(
+    method: string,
+    params: unknown,
+  ): JSONRPCRequest {
+    return {
+      jsonrpc: '2.0',
+      id: ++this._requestId,
+      method,
+      params,
+    };
+  }
+
+  private async _postJsonRpc(request: JSONRPCRequest): Promise<unknown> {
+    const response = await this._fetchImpl(this._endpointUrl!, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...this._headers,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new InternalError(
+        `HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const jsonRpcResponse = (await response.json()) as JSONRPCResponse;
+
+    if ('error' in jsonRpcResponse && jsonRpcResponse.error) {
+      const { code, message, data } = jsonRpcResponse.error;
+      const ErrorClass = ERROR_CODE_MAP[code] ?? InternalError;
+      throw new ErrorClass(message, data);
+    }
+
+    return (jsonRpcResponse as { result: unknown }).result;
+  }
+}

--- a/packages/a2x/src/client/agent-card-resolver.ts
+++ b/packages/a2x/src/client/agent-card-resolver.ts
@@ -1,0 +1,166 @@
+/**
+ * Client-side AgentCard resolution and protocol version detection.
+ */
+
+import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
+import type { ProtocolVersion } from '../a2x/a2x-agent.js';
+
+export type { ProtocolVersion };
+
+// ─── Constants ───
+
+export const AGENT_CARD_WELL_KNOWN_PATH = '/.well-known/agent.json';
+export const AGENT_CARD_WELL_KNOWN_PATH_ALT = '/.well-known/agent-card.json';
+
+const WELL_KNOWN_PATHS = [
+  AGENT_CARD_WELL_KNOWN_PATH,
+  AGENT_CARD_WELL_KNOWN_PATH_ALT,
+] as const;
+
+// ─── Types ───
+
+export interface AgentCardResolverOptions {
+  fetch?: typeof globalThis.fetch;
+  headers?: Record<string, string>;
+  path?: string;
+}
+
+export interface ResolvedAgentCard {
+  card: AgentCardV03 | AgentCardV10;
+  version: ProtocolVersion;
+  baseUrl: string;
+}
+
+// ─── Protocol Version Detection ───
+
+/**
+ * Detect whether an AgentCard is v0.3 or v1.0.
+ *
+ * v0.3 cards have a top-level `url` field and `protocolVersion` string.
+ * v1.0 cards have a `supportedInterfaces` array.
+ */
+export function detectProtocolVersion(card: Record<string, unknown>): ProtocolVersion {
+  if (
+    Array.isArray(card.supportedInterfaces) &&
+    card.supportedInterfaces.length > 0
+  ) {
+    return '1.0';
+  }
+  if (typeof card.url === 'string') {
+    return '0.3';
+  }
+  // Default to 1.0 if structure is ambiguous
+  return '1.0';
+}
+
+// ─── Endpoint URL Extraction ───
+
+/**
+ * Extract the JSON-RPC endpoint URL from a resolved AgentCard.
+ */
+export function getAgentEndpointUrl(
+  card: AgentCardV03 | AgentCardV10,
+  version: ProtocolVersion,
+): string {
+  if (version === '0.3') {
+    const v03 = card as AgentCardV03;
+    if (!v03.url) {
+      throw new Error('v0.3 AgentCard missing required "url" field');
+    }
+    return v03.url;
+  }
+
+  const v10 = card as AgentCardV10;
+  if (!v10.supportedInterfaces || v10.supportedInterfaces.length === 0) {
+    throw new Error('v1.0 AgentCard has no supportedInterfaces');
+  }
+
+  // Prefer JSONRPC binding
+  const jsonRpcInterface = v10.supportedInterfaces.find(
+    (i) => i.protocolBinding?.toUpperCase() === 'JSONRPC',
+  );
+  if (jsonRpcInterface) {
+    return jsonRpcInterface.url;
+  }
+
+  // Fallback to first interface
+  return v10.supportedInterfaces[0].url;
+}
+
+// ─── AgentCard Resolution ───
+
+/**
+ * Fetch and parse an AgentCard.
+ *
+ * Accepts three URL forms:
+ *   1. Full URL ending in .json — fetches directly (e.g. http://host/.well-known/agent.json)
+ *   2. Base URL + explicit path option — fetches baseUrl + path
+ *   3. Base URL only — tries well-known paths in order:
+ *        /.well-known/agent.json, /.well-known/agent-card.json
+ */
+export async function resolveAgentCard(
+  url: string,
+  options?: AgentCardResolverOptions,
+): Promise<ResolvedAgentCard> {
+  const fetchImpl = options?.fetch ?? globalThis.fetch;
+
+  // Full URL to agent card (e.g. http://host:4000/.well-known/agent.json)
+  if (!options?.path && url.endsWith('.json')) {
+    const parsed = new URL(url);
+    return fetchAgentCard(fetchImpl, parsed.origin, parsed.pathname, options?.headers);
+  }
+
+  const normalizedBase = url.replace(/\/+$/, '');
+
+  // Explicit path provided
+  if (options?.path) {
+    return fetchAgentCard(fetchImpl, normalizedBase, options.path, options?.headers);
+  }
+
+  // Try well-known paths in order, return first success
+  let lastError: Error | undefined;
+  for (const path of WELL_KNOWN_PATHS) {
+    try {
+      return await fetchAgentCard(fetchImpl, normalizedBase, path, options?.headers);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch AgentCard from ${normalizedBase} ` +
+    `(tried: ${WELL_KNOWN_PATHS.join(', ')}): ${lastError?.message}`,
+  );
+}
+
+async function fetchAgentCard(
+  fetchImpl: typeof globalThis.fetch,
+  baseUrl: string,
+  path: string,
+  headers?: Record<string, string>,
+): Promise<ResolvedAgentCard> {
+  const cardUrl = `${baseUrl}${path}`;
+
+  const response = await fetchImpl(cardUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      ...headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText}`,
+    );
+  }
+
+  const card = (await response.json()) as Record<string, unknown>;
+  const version = detectProtocolVersion(card);
+
+  return {
+    card: card as unknown as AgentCardV03 | AgentCardV10,
+    version,
+    baseUrl,
+  };
+}

--- a/packages/a2x/src/client/index.ts
+++ b/packages/a2x/src/client/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Client - public API for communicating with remote A2A agents.
+ */
+
+export { A2XClient } from './a2x-client.js';
+export type { A2XClientOptions } from './a2x-client.js';
+
+export {
+  resolveAgentCard,
+  detectProtocolVersion,
+  getAgentEndpointUrl,
+  AGENT_CARD_WELL_KNOWN_PATH,
+  AGENT_CARD_WELL_KNOWN_PATH_ALT,
+} from './agent-card-resolver.js';
+export type {
+  AgentCardResolverOptions,
+  ResolvedAgentCard,
+} from './agent-card-resolver.js';
+
+export { getResponseParser } from './response-parser.js';
+export type { ResponseParser } from './response-parser.js';
+
+export { parseSSEStream } from './sse-parser.js';

--- a/packages/a2x/src/client/response-parser.ts
+++ b/packages/a2x/src/client/response-parser.ts
@@ -1,0 +1,199 @@
+/**
+ * Client-side response parsing.
+ * Inverse of server-side ResponseMapper — normalizes wire format back to internal types.
+ */
+
+import type { Task } from '../types/task.js';
+import type {
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../types/task.js';
+import { TaskState, TASK_STATE_TO_V10 } from '../types/task.js';
+import type { ProtocolVersion } from './agent-card-resolver.js';
+
+// ─── Reverse map: v1.0 UPPER_SNAKE_CASE → internal lowercase TaskState ───
+
+const V10_STATE_TO_INTERNAL = new Map<string, TaskState>();
+for (const [internal, v10] of TASK_STATE_TO_V10) {
+  V10_STATE_TO_INTERNAL.set(v10, internal);
+}
+
+// ─── ResponseParser interface ───
+
+export interface ResponseParser {
+  parseTask(raw: unknown): Task;
+  parseStatusUpdateEvent(raw: unknown): TaskStatusUpdateEvent;
+  parseArtifactUpdateEvent(raw: unknown): TaskArtifactUpdateEvent;
+}
+
+// ─── Shared utilities ───
+
+function stripKind<T extends Record<string, unknown>>(obj: T): T {
+  if ('kind' in obj) {
+    const { kind: _, ...rest } = obj;
+    return rest as T;
+  }
+  return obj;
+}
+
+/**
+ * Normalize a v0.3 Part to internal flat format.
+ * Strips `kind` and converts nested FilePart `{ file: { uri, bytes, mimeType, name } }`
+ * to flat `{ url, raw, mediaType, filename }`.
+ */
+function normalizeV03Part(part: Record<string, unknown>): Record<string, unknown> {
+  const stripped = stripKind(part);
+
+  // v0.3 FilePart: { file: { uri?, bytes?, mimeType?, name? } } → flat
+  if ('file' in stripped && typeof stripped.file === 'object' && stripped.file !== null) {
+    const file = stripped.file as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    if (file.uri) result.url = file.uri;
+    if (file.bytes) result.raw = file.bytes;
+    if (file.mimeType) result.mediaType = file.mimeType;
+    if (file.name) result.filename = file.name;
+    if (stripped.metadata) result.metadata = stripped.metadata;
+    return result;
+  }
+
+  return stripped;
+}
+
+function stripKindDeep(obj: Record<string, unknown>): Record<string, unknown> {
+  const result = stripKind(obj);
+
+  // Strip kind from nested status.message
+  if (result.status && typeof result.status === 'object') {
+    const status = result.status as Record<string, unknown>;
+    if (status.message && typeof status.message === 'object') {
+      status.message = stripKind(status.message as Record<string, unknown>);
+      const msg = status.message as Record<string, unknown>;
+      if (Array.isArray(msg.parts)) {
+        msg.parts = msg.parts.map((p: unknown) =>
+          typeof p === 'object' && p !== null
+            ? normalizeV03Part(p as Record<string, unknown>)
+            : p,
+        );
+      }
+    }
+  }
+
+  // Strip kind from artifacts
+  if (Array.isArray(result.artifacts)) {
+    result.artifacts = result.artifacts.map((a: unknown) => {
+      if (typeof a !== 'object' || a === null) return a;
+      const artifact = stripKind(a as Record<string, unknown>);
+      if (Array.isArray(artifact.parts)) {
+        artifact.parts = artifact.parts.map((p: unknown) =>
+          typeof p === 'object' && p !== null
+            ? normalizeV03Part(p as Record<string, unknown>)
+            : p,
+        );
+      }
+      return artifact;
+    });
+  }
+
+  // Strip kind from history messages
+  if (Array.isArray(result.history)) {
+    result.history = result.history.map((m: unknown) => {
+      if (typeof m !== 'object' || m === null) return m;
+      const msg = stripKind(m as Record<string, unknown>);
+      if (Array.isArray(msg.parts)) {
+        msg.parts = msg.parts.map((p: unknown) =>
+          typeof p === 'object' && p !== null
+            ? normalizeV03Part(p as Record<string, unknown>)
+            : p,
+        );
+      }
+      return msg;
+    });
+  }
+
+  return result;
+}
+
+// ─── V03ResponseParser ───
+
+class V03ResponseParser implements ResponseParser {
+  parseTask(raw: unknown): Task {
+    const obj = raw as Record<string, unknown>;
+    return stripKindDeep(obj) as unknown as Task;
+  }
+
+  parseStatusUpdateEvent(raw: unknown): TaskStatusUpdateEvent {
+    const obj = raw as Record<string, unknown>;
+    return stripKindDeep(obj) as unknown as TaskStatusUpdateEvent;
+  }
+
+  parseArtifactUpdateEvent(raw: unknown): TaskArtifactUpdateEvent {
+    const obj = raw as Record<string, unknown>;
+    const result = stripKind(obj);
+
+    // Strip kind from artifact and its parts
+    if (result.artifact && typeof result.artifact === 'object') {
+      const artifact = stripKind(result.artifact as Record<string, unknown>);
+      if (Array.isArray(artifact.parts)) {
+        artifact.parts = artifact.parts.map((p: unknown) =>
+          typeof p === 'object' && p !== null
+            ? normalizeV03Part(p as Record<string, unknown>)
+            : p,
+        );
+      }
+      result.artifact = artifact;
+    }
+
+    return result as unknown as TaskArtifactUpdateEvent;
+  }
+}
+
+// ─── V10ResponseParser ───
+
+function convertV10State(state: string): TaskState {
+  const mapped = V10_STATE_TO_INTERNAL.get(state);
+  if (mapped) return mapped;
+
+  // If already lowercase (internal format), validate and return
+  const values = Object.values(TaskState) as string[];
+  if (values.includes(state)) return state as TaskState;
+
+  throw new Error(`Unknown task state: ${state}`);
+}
+
+function convertV10TaskState(obj: Record<string, unknown>): void {
+  if (obj.status && typeof obj.status === 'object') {
+    const status = obj.status as Record<string, unknown>;
+    if (typeof status.state === 'string') {
+      status.state = convertV10State(status.state);
+    }
+  }
+}
+
+class V10ResponseParser implements ResponseParser {
+  parseTask(raw: unknown): Task {
+    const obj = { ...(raw as Record<string, unknown>) };
+    convertV10TaskState(obj);
+    return obj as unknown as Task;
+  }
+
+  parseStatusUpdateEvent(raw: unknown): TaskStatusUpdateEvent {
+    const obj = { ...(raw as Record<string, unknown>) };
+    convertV10TaskState(obj);
+    return obj as unknown as TaskStatusUpdateEvent;
+  }
+
+  parseArtifactUpdateEvent(raw: unknown): TaskArtifactUpdateEvent {
+    return raw as TaskArtifactUpdateEvent;
+  }
+}
+
+// ─── Factory ───
+
+const parsers: Record<ProtocolVersion, ResponseParser> = {
+  '0.3': new V03ResponseParser(),
+  '1.0': new V10ResponseParser(),
+};
+
+export function getResponseParser(version: ProtocolVersion): ResponseParser {
+  return parsers[version];
+}

--- a/packages/a2x/src/client/sse-parser.ts
+++ b/packages/a2x/src/client/sse-parser.ts
@@ -1,0 +1,223 @@
+/**
+ * Client-side SSE (Server-Sent Events) stream parser.
+ * Counterpart to server-side src/transport/sse-handler.ts.
+ *
+ * Supports two SSE formats:
+ *
+ * Format A (a2x server — has event: field):
+ *   event: status_update\ndata: {event object}\n\n
+ *   event: artifact_update\ndata: {event object}\n\n
+ *   event: done\ndata: {}\n\n
+ *   event: error\ndata: {error message}\n\n
+ *
+ * Format B (ADK-based servers — data-only, JSON-RPC wrapped):
+ *   data: {"jsonrpc":"2.0","id":1,"result":{event object with "kind" field}}\n\n
+ */
+
+import type {
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../types/task.js';
+import { TERMINAL_STATES, TaskState } from '../types/task.js';
+import type { ResponseParser } from './response-parser.js';
+
+// ─── SSE Event Types (a2x server format) ───
+
+const SSE_EVENT = {
+  STATUS_UPDATE: 'status_update',
+  ARTIFACT_UPDATE: 'artifact_update',
+  DONE: 'done',
+  ERROR: 'error',
+  MESSAGE: 'message',
+} as const;
+
+// ─── SSE Parser ───
+
+interface ParsedSSEEvent {
+  event: string; // empty string when no event: field (SSE standard default: "message")
+  data: string;
+}
+
+/**
+ * Parse SSE blocks from a text buffer. Returns parsed events and any remaining buffer.
+ */
+function extractSSEEvents(buffer: string): {
+  events: ParsedSSEEvent[];
+  remaining: string;
+} {
+  const events: ParsedSSEEvent[] = [];
+  const blocks = buffer.split('\n\n');
+
+  // Last element is either empty (complete block) or a partial block (remaining)
+  const remaining = blocks.pop() ?? '';
+
+  for (const block of blocks) {
+    if (!block.trim()) continue;
+
+    let event = '';
+    const dataLines: string[] = [];
+
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event: ')) {
+        event = line.slice(7);
+      } else if (line.startsWith('event:')) {
+        event = line.slice(6);
+      } else if (line.startsWith('data: ')) {
+        dataLines.push(line.slice(6));
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5));
+      }
+      // Lines starting with ':' are comments — ignored per SSE spec
+    }
+
+    if (dataLines.length > 0) {
+      events.push({ event, data: dataLines.join('\n') });
+    }
+  }
+
+  return { events, remaining };
+}
+
+/**
+ * Unwrap data payload. Handles both raw event objects and JSON-RPC wrapped format.
+ * Returns the actual event object.
+ */
+function unwrapData(data: string): Record<string, unknown> {
+  const parsed = JSON.parse(data) as Record<string, unknown>;
+
+  // JSON-RPC wrapper: { jsonrpc: "2.0", id: ..., result: { ... } }
+  if (parsed.jsonrpc && parsed.result && typeof parsed.result === 'object') {
+    return parsed.result as Record<string, unknown>;
+  }
+
+  return parsed;
+}
+
+/**
+ * Detect event type from the event object when no SSE event: field is present.
+ * Uses the 'kind' discriminator (v0.3) or structural detection.
+ */
+function detectEventType(obj: Record<string, unknown>): string {
+  // v0.3 kind discriminator
+  const kind = obj.kind as string | undefined;
+  if (kind === 'status-update') return SSE_EVENT.STATUS_UPDATE;
+  if (kind === 'artifact-update') return SSE_EVENT.ARTIFACT_UPDATE;
+  if (kind === 'task') return SSE_EVENT.STATUS_UPDATE; // task events contain status
+  if (kind === 'message') return SSE_EVENT.MESSAGE;
+
+  // Structural detection
+  if ('status' in obj && 'taskId' in obj && !('artifacts' in obj)) return SSE_EVENT.STATUS_UPDATE;
+  if ('artifact' in obj) return SSE_EVENT.ARTIFACT_UPDATE;
+  if ('status' in obj && 'id' in obj) return SSE_EVENT.STATUS_UPDATE; // Task object
+
+  return SSE_EVENT.MESSAGE;
+}
+
+/**
+ * Check if a status-like event represents a terminal state.
+ */
+function isTerminalStatus(obj: Record<string, unknown>): boolean {
+  const status = obj.status as Record<string, unknown> | undefined;
+  if (!status) return false;
+  const state = (status.state as string ?? '').toLowerCase().replace('task_state_', '');
+  return TERMINAL_STATES.has(state as TaskState);
+}
+
+/**
+ * Parse an SSE Response stream into typed A2A events.
+ */
+export async function* parseSSEStream(
+  response: Response,
+  parser: ResponseParser,
+): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+  const body = response.body;
+  if (!body) {
+    throw new Error('Response body is null — cannot parse SSE stream');
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const { events, remaining } = extractSSEEvents(buffer);
+      buffer = remaining;
+
+      for (const sseEvent of events) {
+        // Format A: explicit event: field from a2x server
+        if (sseEvent.event) {
+          switch (sseEvent.event) {
+            case SSE_EVENT.STATUS_UPDATE: {
+              const raw = JSON.parse(sseEvent.data);
+              yield parser.parseStatusUpdateEvent(raw);
+              break;
+            }
+            case SSE_EVENT.ARTIFACT_UPDATE: {
+              const raw = JSON.parse(sseEvent.data);
+              yield parser.parseArtifactUpdateEvent(raw);
+              break;
+            }
+            case SSE_EVENT.DONE:
+              return;
+            case SSE_EVENT.ERROR: {
+              let message = 'Remote agent error';
+              try {
+                const errorData = JSON.parse(sseEvent.data);
+                if (errorData.error) message = errorData.error;
+              } catch {
+                if (sseEvent.data) message = sseEvent.data;
+              }
+              throw new Error(message);
+            }
+          }
+          continue;
+        }
+
+        // Format B: no event: field — detect type from data payload
+        const obj = unwrapData(sseEvent.data);
+        const eventType = detectEventType(obj);
+
+        switch (eventType) {
+          case SSE_EVENT.STATUS_UPDATE: {
+            // Could be a Task object (kind: 'task') or a status-update
+            if ('id' in obj && 'status' in obj && 'artifacts' in obj) {
+              // Full Task object — emit as status update from its status
+              yield parser.parseStatusUpdateEvent({
+                taskId: obj.id,
+                contextId: obj.contextId,
+                status: obj.status,
+                metadata: obj.metadata,
+              });
+            } else if ('id' in obj && 'status' in obj) {
+              // Task object without artifacts
+              yield parser.parseStatusUpdateEvent({
+                taskId: obj.id,
+                contextId: obj.contextId,
+                status: obj.status,
+                metadata: obj.metadata,
+              });
+            } else {
+              yield parser.parseStatusUpdateEvent(obj);
+            }
+            // Stop on terminal status with final flag or terminal state
+            const isFinal = (obj as Record<string, unknown>).final === true;
+            if (isFinal && isTerminalStatus(obj)) return;
+            break;
+          }
+          case SSE_EVENT.ARTIFACT_UPDATE: {
+            yield parser.parseArtifactUpdateEvent(obj);
+            break;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/a2x/src/index.ts
+++ b/packages/a2x/src/index.ts
@@ -32,5 +32,8 @@ export * from './a2x/index.js';
 // Layer 4: Transport
 export * from './transport/index.js';
 
-// Remote (Phase 3 stubs)
+// Layer 4: Client
+export * from './client/index.js';
+
+// Remote
 export * from './remote/index.js';

--- a/packages/a2x/src/remote/index.ts
+++ b/packages/a2x/src/remote/index.ts
@@ -1,5 +1,5 @@
 /**
- * Remote - public API (Phase 3)
+ * Remote - public API for integrating remote A2A agents.
  */
 
 export { RemoteA2AAgent } from './remote-a2a-agent.js';

--- a/packages/a2x/src/remote/remote-a2a-agent.ts
+++ b/packages/a2x/src/remote/remote-a2a-agent.ts
@@ -1,29 +1,152 @@
 /**
- * RemoteA2AAgent - Phase 3 stub.
+ * RemoteA2AAgent — Integrates a remote A2A agent into local a2x pipelines.
+ *
+ * Uses A2XClient internally to communicate with the remote agent.
+ * The remote agent is treated as a local BaseAgent, yielding AgentEvents
+ * from the streamed A2A response.
  */
 
 import type { AgentEvent } from '../agent/base-agent.js';
 import { BaseAgent } from '../agent/base-agent.js';
 import type { InvocationContext } from '../runner/context.js';
+import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
+import type { SendMessageConfiguration } from '../types/jsonrpc.js';
+import { TaskState } from '../types/task.js';
+import type { Message, Part } from '../types/common.js';
+import { A2XClient } from '../client/a2x-client.js';
+import type { A2XClientOptions } from '../client/a2x-client.js';
+
+// ─── Types ───
 
 export interface RemoteA2AAgentOptions {
   name: string;
   description: string;
-  agentCardUrl: string;
+  agentCardUrl?: string;
+  agentCard?: AgentCardV03 | AgentCardV10;
+  client?: A2XClient;
   auth?: { token: string; scheme?: string };
+  sendConfiguration?: SendMessageConfiguration;
+  fetchImpl?: typeof globalThis.fetch;
 }
 
+// ─── RemoteA2AAgent ───
+
 export class RemoteA2AAgent extends BaseAgent {
-  readonly agentCardUrl: string;
-  readonly auth?: { token: string; scheme?: string };
+  private readonly _options: RemoteA2AAgentOptions;
+  private _client: A2XClient | null;
 
   constructor(options: RemoteA2AAgentOptions) {
     super({ name: options.name, description: options.description });
-    this.agentCardUrl = options.agentCardUrl;
-    this.auth = options.auth;
+
+    if (!options.agentCardUrl && !options.agentCard && !options.client) {
+      throw new Error(
+        'RemoteA2AAgent requires at least one of: agentCardUrl, agentCard, or client',
+      );
+    }
+
+    this._options = options;
+    this._client = options.client ?? null;
   }
 
-  async *run(_context: InvocationContext): AsyncGenerator<AgentEvent> {
-    throw new Error('RemoteA2AAgent not yet implemented (Phase 3)');
+  async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
+    const client = this._ensureClient();
+    const message = this._buildMessageFromContext(context);
+
+    const eventStream = client.sendMessageStream({
+      message,
+      configuration: this._options.sendConfiguration,
+    });
+
+    for await (const event of eventStream) {
+      if ('status' in event) {
+        // TaskStatusUpdateEvent
+        const state = event.status.state;
+
+        if (state === TaskState.FAILED) {
+          const errorText = event.status.message?.parts
+            .map((p) => ('text' in p ? p.text : ''))
+            .filter(Boolean)
+            .join('') || 'Remote agent failed';
+          yield { type: 'error', error: new Error(errorText) };
+          return;
+        }
+
+        if (state === TaskState.COMPLETED) {
+          yield { type: 'done' };
+          return;
+        }
+
+        // WORKING, SUBMITTED, etc. — informational, no AgentEvent needed
+      } else {
+        // TaskArtifactUpdateEvent
+        for (const part of event.artifact.parts) {
+          if ('text' in part) {
+            yield { type: 'text', text: part.text, role: 'agent' };
+          }
+        }
+      }
+    }
+
+    // Stream ended without explicit COMPLETED — yield done
+    yield { type: 'done' };
+  }
+
+  /**
+   * Lazily create A2XClient based on constructor options.
+   * Priority: client > agentCard > agentCardUrl
+   */
+  private _ensureClient(): A2XClient {
+    if (this._client) return this._client;
+
+    const clientOptions: A2XClientOptions = {
+      fetch: this._options.fetchImpl,
+    };
+
+    if (this._options.auth) {
+      const scheme = this._options.auth.scheme ?? 'Bearer';
+      clientOptions.headers = {
+        Authorization: `${scheme} ${this._options.auth.token}`,
+      };
+    }
+
+    if (this._options.agentCard) {
+      this._client = new A2XClient(this._options.agentCard, clientOptions);
+    } else if (this._options.agentCardUrl) {
+      this._client = new A2XClient(this._options.agentCardUrl, clientOptions);
+    } else {
+      throw new Error('No agentCard, agentCardUrl, or client provided');
+    }
+
+    return this._client;
+  }
+
+  /**
+   * Build a Message from the InvocationContext session events.
+   * Extracts the most recent user text input.
+   */
+  private _buildMessageFromContext(context: InvocationContext): Message {
+    const events = context.session.events;
+    const parts: Part[] = [];
+
+    // Scan from the end for the most recent user text
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (event.type === 'text' && event.role !== 'agent') {
+        parts.push({ text: event.text });
+        break;
+      }
+    }
+
+    if (parts.length === 0) {
+      throw new Error(
+        'No user input found in session — cannot invoke remote agent',
+      );
+    }
+
+    return {
+      messageId: crypto.randomUUID(),
+      role: 'user',
+      parts,
+    };
   }
 }

--- a/packages/a2x/tsup.config.ts
+++ b/packages/a2x/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig([
   {
     entry: {
       'auth/index': 'src/auth/index.ts',
+      'client/index': 'src/client/index.ts',
       'provider/anthropic/index': 'src/provider/anthropic/index.ts',
       'provider/openai/index': 'src/provider/openai/index.ts',
       'provider/google/index': 'src/provider/google/index.ts',

--- a/packages/cli/src/commands/agent-card.ts
+++ b/packages/cli/src/commands/agent-card.ts
@@ -1,129 +1,28 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
+import { resolveAgentCard } from 'a2x/client';
+import { printAgentCard, printConnectionError, parseHeaders } from '../format.js';
 
 export const agentCardCommand = new Command('agent-card')
   .description('Fetch and display an A2A agent card')
-  .argument('<url>', 'Agent URL or direct agent.json URL')
+  .argument('<url>', 'Agent base URL or direct agent card URL (.json)')
   .option('--json', 'Output raw JSON')
-  .option(
-    '--protocol-version <version>',
-    'A2A protocol version (default: auto-detect)',
-  )
-  .action(async (url: string, opts: { json?: boolean; protocolVersion?: string }) => {
+  .option('-H, --header <header...>', 'Custom headers (format: Key:Value)')
+  .action(async (url: string, opts: { json?: boolean; header?: string[] }) => {
     try {
-      const cardUrl = resolveAgentCardUrl(url);
-      const res = await fetch(cardUrl);
-
-      if (!res.ok) {
-        console.error(
-          chalk.red(`Failed to fetch agent card: ${res.status} ${res.statusText}`),
-        );
-        process.exit(1);
-      }
-
-      const card = (await res.json()) as Record<string, unknown>;
+      const headers = parseHeaders(opts.header);
+      const resolved = await resolveAgentCard(url, { headers });
 
       if (opts.json) {
-        console.log(JSON.stringify(card, null, 2));
+        console.log(JSON.stringify(resolved.card, null, 2));
         return;
       }
 
-      printAgentCard(card, opts.protocolVersion);
+      printAgentCard(
+        resolved.card as unknown as Record<string, unknown>,
+        resolved.version,
+      );
     } catch (err) {
-      if (err instanceof TypeError && (err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
-        console.error(chalk.red(`Connection refused: ${url}`));
-      } else if (err instanceof SyntaxError) {
-        console.error(chalk.red('Invalid JSON response from server'));
-      } else {
-        console.error(
-          chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`),
-        );
-      }
+      printConnectionError(err, url);
       process.exit(1);
     }
   });
-
-function resolveAgentCardUrl(url: string): string {
-  if (url.endsWith('.json')) {
-    return url;
-  }
-  const base = url.replace(/\/+$/, '');
-  return `${base}/.well-known/agent.json`;
-}
-
-function printAgentCard(card: Record<string, unknown>, protocolVersion?: string): void {
-  // Determine protocol version from card or option
-  const version =
-    protocolVersion ??
-    (card.protocolVersion as string | undefined) ??
-    detectProtocolVersion(card);
-
-  console.log(chalk.bold.cyan('Agent Card'));
-  console.log(chalk.gray('─'.repeat(40)));
-
-  if (card.name) {
-    console.log(`${chalk.bold('Name:')}         ${card.name}`);
-  }
-  if (card.description) {
-    console.log(`${chalk.bold('Description:')}  ${card.description}`);
-  }
-  if (card.version) {
-    console.log(`${chalk.bold('Version:')}      ${card.version}`);
-  }
-  console.log(`${chalk.bold('Protocol:')}     ${version ?? 'unknown'}`);
-
-  // URL(s)
-  if (card.url) {
-    console.log(`${chalk.bold('URL:')}          ${card.url}`);
-  }
-  const interfaces = (card.supportedInterfaces ?? card.additionalInterfaces) as
-    | Array<Record<string, string>>
-    | undefined;
-  if (interfaces?.length) {
-    console.log(chalk.bold('\nInterfaces:'));
-    for (const iface of interfaces) {
-      const binding = iface.protocolBinding ?? iface.transport ?? '';
-      console.log(`  ${chalk.green('•')} ${iface.url}${binding ? ` (${binding})` : ''}`);
-    }
-  }
-
-  // Capabilities
-  const caps = card.capabilities as Record<string, unknown> | undefined;
-  if (caps) {
-    console.log(chalk.bold('\nCapabilities:'));
-    if (caps.streaming) console.log(`  ${chalk.green('✓')} Streaming`);
-    if (caps.pushNotifications) console.log(`  ${chalk.green('✓')} Push Notifications`);
-    if (caps.stateTransitionHistory) console.log(`  ${chalk.green('✓')} State Transition History`);
-    if (caps.extendedAgentCard) console.log(`  ${chalk.green('✓')} Extended Agent Card`);
-  }
-
-  // Skills
-  const skills = card.skills as Array<Record<string, unknown>> | undefined;
-  if (skills?.length) {
-    console.log(chalk.bold('\nSkills:'));
-    for (const skill of skills) {
-      console.log(`  ${chalk.yellow(skill.name ?? skill.id)}`);
-      if (skill.description) {
-        console.log(`    ${chalk.gray(skill.description)}`);
-      }
-      const tags = skill.tags as string[] | undefined;
-      if (tags?.length) {
-        console.log(`    Tags: ${tags.map((t) => chalk.blue(t)).join(', ')}`);
-      }
-    }
-  }
-
-  // Provider
-  const provider = card.provider as Record<string, string> | undefined;
-  if (provider) {
-    console.log(chalk.bold('\nProvider:'));
-    console.log(`  ${provider.organization}${provider.url ? ` (${provider.url})` : ''}`);
-  }
-}
-
-function detectProtocolVersion(card: Record<string, unknown>): string | undefined {
-  if ('protocolVersion' in card) return card.protocolVersion as string;
-  if ('supportedInterfaces' in card) return '1.0';
-  if ('url' in card && 'skills' in card) return '0.3';
-  return undefined;
-}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,2 +1,4 @@
 export { agentCardCommand } from './agent-card.js';
 export { sendCommand } from './send.js';
+export { streamCommand } from './stream.js';
+export { taskCommand } from './task.js';

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -1,206 +1,47 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
 import crypto from 'node:crypto';
+import type { SendMessageParams } from 'a2x';
+import { printTask, printConnectionError, createClient } from '../format.js';
 
 export const sendCommand = new Command('send')
-  .description('Send a message to an A2A agent')
-  .argument('<url>', 'Agent JSON-RPC endpoint URL')
+  .description('Send a message to an A2A agent (blocking)')
+  .argument('<url>', 'Agent base URL')
   .argument('<message>', 'Message text to send')
-  .option('--task-id <id>', 'Continue an existing task')
+  .option('--context-id <id>', 'Continue an existing conversation context')
+  .option('-H, --header <header...>', 'Custom headers (format: Key:Value)')
   .option('--json', 'Output raw JSON response')
   .action(
     async (
       url: string,
       message: string,
-      opts: { taskId?: string; json?: boolean },
+      opts: { contextId?: string; header?: string[]; json?: boolean },
     ) => {
       try {
-        const requestBody = buildRequest(message, opts.taskId);
+        const client = createClient(url, opts);
 
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody),
-        });
+        const params: SendMessageParams = {
+          message: {
+            messageId: crypto.randomUUID(),
+            role: 'user',
+            parts: [{ text: message }],
+          },
+        };
 
-        if (!res.ok) {
-          console.error(
-            chalk.red(
-              `HTTP error: ${res.status} ${res.statusText}`,
-            ),
-          );
-          process.exit(1);
+        if (opts.contextId) {
+          params.message.contextId = opts.contextId;
         }
 
-        const body = (await res.json()) as Record<string, unknown>;
+        const task = await client.sendMessage(params);
 
         if (opts.json) {
-          console.log(JSON.stringify(body, null, 2));
+          console.log(JSON.stringify(task, null, 2));
           return;
         }
 
-        if (body.error) {
-          printError(body.error as { code: number; message: string; data?: unknown });
-          process.exit(1);
-        }
-
-        printResult(body.result as Record<string, unknown>);
+        printTask(task);
       } catch (err) {
-        if (
-          err instanceof TypeError &&
-          (err as NodeJS.ErrnoException).code === 'ECONNREFUSED'
-        ) {
-          console.error(chalk.red(`Connection refused: ${url}`));
-        } else {
-          console.error(
-            chalk.red(
-              `Error: ${err instanceof Error ? err.message : String(err)}`,
-            ),
-          );
-        }
+        printConnectionError(err, url);
         process.exit(1);
       }
     },
   );
-
-interface JSONRPCRequest {
-  jsonrpc: '2.0';
-  id: string;
-  method: string;
-  params: {
-    message: {
-      messageId: string;
-      role: 'user';
-      parts: Array<{ kind: 'text'; text: string }>;
-      taskId?: string;
-    };
-  };
-}
-
-function buildRequest(message: string, taskId?: string): JSONRPCRequest {
-  const msg: JSONRPCRequest['params']['message'] = {
-    messageId: crypto.randomUUID(),
-    role: 'user',
-    parts: [{ kind: 'text', text: message }],
-  };
-
-  if (taskId) {
-    msg.taskId = taskId;
-  }
-
-  return {
-    jsonrpc: '2.0',
-    id: crypto.randomUUID(),
-    method: 'message/send',
-    params: { message: msg },
-  };
-}
-
-function printError(error: { code: number; message: string; data?: unknown }): void {
-  console.error(chalk.red.bold('JSON-RPC Error'));
-  console.error(chalk.red(`  Code:    ${error.code}`));
-  console.error(chalk.red(`  Message: ${error.message}`));
-  if (error.data) {
-    console.error(chalk.red(`  Data:    ${JSON.stringify(error.data)}`));
-  }
-}
-
-function printResult(result: Record<string, unknown>): void {
-  console.log(chalk.bold.cyan('Response'));
-  console.log(chalk.gray('─'.repeat(40)));
-
-  // Task info
-  if (result.id) {
-    console.log(`${chalk.bold('Task ID:')}  ${result.id}`);
-  }
-  if (result.contextId) {
-    console.log(`${chalk.bold('Context:')}  ${result.contextId}`);
-  }
-
-  // Status
-  const status = result.status as Record<string, unknown> | undefined;
-  if (status) {
-    const state = (status.state as string) ?? 'unknown';
-    const stateColor = getStateColor(state);
-    console.log(`${chalk.bold('Status:')}   ${stateColor(state)}`);
-  }
-
-  // Artifacts
-  const artifacts = result.artifacts as
-    | Array<Record<string, unknown>>
-    | undefined;
-  if (artifacts?.length) {
-    console.log(chalk.bold('\nArtifacts:'));
-    for (const artifact of artifacts) {
-      if (artifact.name) {
-        console.log(`  ${chalk.yellow(artifact.name as string)}`);
-      }
-      const parts = artifact.parts as Array<Record<string, unknown>> | undefined;
-      if (parts) {
-        printParts(parts);
-      }
-    }
-  }
-
-  // Status message (agent response)
-  if (status?.message) {
-    const msg = status.message as Record<string, unknown>;
-    const parts = msg.parts as Array<Record<string, unknown>> | undefined;
-    if (parts?.length) {
-      console.log(chalk.bold('\nAgent Message:'));
-      printParts(parts);
-    }
-  }
-
-  // History
-  const history = result.history as Array<Record<string, unknown>> | undefined;
-  if (history?.length) {
-    console.log(chalk.bold('\nHistory:'));
-    for (const msg of history) {
-      const role = msg.role as string;
-      const roleLabel = role === 'agent' ? chalk.green('Agent') : chalk.blue('User');
-      console.log(`  ${roleLabel}:`);
-      const parts = msg.parts as Array<Record<string, unknown>> | undefined;
-      if (parts) {
-        printParts(parts, '    ');
-      }
-    }
-  }
-}
-
-function printParts(
-  parts: Array<Record<string, unknown>>,
-  indent = '  ',
-): void {
-  for (const part of parts) {
-    if ('text' in part) {
-      console.log(`${indent}${part.text}`);
-    } else if ('data' in part) {
-      console.log(`${indent}${chalk.gray(JSON.stringify(part.data))}`);
-    } else if ('url' in part || 'raw' in part) {
-      const label = (part.filename as string) ?? (part.url as string) ?? '[file]';
-      console.log(`${indent}${chalk.underline(label)}`);
-    }
-  }
-}
-
-function getStateColor(state: string): (text: string) => string {
-  switch (state.toLowerCase().replace('task_state_', '')) {
-    case 'completed':
-      return chalk.green;
-    case 'working':
-    case 'submitted':
-      return chalk.yellow;
-    case 'failed':
-    case 'canceled':
-    case 'rejected':
-      return chalk.red;
-    case 'input-required':
-    case 'input_required':
-    case 'auth-required':
-    case 'auth_required':
-      return chalk.magenta;
-    default:
-      return chalk.white;
-  }
-}

--- a/packages/cli/src/commands/stream.ts
+++ b/packages/cli/src/commands/stream.ts
@@ -1,0 +1,65 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import crypto from 'node:crypto';
+import type { SendMessageParams } from 'a2x';
+import { printStatusUpdate, printArtifactChunk, printConnectionError, createClient } from '../format.js';
+
+export const streamCommand = new Command('stream')
+  .description('Send a message and stream the response via SSE')
+  .argument('<url>', 'Agent base URL')
+  .argument('<message>', 'Message text to send')
+  .option('--context-id <id>', 'Continue an existing conversation context')
+  .option('-H, --header <header...>', 'Custom headers (format: Key:Value)')
+  .option('--json', 'Output raw JSON events (one per line)')
+  .action(
+    async (
+      url: string,
+      message: string,
+      opts: { contextId?: string; header?: string[]; json?: boolean },
+    ) => {
+      try {
+        const client = createClient(url, opts);
+
+        const params: SendMessageParams = {
+          message: {
+            messageId: crypto.randomUUID(),
+            role: 'user',
+            parts: [{ text: message }],
+          },
+        };
+
+        if (opts.contextId) {
+          params.message.contextId = opts.contextId;
+        }
+
+        if (!opts.json) {
+          console.log(chalk.bold.cyan('Streaming response...'));
+          console.log(chalk.gray('─'.repeat(40)));
+        }
+
+        const stream = client.sendMessageStream(params);
+
+        for await (const event of stream) {
+          if (opts.json) {
+            console.log(JSON.stringify(event));
+            continue;
+          }
+
+          if ('status' in event) {
+            printStatusUpdate(event);
+          } else {
+            printArtifactChunk(event, true);
+          }
+        }
+
+        if (!opts.json) {
+          process.stdout.write('\n');
+          console.log(chalk.gray('─'.repeat(40)));
+          console.log(chalk.green('Stream completed'));
+        }
+      } catch (err) {
+        printConnectionError(err, url);
+        process.exit(1);
+      }
+    },
+  );

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import { printTask, printConnectionError, createClient } from '../format.js';
+
+export const taskCommand = new Command('task')
+  .description('Manage A2A tasks');
+
+// ─── task get ───
+
+taskCommand
+  .command('get')
+  .description('Get the current state of a task')
+  .argument('<url>', 'Agent base URL')
+  .argument('<task-id>', 'Task ID to retrieve')
+  .option('-H, --header <header...>', 'Custom headers (format: Key:Value)')
+  .option('--json', 'Output raw JSON response')
+  .action(
+    async (
+      url: string,
+      taskId: string,
+      opts: { header?: string[]; json?: boolean },
+    ) => {
+      try {
+        const client = createClient(url, opts);
+        const task = await client.getTask(taskId);
+
+        if (opts.json) {
+          console.log(JSON.stringify(task, null, 2));
+          return;
+        }
+
+        printTask(task);
+      } catch (err) {
+        printConnectionError(err, url);
+        process.exit(1);
+      }
+    },
+  );
+
+// ─── task cancel ───
+
+taskCommand
+  .command('cancel')
+  .description('Request cancellation of a task')
+  .argument('<url>', 'Agent base URL')
+  .argument('<task-id>', 'Task ID to cancel')
+  .option('-H, --header <header...>', 'Custom headers (format: Key:Value)')
+  .option('--json', 'Output raw JSON response')
+  .action(
+    async (
+      url: string,
+      taskId: string,
+      opts: { header?: string[]; json?: boolean },
+    ) => {
+      try {
+        const client = createClient(url, opts);
+        const task = await client.cancelTask(taskId);
+
+        if (opts.json) {
+          console.log(JSON.stringify(task, null, 2));
+          return;
+        }
+
+        printTask(task);
+      } catch (err) {
+        printConnectionError(err, url);
+        process.exit(1);
+      }
+    },
+  );

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,0 +1,255 @@
+/**
+ * Shared formatting and utility functions for CLI output.
+ */
+
+import chalk from 'chalk';
+import { A2XClient } from 'a2x/client';
+import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from 'a2x';
+
+// ─── Error Formatting ───
+
+export function printError(error: { code: number; message: string; data?: unknown }): void {
+  console.error(chalk.red.bold('JSON-RPC Error'));
+  console.error(chalk.red(`  Code:    ${error.code}`));
+  console.error(chalk.red(`  Message: ${error.message}`));
+  if (error.data) {
+    console.error(chalk.red(`  Data:    ${JSON.stringify(error.data)}`));
+  }
+}
+
+export function printConnectionError(err: unknown, url: string): void {
+  if (err instanceof TypeError && (err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
+    console.error(chalk.red(`Connection refused: ${url}`));
+  } else {
+    console.error(
+      chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`),
+    );
+  }
+}
+
+// ─── Task Formatting ───
+
+export function printTask(task: Task): void {
+  console.log(chalk.bold.cyan('Response'));
+  console.log(chalk.gray('─'.repeat(40)));
+
+  if (task.id) {
+    console.log(`${chalk.bold('Task ID:')}  ${task.id}`);
+  }
+  if (task.contextId) {
+    console.log(`${chalk.bold('Context:')}  ${task.contextId}`);
+  }
+
+  if (task.status) {
+    const state = task.status.state;
+    const stateColor = getStateColor(state);
+    console.log(`${chalk.bold('Status:')}   ${stateColor(state)}`);
+  }
+
+  if (task.artifacts?.length) {
+    console.log(chalk.bold('\nArtifacts:'));
+    for (const artifact of task.artifacts) {
+      if (artifact.name) {
+        console.log(`  ${chalk.yellow(artifact.name)}`);
+      }
+      printParts(artifact.parts);
+    }
+  }
+
+  if (task.status?.message) {
+    const msg = task.status.message;
+    if (msg.parts?.length) {
+      console.log(chalk.bold('\nAgent Message:'));
+      printParts(msg.parts);
+    }
+  }
+
+  if (task.history?.length) {
+    console.log(chalk.bold('\nHistory:'));
+    for (const msg of task.history) {
+      const roleLabel = msg.role === 'agent' ? chalk.green('Agent') : chalk.blue('User');
+      console.log(`  ${roleLabel}:`);
+      printParts(msg.parts, '    ');
+    }
+  }
+}
+
+// ─── Streaming Event Formatting ───
+
+export function printStatusUpdate(event: TaskStatusUpdateEvent): void {
+  const state = event.status.state;
+  const stateColor = getStateColor(state);
+  process.stdout.write(
+    chalk.gray(`[${event.taskId}] `) + chalk.bold('Status: ') + stateColor(state) + '\n',
+  );
+
+  if (event.status.message?.parts?.length) {
+    for (const part of event.status.message.parts) {
+      if ('text' in part) {
+        process.stdout.write(chalk.gray(`  ${part.text}\n`));
+      }
+    }
+  }
+}
+
+export function printArtifactChunk(event: TaskArtifactUpdateEvent, streaming = true): void {
+  for (const part of event.artifact.parts) {
+    if ('text' in part) {
+      if (streaming) {
+        process.stdout.write(part.text);
+      } else {
+        console.log(`  ${part.text}`);
+      }
+    } else if ('data' in part) {
+      console.log(chalk.gray(JSON.stringify(part.data)));
+    } else if ('url' in part || 'raw' in part) {
+      const label = ('filename' in part ? part.filename : undefined) ??
+        ('url' in part ? part.url : undefined) ?? '[file]';
+      console.log(chalk.underline(label));
+    }
+  }
+}
+
+// ─── Part Formatting ───
+
+export function printParts(
+  parts: Part[] | Array<Record<string, unknown>>,
+  indent = '  ',
+): void {
+  for (const part of parts) {
+    if ('text' in part) {
+      console.log(`${indent}${part.text}`);
+    } else if ('data' in part) {
+      console.log(`${indent}${chalk.gray(JSON.stringify(part.data))}`);
+    } else if ('url' in part || 'raw' in part) {
+      const p = part as Record<string, unknown>;
+      const label = (p.filename as string) ?? (p.url as string) ?? '[file]';
+      console.log(`${indent}${chalk.underline(label)}`);
+    }
+  }
+}
+
+// ─── Agent Card Formatting ───
+
+export function printAgentCard(card: Record<string, unknown>, version?: string): void {
+  console.log(chalk.bold.cyan('Agent Card'));
+  console.log(chalk.gray('─'.repeat(40)));
+
+  if (card.name) {
+    console.log(`${chalk.bold('Name:')}         ${card.name}`);
+  }
+  if (card.description) {
+    console.log(`${chalk.bold('Description:')}  ${card.description}`);
+  }
+  if (card.version) {
+    console.log(`${chalk.bold('Version:')}      ${card.version}`);
+  }
+  console.log(`${chalk.bold('Protocol:')}     ${version ?? 'unknown'}`);
+
+  // URL(s)
+  if (card.url) {
+    console.log(`${chalk.bold('URL:')}          ${card.url}`);
+  }
+  const interfaces = (card.supportedInterfaces ?? card.additionalInterfaces) as
+    | Array<Record<string, string>>
+    | undefined;
+  if (interfaces?.length) {
+    console.log(chalk.bold('\nInterfaces:'));
+    for (const iface of interfaces) {
+      const binding = iface.protocolBinding ?? iface.transport ?? '';
+      console.log(`  ${chalk.green('•')} ${iface.url}${binding ? ` (${binding})` : ''}`);
+    }
+  }
+
+  // Capabilities
+  const caps = card.capabilities as Record<string, unknown> | undefined;
+  if (caps) {
+    console.log(chalk.bold('\nCapabilities:'));
+    if (caps.streaming) console.log(`  ${chalk.green('✓')} Streaming`);
+    if (caps.pushNotifications) console.log(`  ${chalk.green('✓')} Push Notifications`);
+    if (caps.stateTransitionHistory) console.log(`  ${chalk.green('✓')} State Transition History`);
+    if (caps.extendedAgentCard) console.log(`  ${chalk.green('✓')} Extended Agent Card`);
+  }
+
+  // Skills
+  const skills = card.skills as Array<Record<string, unknown>> | undefined;
+  if (skills?.length) {
+    console.log(chalk.bold('\nSkills:'));
+    for (const skill of skills) {
+      console.log(`  ${chalk.yellow(skill.name ?? skill.id)}`);
+      if (skill.description) {
+        console.log(`    ${chalk.gray(skill.description)}`);
+      }
+      const tags = skill.tags as string[] | undefined;
+      if (tags?.length) {
+        console.log(`    Tags: ${tags.map((t) => chalk.blue(t)).join(', ')}`);
+      }
+    }
+  }
+
+  // Security
+  const secSchemes = card.securitySchemes as Record<string, unknown> | undefined;
+  if (secSchemes && Object.keys(secSchemes).length > 0) {
+    console.log(chalk.bold('\nSecurity Schemes:'));
+    for (const [name, scheme] of Object.entries(secSchemes)) {
+      const s = scheme as Record<string, unknown>;
+      const type = s.type ?? s.scheme ?? 'unknown';
+      console.log(`  ${chalk.green('•')} ${name} (${type})`);
+    }
+  }
+
+  // Provider
+  const provider = card.provider as Record<string, string> | undefined;
+  if (provider) {
+    console.log(chalk.bold('\nProvider:'));
+    console.log(`  ${provider.organization}${provider.url ? ` (${provider.url})` : ''}`);
+  }
+}
+
+// ─── Helpers ───
+
+export function getStateColor(state: string): (text: string) => string {
+  switch (state.toLowerCase().replace('task_state_', '')) {
+    case 'completed':
+      return chalk.green;
+    case 'working':
+    case 'submitted':
+      return chalk.yellow;
+    case 'failed':
+    case 'canceled':
+    case 'rejected':
+      return chalk.red;
+    case 'input-required':
+    case 'input_required':
+    case 'auth-required':
+    case 'auth_required':
+      return chalk.magenta;
+    default:
+      return chalk.white;
+  }
+}
+
+// ─── CLI Shared Utilities ───
+
+export function parseHeaders(headerArgs?: string[]): Record<string, string> | undefined {
+  if (!headerArgs?.length) return undefined;
+  const headers: Record<string, string> = {};
+  for (const h of headerArgs) {
+    const idx = h.indexOf(':');
+    if (idx > 0) {
+      headers[h.slice(0, idx).trim()] = h.slice(idx + 1).trim();
+    }
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+/**
+ * Create an A2XClient from CLI arguments.
+ */
+export function createClient(
+  url: string,
+  opts: { header?: string[] },
+): A2XClient {
+  const headers = parseHeaders(opts.header);
+  return new A2XClient(url, { headers });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { program } from 'commander';
-import { agentCardCommand, sendCommand } from './commands/index.js';
+import { agentCardCommand, sendCommand, streamCommand, taskCommand } from './commands/index.js';
 
 program
   .name('a2x')
@@ -8,5 +8,7 @@ program
 
 program.addCommand(agentCardCommand);
 program.addCommand(sendCommand);
+program.addCommand(streamCommand);
+program.addCommand(taskCommand);
 
 program.parse();


### PR DESCRIPTION
## Summary
- Add `A2XClient` with `sendMessage`, `sendMessageStream`, `getTask`, `cancelTask` methods
- Add `AgentCardResolver` with A2A v0.3/v1.0 auto-detection and well-known URL fallback
- Add SSE parser supporting both a2x and ADK server formats, plus v0.3/v1.0 response parsers (kind stripping, state conversion, FilePart normalization)
- Complete `RemoteA2AAgent` implementation using `A2XClient`
- Refactor CLI commands (`agent-card`, `send`) to use SDK; add `stream` and `task` (get/cancel) commands
- Add `a2x/client` subpath export

## Test plan
- [x] Unit tests added for A2XClient (`packages/a2x/src/__tests__/client.test.ts` — 625 lines)
- [ ] Verify `a2x send` command works against a running agent
- [ ] Verify `a2x stream` command streams SSE responses correctly
- [ ] Verify `a2x agent-card` resolves both v0.3 and v1.0 agent cards
- [ ] Verify `a2x task get` and `a2x task cancel` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)