### PR TITLE
refactor(cli): nest commands under a2a parent command

### DIFF
--- a/packages/cli/src/commands/a2a/agent-card.ts
+++ b/packages/cli/src/commands/a2a/agent-card.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { resolveAgentCard } from 'a2x/client';
-import { printAgentCard, printConnectionError, parseHeaders } from '../format.js';
+import { printAgentCard, printConnectionError, parseHeaders } from '../../format.js';
 
 export const agentCardCommand = new Command('agent-card')
   .description('Fetch and display an A2A agent card')

--- a/packages/cli/src/commands/a2a/index.ts
+++ b/packages/cli/src/commands/a2a/index.ts
@@ -1,0 +1,13 @@
+import { Command } from 'commander';
+import { agentCardCommand } from './agent-card.js';
+import { sendCommand } from './send.js';
+import { streamCommand } from './stream.js';
+import { taskCommand } from './task.js';
+
+export const a2aCommand = new Command('a2a')
+  .description('A2A protocol commands');
+
+a2aCommand.addCommand(agentCardCommand);
+a2aCommand.addCommand(sendCommand);
+a2aCommand.addCommand(streamCommand);
+a2aCommand.addCommand(taskCommand);

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import crypto from 'node:crypto';
 import type { SendMessageParams } from 'a2x';
-import { printTask, printConnectionError, createClient } from '../format.js';
+import { printTask, printConnectionError, createClient } from '../../format.js';
 
 export const sendCommand = new Command('send')
   .description('Send a message to an A2A agent (blocking)')

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import crypto from 'node:crypto';
 import type { SendMessageParams } from 'a2x';
-import { printStatusUpdate, printArtifactChunk, printConnectionError, createClient } from '../format.js';
+import { printStatusUpdate, printArtifactChunk, printConnectionError, createClient } from '../../format.js';
 
 export const streamCommand = new Command('stream')
   .description('Send a message and stream the response via SSE')

--- a/packages/cli/src/commands/a2a/task.ts
+++ b/packages/cli/src/commands/a2a/task.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { printTask, printConnectionError, createClient } from '../format.js';
+import { printTask, printConnectionError, createClient } from '../../format.js';
 
 export const taskCommand = new Command('task')
   .description('Manage A2A tasks');

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,1 @@
-export { agentCardCommand } from './agent-card.js';
-export { sendCommand } from './send.js';
-export { streamCommand } from './stream.js';
-export { taskCommand } from './task.js';
+export { a2aCommand } from './a2a/index.js';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,14 +1,11 @@
 import { program } from 'commander';
-import { agentCardCommand, sendCommand, streamCommand, taskCommand } from './commands/index.js';
+import { a2aCommand } from './commands/index.js';
 
 program
   .name('a2x')
   .description('CLI for the a2x A2A protocol SDK')
   .version('0.1.0');
 
-program.addCommand(agentCardCommand);
-program.addCommand(sendCommand);
-program.addCommand(streamCommand);
-program.addCommand(taskCommand);
+program.addCommand(a2aCommand);
 
 program.parse();


### PR DESCRIPTION
## Summary
- Move all CLI commands (agent-card, send, stream, task) under `a2a` parent command
- Reorganize source files into `commands/a2a/` directory to match command hierarchy
- CLI usage: `a2x a2a <subcommand>` (e.g. `a2x a2a send`, `a2x a2a agent-card`)

## Test plan
- [x] `pnpm --filter @a2x/cli build` succeeds
- [ ] `a2x a2a --help` lists all subcommands
- [ ] `a2x a2a agent-card --help` shows correct usage
- [ ] `a2x a2a send`, `stream`, `task` subcommands work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)