### PR TITLE
Exclude CLI from changesets npm publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@a2x/cli"]
 }


### PR DESCRIPTION
## Summary
- Add `@a2x/cli` to changesets `ignore` list so it is not published to npm
- CLI is distributed via GitHub Releases only, not npm

## Context
After merging #6, `release-sdk.yml` tried to publish both `a2x` and `@a2x/cli` to npm. CLI should be excluded since it uses a separate release workflow (`release-cli.yml`) with GitHub Releases.