### PR TITLE
Mark CLI as private to prevent npm publish

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@a2x/cli",
+  "private": true,
   "version": "0.1.0",
   "type": "module",
   "description": "CLI for the a2x A2A protocol SDK",
@@ -29,9 +30,6 @@
     "type": "git",
     "url": "https://github.com/planetarium/a2x.git",
     "directory": "packages/cli"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "keywords": ["a2a", "agent-to-agent", "ai", "agent", "cli"],
   "license": "MIT"


### PR DESCRIPTION
## Summary
- Add `private: true` to CLI package.json to prevent changesets from publishing it to npm
- Remove `publishConfig` since CLI is distributed via GitHub Releases only
- Fixes Release SDK workflow failure caused by attempting to publish `@a2x/cli` to npm