### PR TITLE
Rename SDK package from a2x to @a2x/a2x

### DIFF
--- a/packages/a2x/package.json
+++ b/packages/a2x/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a2x",
+  "name": "@a2x/a2x",
   "version": "0.1.0",
   "type": "module",
   "description": "A2A (Agent-to-Agent) protocol SDK for TypeScript",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "a2x": "workspace:*",
+    "@a2x/a2x": "workspace:*",
     "commander": "^13.0.0",
     "chalk": "^5.4.0"
   },

--- a/packages/cli/src/cli-auth-provider.ts
+++ b/packages/cli/src/cli-auth-provider.ts
@@ -9,7 +9,7 @@
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import chalk from 'chalk';
-import type { AuthProvider } from 'a2x/client';
+import type { AuthProvider } from '@a2x/a2x/client';
 import {
   AuthScheme,
   ApiKeyAuthScheme,
@@ -21,7 +21,7 @@ import {
   OAuth2ImplicitAuthScheme,
   OAuth2PasswordAuthScheme,
   OpenIdConnectAuthScheme,
-} from 'a2x/client';
+} from '@a2x/a2x/client';
 import { loadCredentials, saveCredentials, clearCredentials } from './token-store.js';
 
 async function prompt(question: string): Promise<string> {

--- a/packages/cli/src/commands/a2a/agent-card.ts
+++ b/packages/cli/src/commands/a2a/agent-card.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { resolveAgentCard } from 'a2x/client';
+import { resolveAgentCard } from '@a2x/a2x/client';
 import { printAgentCard, printConnectionError, parseHeaders } from '../../format.js';
 
 export const agentCardCommand = new Command('agent-card')

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import crypto from 'node:crypto';
-import type { SendMessageParams } from 'a2x';
+import type { SendMessageParams } from '@a2x/a2x';
 import { printTask, printConnectionError, createClient } from '../../format.js';
 
 export const sendCommand = new Command('send')

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import crypto from 'node:crypto';
-import type { SendMessageParams } from 'a2x';
+import type { SendMessageParams } from '@a2x/a2x';
 import { printStatusUpdate, printArtifactChunk, printConnectionError, createClient } from '../../format.js';
 
 export const streamCommand = new Command('stream')

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -3,8 +3,8 @@
  */
 
 import chalk from 'chalk';
-import { A2XClient } from 'a2x/client';
-import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from 'a2x';
+import { A2XClient } from '@a2x/a2x/client';
+import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from '@a2x/a2x';
 import { CliAuthProvider } from './cli-auth-provider.js';
 
 // ─── Error Formatting ───

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
 
   packages/cli:
     dependencies:
-      a2x:
+      '@a2x/a2x':
         specifier: workspace:*
         version: link:../a2x
       chalk:
@@ -79,7 +79,7 @@ importers:
 
   samples/express:
     dependencies:
-      a2x:
+      '@a2x/a2x':
         specifier: workspace:*
         version: link:../../packages/a2x
       dotenv:
@@ -104,7 +104,7 @@ importers:
 
   samples/nextjs:
     dependencies:
-      a2x:
+      '@a2x/a2x':
         specifier: workspace:*
         version: link:../../packages/a2x
       next:

--- a/samples/express/package.json
+++ b/samples/express/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "a2x": "workspace:*",
+    "@a2x/a2x": "workspace:*",
     "dotenv": "^16",
     "express": "^5.1.0"
   },

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -11,13 +11,13 @@ import {
   createSSEStream,
   ApiKeyAuthorization,
   OAuth2DeviceCodeAuthorization,
-} from 'a2x';
+} from '@a2x/a2x';
 import type {
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
   RequestContext,
-} from 'a2x';
-import { GoogleProvider } from 'a2x/google';
+} from '@a2x/a2x';
+import { GoogleProvider } from '@a2x/a2x/google';
 
 // ─── 1. Define your agent ───
 

--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "a2x": "workspace:*",
+    "@a2x/a2x": "workspace:*",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/samples/nextjs/src/app/api/a2a/route.ts
+++ b/samples/nextjs/src/app/api/a2a/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { handler } from "@/lib/a2x-setup";
-import { createSSEStream } from "a2x";
-import type { RequestContext } from "a2x";
+import { createSSEStream } from "@a2x/a2x";
+import type { RequestContext } from "@a2x/a2x";
 
 const SSE_HEADERS = {
   "Content-Type": "text/event-stream",

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -7,8 +7,8 @@ import {
   A2XAgent,
   DefaultRequestHandler,
   OAuth2DeviceCodeAuthorization,
-} from "a2x";
-import { AnthropicProvider } from "a2x/anthropic";
+} from "@a2x/a2x";
+import { AnthropicProvider } from "@a2x/a2x/anthropic";
 import { globalTokens } from "@/app/oauth/token/route";
 
 const agent = new LlmAgent({


### PR DESCRIPTION
## Summary
- Rename SDK package from `a2x` to `@a2x/a2x` to comply with npm naming policy
- npm rejects unscoped `a2x` as too similar to existing packages (ai, ava, ajv, etc.)
- Update all workspace dependencies and TypeScript imports across CLI and samples