### PR TITLE
Rename SDK to @a2x/sdk and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # a2x
 
+[![npm version](https://img.shields.io/npm/v/@a2x/sdk.svg)](https://www.npmjs.com/package/@a2x/sdk)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A self-contained TypeScript SDK for building [A2A (Agent-to-Agent)](https://google.github.io/A2A/) protocol agents with integrated OAuth 2.0 Device Flow authentication.
 
 ## Why a2x?
@@ -12,12 +15,23 @@ Existing A2A libraries like Google ADK (`@google/adk`) and `@a2a-js/sdk` have fu
 
 a2x solves all three. Define your agent once, and a2x generates spec-compliant AgentCards for any protocol version — automatically.
 
+## Installation
+
+```bash
+# SDK
+npm install @a2x/sdk
+
+# CLI (via GitHub Releases)
+# Download the latest tarball from https://github.com/planetarium/a2x/releases
+```
+
 ## Key Features
 
 - **Auto-extraction** — `A2XAgent` infers AgentCard fields (`name`, `description`, `capabilities.streaming`) from your runtime objects. No manual duplication.
 - **Multi-version AgentCard** — Generate v0.3 and v1.0 AgentCards from the same `A2XAgent` instance with `getAgentCard('0.3')` / `getAgentCard('1.0')`.
 - **Builder pattern** — Override any auto-extracted value with chainable methods (`setName()`, `addSkill()`, `addSecurityScheme()`, etc.).
 - **ADK-compatible patterns** — Familiar `LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, `FunctionTool`, `AgentTool`, `Runner`, and `Session` APIs.
+- **Client SDK** — `A2XClient` for interacting with any A2A-compliant agent, with built-in auth scheme support.
 - **Device Flow auth** — Built-in OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI and browserless environments.
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class support for `message/stream` via Server-Sent Events.
@@ -35,8 +49,8 @@ import {
   InMemoryTaskStore,
   DefaultRequestHandler,
   StreamingMode,
-} from 'a2x';
-import { GoogleProvider } from 'a2x/google';
+} from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
 
 // 1. Define your agent
 const agent = new LlmAgent({
@@ -111,13 +125,35 @@ getAgentCard(version?)
 | `FunctionTool` | Wrap any async function as an agent tool (with Zod schema) |
 | `AgentTool` | Use another agent as a callable tool |
 
+## Client SDK
+
+```typescript
+import { A2XClient, resolveAgentCard } from '@a2x/sdk/client';
+
+// Discover an agent
+const card = await resolveAgentCard('https://agent.example.com');
+
+// Create a client and send messages
+const client = new A2XClient(card);
+const task = await client.sendMessage({
+  message: { role: 'user', parts: [{ text: 'Hello!' }] },
+});
+
+// Or stream responses
+for await (const event of client.sendMessageStream({
+  message: { role: 'user', parts: [{ text: 'Tell me a story' }] },
+})) {
+  console.log(event);
+}
+```
+
 ## Server Integration
 
 **Quick prototype** with `toA2x()`:
 
 ```typescript
-import { LlmAgent, toA2x } from 'a2x';
-import { GoogleProvider } from 'a2x/google';
+import { LlmAgent, toA2x } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
 
 const agent = new LlmAgent({
   name: 'quick_agent',
@@ -148,7 +184,7 @@ export async function GET() {
 ## Device Flow Authentication
 
 ```typescript
-import { DeviceFlowClient } from 'a2x/auth';
+import { DeviceFlowClient } from '@a2x/sdk/auth';
 
 const authClient = new DeviceFlowClient({
   agentCardUrl: 'https://my-agent.example.com/.well-known/agent.json',
@@ -159,6 +195,33 @@ console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
 
 const token = await authClient.pollForToken(deviceCode);
 const a2aClient = authClient.createAuthenticatedClient(token);
+```
+
+## CLI
+
+The `@a2x/cli` provides command-line tools for interacting with A2A agents.
+
+```bash
+# Send a message to an agent
+a2x a2a send <agent-url> "Hello, agent!"
+
+# Stream a response
+a2x a2a stream <agent-url> "Tell me a story"
+
+# Fetch an agent card
+a2x a2a agent-card <agent-url>
+
+# Check task status
+a2x a2a task <agent-url> <task-id>
+```
+
+Install from [GitHub Releases](https://github.com/planetarium/a2x/releases) or build from source:
+
+```bash
+git clone https://github.com/planetarium/a2x.git
+cd a2x
+pnpm install && pnpm build
+pnpm cli:install
 ```
 
 ## A2A Protocol Versions
@@ -182,7 +245,9 @@ a2x handles the structural differences between A2A v0.3 and v1.0 transparently:
 - **Build**: tsup (ESM + CJS dual emit)
 - **Package manager**: pnpm (workspace)
 - **Test**: vitest
+- **Versioning**: changesets (independent per package)
+- **CI/CD**: GitHub Actions
 
 ## License
 
-TBD
+MIT

--- a/packages/a2x/package.json
+++ b/packages/a2x/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@a2x/a2x",
+  "name": "@a2x/sdk",
   "version": "0.1.0",
   "type": "module",
   "description": "A2A (Agent-to-Agent) protocol SDK for TypeScript",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@a2x/a2x": "workspace:*",
+    "@a2x/sdk": "workspace:*",
     "commander": "^13.0.0",
     "chalk": "^5.4.0"
   },

--- a/packages/cli/src/cli-auth-provider.ts
+++ b/packages/cli/src/cli-auth-provider.ts
@@ -9,7 +9,7 @@
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import chalk from 'chalk';
-import type { AuthProvider } from '@a2x/a2x/client';
+import type { AuthProvider } from '@a2x/sdk/client';
 import {
   AuthScheme,
   ApiKeyAuthScheme,
@@ -21,7 +21,7 @@ import {
   OAuth2ImplicitAuthScheme,
   OAuth2PasswordAuthScheme,
   OpenIdConnectAuthScheme,
-} from '@a2x/a2x/client';
+} from '@a2x/sdk/client';
 import { loadCredentials, saveCredentials, clearCredentials } from './token-store.js';
 
 async function prompt(question: string): Promise<string> {

--- a/packages/cli/src/commands/a2a/agent-card.ts
+++ b/packages/cli/src/commands/a2a/agent-card.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { resolveAgentCard } from '@a2x/a2x/client';
+import { resolveAgentCard } from '@a2x/sdk/client';
 import { printAgentCard, printConnectionError, parseHeaders } from '../../format.js';
 
 export const agentCardCommand = new Command('agent-card')

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import crypto from 'node:crypto';
-import type { SendMessageParams } from '@a2x/a2x';
+import type { SendMessageParams } from '@a2x/sdk';
 import { printTask, printConnectionError, createClient } from '../../format.js';
 
 export const sendCommand = new Command('send')

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import crypto from 'node:crypto';
-import type { SendMessageParams } from '@a2x/a2x';
+import type { SendMessageParams } from '@a2x/sdk';
 import { printStatusUpdate, printArtifactChunk, printConnectionError, createClient } from '../../format.js';
 
 export const streamCommand = new Command('stream')

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -3,8 +3,8 @@
  */
 
 import chalk from 'chalk';
-import { A2XClient } from '@a2x/a2x/client';
-import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from '@a2x/a2x';
+import { A2XClient } from '@a2x/sdk/client';
+import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from '@a2x/sdk';
 import { CliAuthProvider } from './cli-auth-provider.js';
 
 // ─── Error Formatting ───

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
 
   packages/cli:
     dependencies:
-      '@a2x/a2x':
+      '@a2x/sdk':
         specifier: workspace:*
         version: link:../a2x
       chalk:
@@ -79,7 +79,7 @@ importers:
 
   samples/express:
     dependencies:
-      '@a2x/a2x':
+      '@a2x/sdk':
         specifier: workspace:*
         version: link:../../packages/a2x
       dotenv:
@@ -104,7 +104,7 @@ importers:
 
   samples/nextjs:
     dependencies:
-      '@a2x/a2x':
+      '@a2x/sdk':
         specifier: workspace:*
         version: link:../../packages/a2x
       next:
@@ -4900,7 +4900,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -4933,7 +4933,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4948,7 +4948,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/samples/express/package.json
+++ b/samples/express/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@a2x/a2x": "workspace:*",
+    "@a2x/sdk": "workspace:*",
     "dotenv": "^16",
     "express": "^5.1.0"
   },

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -11,13 +11,13 @@ import {
   createSSEStream,
   ApiKeyAuthorization,
   OAuth2DeviceCodeAuthorization,
-} from '@a2x/a2x';
+} from '@a2x/sdk';
 import type {
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
   RequestContext,
-} from '@a2x/a2x';
-import { GoogleProvider } from '@a2x/a2x/google';
+} from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
 
 // ─── 1. Define your agent ───
 

--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@a2x/a2x": "workspace:*",
+    "@a2x/sdk": "workspace:*",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/samples/nextjs/src/app/api/a2a/route.ts
+++ b/samples/nextjs/src/app/api/a2a/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { handler } from "@/lib/a2x-setup";
-import { createSSEStream } from "@a2x/a2x";
-import type { RequestContext } from "@a2x/a2x";
+import { createSSEStream } from "@a2x/sdk";
+import type { RequestContext } from "@a2x/sdk";
 
 const SSE_HEADERS = {
   "Content-Type": "text/event-stream",

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -7,8 +7,8 @@ import {
   A2XAgent,
   DefaultRequestHandler,
   OAuth2DeviceCodeAuthorization,
-} from "@a2x/a2x";
-import { AnthropicProvider } from "@a2x/a2x/anthropic";
+} from "@a2x/sdk";
+import { AnthropicProvider } from "@a2x/sdk/anthropic";
 import { globalTokens } from "@/app/oauth/token/route";
 
 const agent = new LlmAgent({


### PR DESCRIPTION
## Summary
- Rename SDK package from `@a2x/a2x` to `@a2x/sdk`
- Update all workspace dependencies and TypeScript imports
- Update README: add installation, Client SDK, CLI sections, fix license to MIT

## After merge
- `@a2x/sdk@0.1.0` will be auto-published to npm
- Run `npm unpublish @a2x/a2x@0.1.0` to remove the old package