### PR TITLE
feat(skills): add a2x-integration skill

### DIFF
--- a/skills/a2x-integration/SKILL.md
+++ b/skills/a2x-integration/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: a2x-integration
+description: Integrates the @a2x/sdk (A2A Agent-to-Agent protocol) into any TypeScript project. Supports Next.js App Router, Next.js Pages Router, Express, NestJS, and zero-framework quick start. Use when the user wants to add A2A agent capabilities using @a2x/sdk, or says things like "add a2x", "integrate a2x", "a2x agent", "a2x endpoint", "add a2a with a2x", "create an a2x agent".
+---
+
+# a2x-integration
+
+Add A2A (Agent-to-Agent) protocol support to any TypeScript project using `@a2x/sdk`.
+
+**`@a2x/sdk`** is a self-contained A2A SDK with zero runtime dependencies (only Node.js built-ins). It includes an agent runtime, LLM providers, authentication, task management, and HTTP transport — all in one package.
+
+---
+
+## Before You Start
+
+**IMPORTANT**: The `@a2x/sdk` package evolves quickly. Before writing any code:
+
+1. Install the package first (see Step 1).
+2. Read actual type definitions from `node_modules/@a2x/sdk` to confirm current API signatures.
+3. If a class, function, or import path referenced in this skill does not exist in the installed version, search `node_modules/@a2x/sdk` for the closest equivalent.
+4. **Never hardcode package versions.** Always install the latest.
+
+---
+
+## Wiki Reference
+
+This skill uses a wiki-style structure. Detailed reference material is in the `wiki/` directory:
+
+| Topic | File | Description |
+|-------|------|-------------|
+| **Core Concepts** | [wiki/concepts.md](./wiki/concepts.md) | Architecture layers, key classes, protocol versions |
+| **LLM Providers** | [wiki/providers.md](./wiki/providers.md) | Google, Anthropic, OpenAI provider setup |
+| **Tools & Agents** | [wiki/tools-and-agents.md](./wiki/tools-and-agents.md) | FunctionTool, AgentTool, multi-agent patterns |
+| **Security** | [wiki/security.md](./wiki/security.md) | API Key, Bearer, OAuth2, security requirements |
+| **SSE Streaming** | [wiki/streaming.md](./wiki/streaming.md) | createSSEStream, AsyncGenerator, SSE headers |
+| **Quick Start** | [wiki/quick-start.md](./wiki/quick-start.md) | `toA2x()` helper for zero-framework prototyping |
+
+### Framework Guides
+
+| Framework | File |
+|-----------|------|
+| **Next.js App Router** | [wiki/nextjs-app-router.md](./wiki/nextjs-app-router.md) |
+| **Next.js Pages Router** | [wiki/nextjs-pages-router.md](./wiki/nextjs-pages-router.md) |
+| **Express** | [wiki/express.md](./wiki/express.md) |
+| **NestJS** | [wiki/nestjs.md](./wiki/nestjs.md) |
+
+---
+
+## Workflow
+
+### Step 0 — Analyze the Existing Project
+
+Before any implementation:
+
+1. Read `package.json` to identify the HTTP framework, package manager, and existing dependencies.
+2. Inspect `src/` (or project root) to understand the directory layout and conventions.
+3. Determine the framework type:
+   - **Next.js App Router** — `src/app/` or `app/` directory with `route.ts` files
+   - **Next.js Pages Router** — `src/pages/` or `pages/` directory with `api/` folder
+   - **Express** — `express` in dependencies, typically `app.ts` or `server.ts`
+   - **NestJS** — `@nestjs/core` in dependencies, module/controller/service pattern
+   - **None / Quick prototype** — No HTTP framework, or user wants minimal setup
+4. Check for an existing `.env.example` or `.env` file to understand environment variable conventions.
+5. Identify which LLM provider the user wants (Google Gemini, Anthropic Claude, OpenAI GPT). If unclear, ask the user.
+
+---
+
+### Step 1 — Install Packages
+
+```bash
+# Use the project's package manager (npm, pnpm, yarn, bun)
+npm install @a2x/sdk
+```
+
+Install the LLM provider SDK as a peer dependency based on user choice:
+
+```bash
+# For Google Gemini
+npm install @google/genai
+
+# For Anthropic Claude
+npm install @anthropic-ai/sdk
+
+# For OpenAI GPT
+npm install openai
+```
+
+After installation, verify key exports exist:
+
+```bash
+grep -r "export" node_modules/@a2x/sdk/dist/index.d.ts 2>/dev/null | head -30
+```
+
+Look for these key exports:
+
+| Export | Purpose |
+|--------|---------|
+| `LlmAgent` | Agent with LLM provider and tools |
+| `InMemoryRunner` | Agent execution runtime |
+| `AgentExecutor` | Bridges runner with A2A task lifecycle |
+| `InMemoryTaskStore` | In-memory task storage |
+| `A2XAgent` | A2A protocol integration (AgentCard, skills, security) |
+| `DefaultRequestHandler` | Framework-agnostic JSON-RPC handler |
+| `createSSEStream` | SSE streaming helper |
+| `FunctionTool` | Wrap async functions as tools |
+
+---
+
+### Step 2 — Set Up Environment Variables
+
+Create or update `.env.example`:
+
+```env
+# LLM Provider API Key (choose one based on your provider)
+GOOGLE_API_KEY=
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+
+# Public base URL of this server (used in AgentCard)
+BASE_URL=http://localhost:3000
+
+# Optional: Security
+# API_KEYS=key1,key2,key3
+```
+
+Ensure `.env.local` (or `.env`) is in `.gitignore`.
+
+---
+
+### Step 3 — Create the A2X Setup Module
+
+This is the core integration. Create an a2x setup file (e.g., `lib/a2x-setup.ts`, `src/lib/a2x-setup.ts`, or wherever the project keeps shared modules).
+
+Read [wiki/concepts.md](./wiki/concepts.md) for the full architecture, then create the setup:
+
+```typescript
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+} from '@a2x/sdk';
+// Choose your provider — see wiki/providers.md
+import { GoogleProvider } from '@a2x/sdk/google';
+// import { AnthropicProvider } from '@a2x/sdk/anthropic';
+// import { OpenAIProvider } from '@a2x/sdk/openai';
+
+// 1. Define the LLM agent
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful AI agent.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+  instruction: 'You are a helpful assistant. Answer clearly and concisely.',
+  // tools: [],  // Add FunctionTools here — see wiki/tools-and-agents.md
+});
+
+// 2. Create the runtime
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+const taskStore = new InMemoryTaskStore();
+
+// 3. Create the A2XAgent (A2A protocol bridge)
+export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+  .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/a2a`)
+  .addSkill({
+    id: 'chat',
+    name: 'General Chat',
+    description: 'General-purpose conversation and Q&A',
+    tags: ['chat', 'general'],
+  });
+// Add security — see wiki/security.md
+// .addSecurityScheme('apiKey', new ApiKeyAuthorization({ ... }))
+// .addSecurityRequirement({ apiKey: [] })
+
+// 4. Create the request handler
+export const handler = new DefaultRequestHandler(a2xAgent);
+```
+
+**Customization points for the user:**
+- `name` / `description` — agent identity
+- `provider` — which LLM to use (see [wiki/providers.md](./wiki/providers.md))
+- `instruction` — system prompt that defines agent behavior
+- `tools` — array of tools (see [wiki/tools-and-agents.md](./wiki/tools-and-agents.md))
+- `skills` — A2A skills advertised in the AgentCard
+- Security — authentication schemes (see [wiki/security.md](./wiki/security.md))
+
+---
+
+### Step 4 — Implement Route Handlers
+
+Choose the framework guide matching the project:
+
+- **Next.js App Router** → [wiki/nextjs-app-router.md](./wiki/nextjs-app-router.md)
+- **Next.js Pages Router** → [wiki/nextjs-pages-router.md](./wiki/nextjs-pages-router.md)
+- **Express** → [wiki/express.md](./wiki/express.md)
+- **NestJS** → [wiki/nestjs.md](./wiki/nestjs.md)
+- **Quick prototype (no framework)** → [wiki/quick-start.md](./wiki/quick-start.md)
+
+Each guide provides:
+1. Agent Card endpoint (`GET /.well-known/agent.json`)
+2. JSON-RPC endpoint (`POST /a2a`)
+3. SSE streaming setup
+4. Framework-specific notes
+
+The core logic is framework-agnostic (see [wiki/streaming.md](./wiki/streaming.md)):
+
+```typescript
+const result = await handler.handle(body, context);
+
+if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+  // Streaming: AsyncGenerator → convert to SSE response
+} else {
+  // Synchronous: plain object → return as JSON
+}
+```
+
+---
+
+### Step 5 — Verify
+
+1. **Build check**: Run the project's build command to ensure no type errors.
+2. **Agent Card**: `curl http://localhost:<port>/.well-known/agent.json` — should return valid JSON with `name`, `url`, `skills`, `capabilities`.
+3. **Send message**:
+   ```bash
+   curl -X POST http://localhost:<port>/a2a \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Hello"}]}}}'
+   ```
+4. Remind the user to set their LLM provider API key if not already done.
+5. Optionally test with `a2x` CLI:
+   ```bash
+   a2x a2a agent-card http://localhost:<port>
+   a2x a2a send http://localhost:<port> "Hello, agent!"
+   ```
+
+---
+
+## Exposed Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/.well-known/agent.json` | GET | AgentCard discovery (A2A standard) |
+| `/a2a` | POST | JSON-RPC 2.0 endpoint for A2A messages |
+
+The paths can be customized — update `setDefaultUrl()` on the A2XAgent to match.
+
+---
+
+## Key Differences from `ts-a2a-integration` Skill
+
+This skill uses `@a2x/sdk` instead of `@a2a-js/sdk` + `@google/adk`. Key differences:
+
+| Feature | `@a2x/sdk` | `@a2a-js/sdk` + `@google/adk` |
+|---------|-----------|-------------------------------|
+| Dependencies | Single package | Two packages |
+| LLM Providers | Google, Anthropic, OpenAI built-in | Google only (via ADK) |
+| Protocol Versions | v0.3 + v1.0 from single definition | v1.0 only |
+| AgentCard | Auto-generated via `A2XAgent` builder | Manual JSON object |
+| Authentication | Built-in security scheme classes | Manual implementation |
+| Handler | `DefaultRequestHandler` (framework-agnostic) | `JsonRpcTransportHandler` |
+| Quick Start | `toA2x()` helper with built-in HTTP server | Not available |
+
+---
+
+## After Applying
+
+Remind the user to:
+1. Set their LLM provider API key in the environment
+2. Customize the agent: name, description, instruction (system prompt), and skills
+3. Add tools if needed (see [wiki/tools-and-agents.md](./wiki/tools-and-agents.md))
+4. Configure security if needed (see [wiki/security.md](./wiki/security.md))
+5. Test with `curl` or the `a2x` CLI

--- a/skills/a2x-integration/wiki/concepts.md
+++ b/skills/a2x-integration/wiki/concepts.md
@@ -1,0 +1,213 @@
+# Core Concepts
+
+`@a2x/sdk` is a layered architecture with four main layers.
+
+---
+
+## Architecture Layers
+
+```
+Layer 4: Transport        — DefaultRequestHandler, createSSEStream, toA2x
+Layer 3: A2X Integration  — A2XAgent, AgentExecutor, TaskStore, AgentCard mappers
+Layer 2: Agent Runtime    — LlmAgent, Tools, Runner, Session, Providers
+Layer 1: Types & Security — A2A protocol types, SecurityScheme classes
+```
+
+---
+
+## Key Classes
+
+### LlmAgent
+
+The core agent that uses an LLM provider to process messages. Supports tools, callbacks, and output schemas.
+
+```typescript
+import { LlmAgent } from '@a2x/sdk';
+
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful agent.',
+  provider: provider,      // GoogleProvider, AnthropicProvider, or OpenAIProvider
+  instruction: 'You are a helpful assistant.',
+  tools: [],               // FunctionTool instances
+  maxLlmCalls: 25,         // Max LLM roundtrips per run (default: 25)
+  outputSchema: undefined,  // JSON Schema for structured output
+  // Callbacks:
+  // beforeModelCallback, afterModelCallback, beforeToolCallback
+});
+```
+
+The `instruction` field can also be a function for dynamic system prompts:
+
+```typescript
+instruction: (context) => `You are helping user ${context.session.userId}.`,
+```
+
+### InMemoryRunner
+
+Executes agents within a session context. Manages message history and tool call loops.
+
+```typescript
+import { InMemoryRunner } from '@a2x/sdk';
+
+const runner = new InMemoryRunner({
+  agent,
+  appName: 'my-app',   // Used as namespace for session storage
+});
+```
+
+### AgentExecutor
+
+Bridges the Runner with the A2A Task lifecycle. Converts agent events to A2A protocol events (status updates, artifacts).
+
+```typescript
+import { AgentExecutor, StreamingMode } from '@a2x/sdk';
+
+const executor = new AgentExecutor({
+  runner,
+  runConfig: {
+    streamingMode: StreamingMode.SSE,  // or StreamingMode.NONE
+    maxLlmCalls: 25,
+  },
+});
+```
+
+**StreamingMode options:**
+- `StreamingMode.SSE` — Returns an AsyncGenerator for `message/stream` requests
+- `StreamingMode.NONE` — Always returns completed Task synchronously
+
+### InMemoryTaskStore
+
+Manages A2A Task state (create, get, update, cancel). In-memory by default.
+
+```typescript
+import { InMemoryTaskStore } from '@a2x/sdk';
+
+const taskStore = new InMemoryTaskStore();
+```
+
+For production, implement the `TaskStore` interface with database backing:
+
+```typescript
+interface TaskStore {
+  createTask(params: CreateTaskParams): Promise<Task>;
+  getTask(id: string): Promise<Task | null>;
+  updateTask(id: string, update: TaskUpdate): Promise<void>;
+  cancelTask(id: string): Promise<void>;
+}
+```
+
+### A2XAgent
+
+The central integration class. Bridges agent runtime with A2A protocol. Auto-generates AgentCards for both v0.3 and v1.0 from a single definition.
+
+```typescript
+import { A2XAgent } from '@a2x/sdk';
+
+const a2xAgent = new A2XAgent({
+  taskStore,
+  executor,
+  protocolVersion: '1.0',  // Default protocol version: '0.3' | '1.0'
+});
+```
+
+**Builder methods** (all chainable):
+
+```typescript
+a2xAgent
+  .setName('My Agent')              // Override auto-extracted name
+  .setDescription('Agent desc')     // Override auto-extracted description
+  .setVersion('1.0.0')              // Agent version
+  .setDefaultUrl('http://localhost:3000/a2a')  // Required: endpoint URL
+  .setCapabilities({ streaming: true, pushNotifications: false })
+  .addSkill({
+    id: 'skill-id',
+    name: 'Skill Name',
+    description: 'What this skill does',
+    tags: ['tag1', 'tag2'],
+    examples: ['Example input'],
+  })
+  .addSecurityScheme('schemeName', securitySchemeInstance)
+  .addSecurityRequirement({ schemeName: [] });
+```
+
+**Getting AgentCards:**
+
+```typescript
+const cardV10 = a2xAgent.getAgentCard();       // Default version
+const cardV03 = a2xAgent.getAgentCard('0.3');   // Explicit v0.3
+const cardV10 = a2xAgent.getAgentCard('1.0');   // Explicit v1.0
+```
+
+### DefaultRequestHandler
+
+Framework-agnostic JSON-RPC handler. Routes A2A methods to the appropriate logic.
+
+```typescript
+import { DefaultRequestHandler } from '@a2x/sdk';
+
+const handler = new DefaultRequestHandler(a2xAgent);
+
+// Handle a JSON-RPC request
+const result = await handler.handle(body, context);
+// result: JSONRPCResponse | AsyncGenerator (for streaming)
+
+// Get AgentCard
+const card = handler.getAgentCard();          // Default version
+const card = handler.getAgentCard('0.3');     // Specific version
+```
+
+**Supported A2A methods:**
+- `message/send` — Send a message, get completed Task
+- `message/stream` — Send a message, get streaming events (AsyncGenerator)
+- `tasks/get` — Get a task by ID
+- `tasks/cancel` — Cancel a running task
+
+---
+
+## Protocol Versions (v0.3 vs v1.0)
+
+`@a2x/sdk` supports both A2A protocol versions from a single definition. The key differences are handled automatically by mappers:
+
+| Aspect | v0.3 | v1.0 |
+|--------|------|------|
+| URL | `AgentCard.url` (top-level) | `supportedInterfaces[].url` |
+| Transport | `preferredTransport` | `supportedInterfaces[].protocolBinding` |
+| Security | `security[]` + `securitySchemes{}` | `securityRequirements[]` (OpenAPI 3.2) |
+| Device Code OAuth | Not supported | Supported |
+
+You define your agent once, and `A2XAgent.getAgentCard(version)` outputs the correct format.
+
+---
+
+## RequestContext
+
+Framework-agnostic auth context passed to `handler.handle()`:
+
+```typescript
+import type { RequestContext } from '@a2x/sdk';
+
+const context: RequestContext = {
+  headers: { 'x-api-key': 'my-key', authorization: 'Bearer token' },
+  query: { version: '1.0' },
+  cookies: { session: 'abc' },
+};
+
+const result = await handler.handle(body, context);
+```
+
+Each framework extracts this differently — see the framework-specific guides.
+
+---
+
+## Task Lifecycle
+
+```
+SUBMITTED → WORKING → COMPLETED
+                    → FAILED
+                    → CANCELED
+                    → INPUT_REQUIRED
+                    → AUTH_REQUIRED
+```
+
+Tasks are created automatically when `message/send` or `message/stream` is called. The `AgentExecutor` manages state transitions.

--- a/skills/a2x-integration/wiki/express.md
+++ b/skills/a2x-integration/wiki/express.md
@@ -1,0 +1,207 @@
+# Express
+
+Route setup for A2A protocol integration using `@a2x/sdk` in Express projects.
+
+---
+
+## Directory Structure
+
+```
+src/
+├── lib/
+│   └── a2x-setup.ts       # A2X setup module
+└── index.ts                # Express app entry point
+```
+
+Or for larger projects:
+
+```
+src/
+├── lib/
+│   └── a2x-setup.ts       # A2X setup module
+├── routes/
+│   └── a2a.ts              # A2A route handlers
+└── index.ts                # Express app entry point
+```
+
+---
+
+## Setup Module
+
+`src/lib/a2x-setup.ts`:
+
+```typescript
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+  ApiKeyAuthorization,
+} from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful AI agent.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+  instruction: 'You are a helpful assistant.',
+});
+
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+const taskStore = new InMemoryTaskStore();
+
+export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+  .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:4000'}/a2a`)
+  .addSkill({
+    id: 'chat',
+    name: 'General Chat',
+    description: 'General conversation and Q&A',
+    tags: ['chat', 'general'],
+  })
+  // Optional: add authentication
+  .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+    in: 'header',
+    name: 'x-api-key',
+    keys: process.env.API_KEYS?.split(','),
+  }))
+  .addSecurityRequirement({ apiKey: [] });
+
+export const handler = new DefaultRequestHandler(a2xAgent);
+```
+
+---
+
+## Complete Express App
+
+```typescript
+import 'dotenv/config';
+import express from 'express';
+import { handler, a2xAgent } from './lib/a2x-setup';
+import { createSSEStream } from '@a2x/sdk';
+import type { RequestContext } from '@a2x/sdk';
+
+const app = express();
+app.use(express.json());
+
+// AgentCard discovery
+app.get('/.well-known/agent.json', (_req, res) => {
+  try {
+    const card = handler.getAgentCard();
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.json(card);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Internal error',
+    });
+  }
+});
+
+// JSON-RPC endpoint
+app.post('/a2a', async (req, res) => {
+  // Build RequestContext for authentication
+  const context: RequestContext = {
+    headers: req.headers as Record<string, string | string[] | undefined>,
+    query: req.query as Record<string, string | string[] | undefined>,
+  };
+
+  try {
+    const result = await handler.handle(req.body, context);
+
+    // Streaming → SSE
+    if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+
+      const stream = createSSEStream(result as AsyncGenerator);
+      const reader = stream.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+        }
+      } catch (error) {
+        const errorData = JSON.stringify({
+          error: error instanceof Error ? error.message : 'Internal error',
+        });
+        res.write(`event: error\ndata: ${errorData}\n\n`);
+      }
+      res.end();
+      return;
+    }
+
+    // Synchronous → JSON
+    res.json(result);
+  } catch {
+    res.status(400).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32700, message: 'Parse error' },
+    });
+  }
+});
+
+// Start server
+const PORT = Number(process.env.PORT) || 4000;
+app.listen(PORT, () => {
+  console.log(`Agent running on http://localhost:${PORT}`);
+  console.log(`Agent Card: http://localhost:${PORT}/.well-known/agent.json`);
+  console.log(`JSON-RPC:   POST http://localhost:${PORT}/a2a`);
+});
+```
+
+---
+
+## Express-Specific Notes
+
+### Singleton Lifecycle
+
+Express runs as a long-lived process, so module-level singletons are naturally stable. No `globalThis` caching needed.
+
+### Body Parsing
+
+`express.json()` middleware parses the JSON body — `req.body` is already an object.
+
+### Client Disconnect Handling
+
+For cleaner streaming cleanup, listen for client disconnect:
+
+```typescript
+const generator = result as AsyncGenerator;
+req.on('close', () => {
+  generator.return(undefined);
+});
+```
+
+### CORS
+
+If your agent needs to accept requests from browsers:
+
+```typescript
+import cors from 'cors';
+app.use(cors());
+```
+
+### Environment Variables
+
+Use `dotenv` for `.env` file loading:
+
+```bash
+npm install dotenv
+```
+
+```typescript
+import 'dotenv/config';  // At the top of your entry file
+```

--- a/skills/a2x-integration/wiki/nestjs.md
+++ b/skills/a2x-integration/wiki/nestjs.md
@@ -1,0 +1,264 @@
+# NestJS
+
+Module, Controller, and Service setup for A2A protocol integration using `@a2x/sdk` in NestJS projects.
+
+---
+
+## Directory Structure
+
+```
+src/
+├── a2a/
+│   ├── a2a.module.ts         # A2A feature module
+│   ├── a2a.controller.ts     # Route handlers
+│   └── a2a.service.ts        # A2X setup and business logic
+├── app.module.ts             # Root module (imports A2aModule)
+└── main.ts                   # Bootstrap
+```
+
+---
+
+## A2A Service
+
+`src/a2a/a2a.service.ts`:
+
+```typescript
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+  createSSEStream,
+} from '@a2x/sdk';
+import type { RequestContext } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+// Or: import { AnthropicProvider } from '@a2x/sdk/anthropic';
+// Or: import { OpenAIProvider } from '@a2x/sdk/openai';
+
+@Injectable()
+export class A2aService implements OnModuleInit {
+  private handler!: DefaultRequestHandler;
+  private a2xAgent!: A2XAgent;
+
+  onModuleInit() {
+    const agent = new LlmAgent({
+      name: 'my-agent',
+      description: 'A helpful AI agent.',
+      provider: new GoogleProvider({
+        model: 'gemini-2.5-flash',
+        apiKey: process.env.GOOGLE_API_KEY!,
+      }),
+      instruction: 'You are a helpful assistant.',
+    });
+
+    const runner = new InMemoryRunner({ agent, appName: agent.name });
+    const executor = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const taskStore = new InMemoryTaskStore();
+
+    this.a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+      .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/a2a`)
+      .addSkill({
+        id: 'chat',
+        name: 'General Chat',
+        description: 'General conversation and Q&A',
+        tags: ['chat', 'general'],
+      });
+
+    this.handler = new DefaultRequestHandler(this.a2xAgent);
+  }
+
+  getAgentCard() {
+    return this.handler.getAgentCard();
+  }
+
+  async handleRequest(body: unknown, context: RequestContext) {
+    return this.handler.handle(body, context);
+  }
+
+  createSSEStream(generator: AsyncGenerator) {
+    return createSSEStream(generator);
+  }
+}
+```
+
+---
+
+## A2A Controller
+
+`src/a2a/a2a.controller.ts`:
+
+```typescript
+import { Controller, Get, Post, Req, Res } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import type { RequestContext } from '@a2x/sdk';
+import { A2aService } from './a2a.service';
+
+@Controller()
+export class A2aController {
+  constructor(private readonly a2aService: A2aService) {}
+
+  @Get('.well-known/agent.json')
+  getAgentCard(@Res() res: Response) {
+    try {
+      const card = this.a2aService.getAgentCard();
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.json(card);
+    } catch (error) {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Internal error',
+      });
+    }
+  }
+
+  @Post('a2a')
+  async handleA2a(@Req() req: Request, @Res() res: Response) {
+    // Build RequestContext for authentication
+    const context: RequestContext = {
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      query: req.query as Record<string, string | string[] | undefined>,
+    };
+
+    try {
+      const result = await this.a2aService.handleRequest(req.body, context);
+
+      // Streaming → SSE
+      if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+
+        const stream = this.a2aService.createSSEStream(result as AsyncGenerator);
+        const reader = stream.getReader();
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+          }
+        } catch (error) {
+          const errorData = JSON.stringify({
+            error: error instanceof Error ? error.message : 'Internal error',
+          });
+          res.write(`event: error\ndata: ${errorData}\n\n`);
+        }
+        res.end();
+        return;
+      }
+
+      // Synchronous → JSON
+      res.json(result);
+    } catch {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      });
+    }
+  }
+}
+```
+
+---
+
+## A2A Module
+
+`src/a2a/a2a.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { A2aController } from './a2a.controller';
+import { A2aService } from './a2a.service';
+
+@Module({
+  controllers: [A2aController],
+  providers: [A2aService],
+  exports: [A2aService],
+})
+export class A2aModule {}
+```
+
+---
+
+## Register in App Module
+
+`src/app.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { A2aModule } from './a2a/a2a.module';
+
+@Module({
+  imports: [A2aModule],
+})
+export class AppModule {}
+```
+
+---
+
+## NestJS-Specific Notes
+
+### Using @Res() with Streaming
+
+When using `@Res()` decorator, NestJS delegates response handling to you. This is required for SSE streaming since NestJS doesn't natively support `AsyncGenerator` responses from controllers.
+
+### ConfigService for Environment Variables
+
+For a more NestJS-idiomatic approach, inject `ConfigService`:
+
+```typescript
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class A2aService {
+  constructor(private configService: ConfigService) {}
+
+  onModuleInit() {
+    const apiKey = this.configService.getOrThrow<string>('GOOGLE_API_KEY');
+    const baseUrl = this.configService.get<string>('BASE_URL', 'http://localhost:3000');
+    // ...
+  }
+}
+```
+
+Requires `@nestjs/config`:
+
+```bash
+npm install @nestjs/config
+```
+
+```typescript
+// app.module.ts
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    A2aModule,
+  ],
+})
+export class AppModule {}
+```
+
+### CORS
+
+Enable CORS in `main.ts`:
+
+```typescript
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  await app.listen(3000);
+}
+```
+
+### Raw Body Access
+
+NestJS parses JSON bodies by default via Express middleware, so `req.body` is already available as a parsed object.

--- a/skills/a2x-integration/wiki/nextjs-app-router.md
+++ b/skills/a2x-integration/wiki/nextjs-app-router.md
@@ -1,0 +1,200 @@
+# Next.js App Router
+
+Route Handlers for A2A protocol integration using `@a2x/sdk` in Next.js App Router projects.
+
+---
+
+## Directory Structure
+
+```
+src/
+├── lib/
+│   └── a2x-setup.ts                    # A2X setup module (shared singleton)
+└── app/
+    ├── .well-known/
+    │   └── agent.json/
+    │       └── route.ts                 # AgentCard GET endpoint
+    └── api/
+        └── a2a/
+            └── route.ts                 # JSON-RPC POST endpoint
+```
+
+Next.js App Router uses folder-based routing. The `.well-known/agent.json/` folder (with dots) is handled correctly.
+
+---
+
+## Setup Module
+
+`src/lib/a2x-setup.ts`:
+
+```typescript
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+} from '@a2x/sdk';
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+// Or: import { GoogleProvider } from '@a2x/sdk/google';
+// Or: import { OpenAIProvider } from '@a2x/sdk/openai';
+
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful AI agent.',
+  provider: new AnthropicProvider({
+    model: 'claude-sonnet-4-20250514',
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+  }),
+  instruction: 'You are a helpful assistant.',
+});
+
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+const taskStore = new InMemoryTaskStore();
+
+export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+  .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/api/a2a`)
+  .addSkill({
+    id: 'chat',
+    name: 'General Chat',
+    description: 'General conversation and Q&A',
+    tags: ['chat', 'general'],
+  });
+
+export const handler = new DefaultRequestHandler(a2xAgent);
+```
+
+### globalThis Singleton for HMR
+
+In dev mode, Next.js HMR re-evaluates server modules. If you need stable singletons (e.g., to preserve in-memory task state across hot reloads), use `globalThis` caching:
+
+```typescript
+const GLOBAL_KEY = Symbol.for('a2x-handler');
+
+function getOrCreate() {
+  const g = globalThis as Record<symbol, { handler: DefaultRequestHandler; a2xAgent: A2XAgent } | undefined>;
+  if (!g[GLOBAL_KEY]) {
+    // ... create agent, runner, executor, taskStore, a2xAgent, handler ...
+    g[GLOBAL_KEY] = { handler, a2xAgent };
+  }
+  return g[GLOBAL_KEY]!;
+}
+
+export const { handler, a2xAgent } = getOrCreate();
+```
+
+This is the same pattern Next.js recommends for Prisma and other singleton clients.
+
+---
+
+## AgentCard Endpoint
+
+`src/app/.well-known/agent.json/route.ts`:
+
+```typescript
+import { NextResponse } from 'next/server';
+import { a2xAgent } from '@/lib/a2x-setup';
+
+export async function GET(): Promise<Response> {
+  try {
+    const card = a2xAgent.getAgentCard();
+    return NextResponse.json(card, {
+      headers: { 'Cache-Control': 'public, max-age=3600' },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal error' },
+      { status: 500 },
+    );
+  }
+}
+```
+
+Only exporting `GET` means Next.js automatically returns 405 for other methods.
+
+---
+
+## JSON-RPC Endpoint
+
+`src/app/api/a2a/route.ts`:
+
+```typescript
+import { NextResponse } from 'next/server';
+import { handler } from '@/lib/a2x-setup';
+import { createSSEStream } from '@a2x/sdk';
+import type { RequestContext } from '@a2x/sdk';
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  'Connection': 'keep-alive',
+  'X-Accel-Buffering': 'no',
+} as const;
+
+export async function POST(request: Request): Promise<Response> {
+  // 1. Parse JSON body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null },
+      { status: 400 },
+    );
+  }
+
+  // 2. Build RequestContext for authentication
+  const context: RequestContext = {
+    headers: Object.fromEntries(request.headers.entries()),
+    query: Object.fromEntries(new URL(request.url).searchParams.entries()),
+  };
+
+  // 3. Handle the request
+  const result = await handler.handle(body, context);
+
+  // 4. Streaming → SSE response
+  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    const stream = createSSEStream(result as AsyncGenerator);
+    return new Response(stream, { headers: SSE_HEADERS });
+  }
+
+  // 5. Synchronous → JSON response
+  return NextResponse.json(result);
+}
+```
+
+---
+
+## Next.js-Specific Notes
+
+### Bundling Issues
+
+If the build fails with module resolution errors, add to `next.config.ts`:
+
+```typescript
+const nextConfig = {
+  serverExternalPackages: ['@a2x/sdk'],
+};
+export default nextConfig;
+```
+
+### Environment Variables
+
+- Use `.env.local` for secrets (auto-loaded by Next.js, already in `.gitignore`).
+- Do **not** prefix API keys with `NEXT_PUBLIC_` — they must remain server-side only.
+- `@/lib/a2x-setup` uses the `@/` path alias (configured in `tsconfig.json`).
+
+### Runtime
+
+If using edge runtime, note that `@a2x/sdk` uses Node.js built-in modules. Stick with the default Node.js runtime:
+
+```typescript
+// Do NOT set this for a2x routes:
+// export const runtime = 'edge';
+```

--- a/skills/a2x-integration/wiki/nextjs-pages-router.md
+++ b/skills/a2x-integration/wiki/nextjs-pages-router.md
@@ -1,0 +1,162 @@
+# Next.js Pages Router
+
+API Routes for A2A protocol integration using `@a2x/sdk` in Next.js Pages Router projects.
+
+---
+
+## Directory Structure
+
+```
+src/
+├── lib/
+│   └── a2x-setup.ts                  # A2X setup module (shared singleton)
+└── pages/
+    └── api/
+        ├── a2a.ts                     # JSON-RPC POST endpoint
+        └── well-known/
+            └── agent.json.ts          # AgentCard GET endpoint
+```
+
+> Note: Next.js Pages Router cannot serve `/.well-known/agent.json` directly due to the dot-prefixed path. Use `/api/well-known/agent.json` or configure a rewrite in `next.config.ts`.
+
+---
+
+## Setup Module
+
+`src/lib/a2x-setup.ts` — same as App Router (see [nextjs-app-router.md](./nextjs-app-router.md#setup-module)).
+
+---
+
+## AgentCard Endpoint
+
+`src/pages/api/well-known/agent.json.ts`:
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { a2xAgent } from '@/lib/a2x-setup';
+
+export default function agentCardHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const card = a2xAgent.getAgentCard();
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.json(card);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Internal error',
+    });
+  }
+}
+```
+
+### Rewrite for Standard Path
+
+To serve the AgentCard at the standard `/.well-known/agent.json` path, add a rewrite in `next.config.ts`:
+
+```typescript
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/agent.json',
+        destination: '/api/well-known/agent.json',
+      },
+    ];
+  },
+};
+export default nextConfig;
+```
+
+---
+
+## JSON-RPC Endpoint
+
+`src/pages/api/a2a.ts`:
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { handler } from '@/lib/a2x-setup';
+import { createSSEStream } from '@a2x/sdk';
+import type { RequestContext } from '@a2x/sdk';
+
+// Disable body parsing — we need the raw JSON object, but Next.js parses it by default
+// Actually, Next.js Pages API parses JSON by default, so req.body is already an object.
+
+export default async function a2aHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Build RequestContext for authentication
+  const context: RequestContext = {
+    headers: req.headers as Record<string, string | string[] | undefined>,
+    query: req.query as Record<string, string | string[] | undefined>,
+  };
+
+  try {
+    const result = await handler.handle(req.body, context);
+
+    // Streaming → SSE
+    if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+
+      const stream = createSSEStream(result as AsyncGenerator);
+      const reader = stream.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+        }
+      } catch (error) {
+        const errorData = JSON.stringify({
+          error: error instanceof Error ? error.message : 'Streaming error',
+        });
+        res.write(`event: error\ndata: ${errorData}\n\n`);
+      }
+      res.end();
+      return;
+    }
+
+    // Synchronous → JSON
+    res.json(result);
+  } catch {
+    res.status(400).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32700, message: 'Parse error' },
+    });
+  }
+}
+```
+
+---
+
+## Pages Router-Specific Notes
+
+### SSE Streaming
+
+Pages Router uses the Node.js `res.write()` / `res.end()` API (like Express), not the Web Streams API. Use `createSSEStream().getReader()` to read chunks and write them to the response.
+
+### Body Parsing
+
+Next.js Pages API Routes automatically parse JSON bodies. `req.body` is already an object — no need for `request.json()`.
+
+### Bundling Issues
+
+Same as App Router — add `@a2x/sdk` to `serverExternalPackages` if needed:
+
+```typescript
+const nextConfig = {
+  serverExternalPackages: ['@a2x/sdk'],
+};
+```

--- a/skills/a2x-integration/wiki/providers.md
+++ b/skills/a2x-integration/wiki/providers.md
@@ -1,0 +1,91 @@
+# LLM Providers
+
+`@a2x/sdk` includes built-in providers for three major LLM services. Each provider is in a separate entry point to keep the main bundle small (tree-shakeable).
+
+---
+
+## Google Gemini
+
+```bash
+npm install @google/genai
+```
+
+```typescript
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const provider = new GoogleProvider({
+  model: 'gemini-2.5-flash',          // or 'gemini-2.5-pro', etc.
+  apiKey: process.env.GOOGLE_API_KEY!,
+});
+```
+
+**Environment variable:** `GOOGLE_API_KEY`
+
+---
+
+## Anthropic Claude
+
+```bash
+npm install @anthropic-ai/sdk
+```
+
+```typescript
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+
+const provider = new AnthropicProvider({
+  model: 'claude-sonnet-4-20250514',   // or any Claude model
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+});
+```
+
+**Environment variable:** `ANTHROPIC_API_KEY`
+
+---
+
+## OpenAI GPT
+
+```bash
+npm install openai
+```
+
+```typescript
+import { OpenAIProvider } from '@a2x/sdk/openai';
+
+const provider = new OpenAIProvider({
+  model: 'gpt-4o',                     // or 'gpt-4o-mini', etc.
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+```
+
+**Environment variable:** `OPENAI_API_KEY`
+
+---
+
+## Using a Provider with LlmAgent
+
+```typescript
+import { LlmAgent } from '@a2x/sdk';
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful agent.',
+  provider: new AnthropicProvider({
+    model: 'claude-sonnet-4-20250514',
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+  }),
+  instruction: 'You are a helpful assistant.',
+});
+```
+
+---
+
+## Import Paths
+
+| Provider | Import Path | Peer Dependency |
+|----------|-------------|-----------------|
+| Google Gemini | `@a2x/sdk/google` | `@google/genai >= 1.0.0` |
+| Anthropic Claude | `@a2x/sdk/anthropic` | `@anthropic-ai/sdk >= 0.52.0` |
+| OpenAI GPT | `@a2x/sdk/openai` | `openai >= 4.0.0` |
+
+All peer dependencies are optional — only install the one you need.

--- a/skills/a2x-integration/wiki/quick-start.md
+++ b/skills/a2x-integration/wiki/quick-start.md
@@ -1,0 +1,129 @@
+# Quick Start with toA2x
+
+`toA2x()` is a zero-framework helper that converts an `LlmAgent` into a fully working A2A server with a single function call. It includes a built-in HTTP server using Node.js `http` module — no Express, Next.js, or any framework needed.
+
+---
+
+## Minimal Example
+
+```typescript
+import { LlmAgent, toA2x } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const agent = new LlmAgent({
+  name: 'my-agent',
+  description: 'A helpful assistant.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+  instruction: 'You are a helpful assistant.',
+});
+
+const { handler, a2xAgent, listen } = toA2x(agent, {
+  defaultUrl: 'http://localhost:3000/a2a',
+});
+
+await listen(3000);
+// Server running on http://localhost:3000
+// Agent Card: GET http://localhost:3000/.well-known/agent.json
+// JSON-RPC:   POST http://localhost:3000/a2a
+```
+
+---
+
+## With Options
+
+```typescript
+import {
+  LlmAgent,
+  toA2x,
+  StreamingMode,
+  ApiKeyAuthorization,
+} from '@a2x/sdk';
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+
+const agent = new LlmAgent({
+  name: 'secure-agent',
+  description: 'A secured assistant.',
+  provider: new AnthropicProvider({
+    model: 'claude-sonnet-4-20250514',
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+  }),
+  instruction: 'You are a helpful, secure assistant.',
+});
+
+const { handler, a2xAgent, listen } = toA2x(agent, {
+  defaultUrl: 'http://localhost:4000/a2a',
+  port: 4000,
+  streamingMode: StreamingMode.SSE,
+  protocolVersion: '1.0',
+  skills: [
+    {
+      id: 'chat',
+      name: 'General Chat',
+      description: 'General conversation',
+      tags: ['chat'],
+    },
+  ],
+  securitySchemes: {
+    apiKey: new ApiKeyAuthorization({
+      in: 'header',
+      name: 'x-api-key',
+      keys: ['my-secret-key'],
+    }),
+  },
+  securityRequirements: [{ apiKey: [] }],
+});
+
+await listen();  // Uses port from options (4000)
+```
+
+---
+
+## ToA2xOptions
+
+```typescript
+interface ToA2xOptions {
+  defaultUrl: string;                              // Required: base URL for AgentCard
+  port?: number;                                    // Port for listen() (default: 3000)
+  skills?: A2XAgentSkill[];                         // Skills to advertise
+  streamingMode?: StreamingMode;                    // SSE or NONE (default: SSE)
+  securitySchemes?: Record<string, BaseSecurityScheme>;
+  securityRequirements?: SecurityRequirement[];
+  protocolVersion?: '0.3' | '1.0';                 // Default protocol version
+}
+```
+
+---
+
+## ToA2xResult
+
+```typescript
+interface ToA2xResult {
+  handler: DefaultRequestHandler;   // For custom HTTP integration
+  a2xAgent: A2XAgent;              // For further configuration
+  listen(port?: number): Promise<void>;  // Start the built-in HTTP server
+}
+```
+
+You can use `handler` and `a2xAgent` directly if you want to integrate into an existing server, or call `listen()` for the built-in server.
+
+---
+
+## Built-in Server Features
+
+The `listen()` method creates a Node.js HTTP server that handles:
+- `GET /.well-known/agent.json` — AgentCard discovery (supports `?version=0.3` or `?version=1.0`)
+- `POST /a2a` (or any POST) — JSON-RPC endpoint with SSE streaming
+- `OPTIONS` — CORS preflight with `Access-Control-Allow-Origin: *`
+
+---
+
+## When to Use toA2x
+
+- **Prototyping** — Quickest way to get an A2A agent running
+- **Scripts / standalone agents** — Single-file A2A agents
+- **Testing** — Spin up a test agent in CI
+
+For production, use a proper framework (Express, Next.js, NestJS) with the full setup pattern.

--- a/skills/a2x-integration/wiki/security.md
+++ b/skills/a2x-integration/wiki/security.md
@@ -1,0 +1,180 @@
+# Security & Authentication
+
+`@a2x/sdk` includes built-in security scheme classes that map to OpenAPI 3.x security. Authentication is evaluated automatically by `DefaultRequestHandler` when a `RequestContext` is provided.
+
+---
+
+## API Key Authentication
+
+```typescript
+import { ApiKeyAuthorization } from '@a2x/sdk';
+
+const apiKeyScheme = new ApiKeyAuthorization({
+  in: 'header',           // 'header' | 'query' | 'cookie'
+  name: 'x-api-key',     // Header/query/cookie name
+  description: 'API key for agent access',
+  // Option 1: Static key list
+  keys: ['key1', 'key2', 'key3'],
+  // Option 2: Custom validator (overrides keys)
+  // validator: async (key) => {
+  //   const valid = await db.checkApiKey(key);
+  //   return { authenticated: valid, principal: { sub: 'user-id' } };
+  // },
+});
+```
+
+---
+
+## HTTP Bearer Token
+
+```typescript
+import { HttpBearerAuthorization } from '@a2x/sdk';
+
+const bearerScheme = new HttpBearerAuthorization({
+  description: 'Bearer token authentication',
+  tokenValidator: async (token) => {
+    // Validate JWT or opaque token
+    const decoded = await verifyJwt(token);
+    if (!decoded) return { authenticated: false, error: 'Invalid token' };
+    return {
+      authenticated: true,
+      principal: { sub: decoded.sub },
+      scopes: decoded.scopes,
+    };
+  },
+});
+```
+
+---
+
+## OAuth2 Device Code Flow
+
+For CLI / headless clients (v1.0 protocol only; v0.3 will log a warning):
+
+```typescript
+import { OAuth2DeviceCodeAuthorization } from '@a2x/sdk';
+
+const deviceCodeScheme = new OAuth2DeviceCodeAuthorization({
+  deviceAuthorizationUrl: `${process.env.BASE_URL}/device/authorize`,
+  tokenUrl: `${process.env.BASE_URL}/oauth/token`,
+  scopes: { 'agent:invoke': 'Invoke the agent' },
+  description: 'OAuth2 Device Code flow for CLI clients',
+  tokenValidator: async (token, requiredScopes) => {
+    // Validate the access token
+    if (token !== expectedToken) {
+      return { authenticated: false, error: 'Invalid access token' };
+    }
+    return {
+      authenticated: true,
+      principal: { sub: 'device-user' },
+      scopes: ['agent:invoke'],
+    };
+  },
+});
+```
+
+---
+
+## Other Schemes
+
+```typescript
+import {
+  HttpBasicAuthorization,
+  OAuth2AuthorizationCodeAuthorization,
+  OAuth2ClientCredentialsAuthorization,
+  OAuth2PasswordAuthorization,
+  OAuth2ImplicitAuthorization,
+  OpenIdConnectAuthorization,
+  MutualTlsAuthorization,
+} from '@a2x/sdk';
+```
+
+---
+
+## Registering Schemes on A2XAgent
+
+```typescript
+a2xAgent
+  .addSecurityScheme('apiKey', apiKeyScheme)
+  .addSecurityScheme('bearer', bearerScheme)
+  .addSecurityScheme('deviceCode', deviceCodeScheme);
+```
+
+---
+
+## Security Requirements (OR / AND logic)
+
+Security requirements define which schemes must be satisfied. Multiple requirements use **OR** logic (any one satisfies). Multiple schemes within a single requirement use **AND** logic (all must pass).
+
+### OR logic — either scheme satisfies:
+
+```typescript
+// User can authenticate with EITHER api key OR bearer token
+a2xAgent
+  .addSecurityRequirement({ apiKey: [] })
+  .addSecurityRequirement({ bearer: ['agent:invoke'] });
+```
+
+### AND logic — both schemes must pass:
+
+```typescript
+// User must provide BOTH api key AND bearer token
+a2xAgent
+  .addSecurityRequirement({ apiKey: [], bearer: ['agent:invoke'] });
+```
+
+### Scopes
+
+The array values are required scopes:
+- `{ apiKey: [] }` — No scope required
+- `{ bearer: ['agent:invoke'] }` — Requires `agent:invoke` scope
+
+---
+
+## Passing RequestContext
+
+For authentication to work, you must pass a `RequestContext` to `handler.handle()`:
+
+```typescript
+import type { RequestContext } from '@a2x/sdk';
+
+// Express
+const context: RequestContext = {
+  headers: req.headers as Record<string, string | string[] | undefined>,
+  query: req.query as Record<string, string | string[] | undefined>,
+};
+
+// Next.js App Router
+const context: RequestContext = {
+  headers: Object.fromEntries(request.headers.entries()),
+  query: Object.fromEntries(new URL(request.url).searchParams.entries()),
+};
+
+const result = await handler.handle(body, context);
+```
+
+If no `context` is provided, authentication is skipped.
+
+---
+
+## AuthResult
+
+All validators return an `AuthResult`:
+
+```typescript
+interface AuthResult {
+  authenticated: boolean;
+  error?: string;          // Error message if not authenticated
+  principal?: {            // User identity info
+    sub?: string;
+    [key: string]: unknown;
+  };
+  scopes?: string[];       // Granted scopes
+}
+```
+
+---
+
+## No-Auth Mode
+
+If no security schemes are added, the agent runs without authentication (open access). This is fine for development but not recommended for production.

--- a/skills/a2x-integration/wiki/streaming.md
+++ b/skills/a2x-integration/wiki/streaming.md
@@ -1,0 +1,166 @@
+# SSE Streaming
+
+`@a2x/sdk` supports Server-Sent Events (SSE) streaming for the `message/stream` A2A method. The handler returns an `AsyncGenerator` that yields streaming events.
+
+---
+
+## Detecting Streaming vs Synchronous Responses
+
+```typescript
+const result = await handler.handle(body, context);
+
+if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+  // Streaming: result is an AsyncGenerator
+  // → respond with SSE stream
+} else {
+  // Synchronous: result is a plain JSON-RPC response object
+  // → respond with JSON
+}
+```
+
+This pattern is the same across all frameworks — only the HTTP response API differs.
+
+---
+
+## createSSEStream Helper
+
+`@a2x/sdk` provides a `createSSEStream()` utility that converts an AsyncGenerator into a `ReadableStream` formatted as SSE:
+
+```typescript
+import { createSSEStream } from '@a2x/sdk';
+
+const stream = createSSEStream(result as AsyncGenerator);
+// stream is a ReadableStream with SSE-formatted data
+```
+
+Each event is formatted as:
+```
+data: {JSON stringified event}\n\n
+```
+
+---
+
+## SSE Headers
+
+Always set these headers for SSE responses:
+
+```typescript
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  'Connection': 'keep-alive',
+  'X-Accel-Buffering': 'no',   // Prevents nginx/reverse proxy buffering
+};
+```
+
+---
+
+## Framework Patterns
+
+### Next.js App Router (Web Streams API)
+
+```typescript
+if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+  const stream = createSSEStream(result as AsyncGenerator);
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+```
+
+### Express (res.write / res.end)
+
+```typescript
+if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  const stream = createSSEStream(result as AsyncGenerator);
+  const reader = stream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+    }
+  } catch (error) {
+    const errorData = JSON.stringify({
+      error: error instanceof Error ? error.message : 'Internal error',
+    });
+    res.write(`event: error\ndata: ${errorData}\n\n`);
+  }
+  res.end();
+}
+```
+
+### NestJS (StreamableFile or raw response)
+
+```typescript
+if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+  const stream = createSSEStream(result as AsyncGenerator);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+    }
+  } catch (error) {
+    res.write(`event: error\ndata: ${JSON.stringify({ error: 'Streaming error' })}\n\n`);
+  }
+  res.end();
+}
+```
+
+---
+
+## Manual SSE (Without createSSEStream)
+
+If you prefer manual control:
+
+```typescript
+const generator = result as AsyncGenerator;
+const encoder = new TextEncoder();
+
+const stream = new ReadableStream({
+  async start(controller) {
+    try {
+      for await (const event of generator) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+    } catch (error) {
+      const errData = { jsonrpc: '2.0', error: { code: -32603, message: 'Streaming error' }, id: null };
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(errData)}\n\n`));
+    } finally {
+      controller.close();
+    }
+  },
+  cancel() {
+    generator.return(undefined);  // Clean up on client disconnect
+  },
+});
+```
+
+---
+
+## StreamingMode Configuration
+
+Set on `AgentExecutor`:
+
+```typescript
+import { AgentExecutor, StreamingMode } from '@a2x/sdk';
+
+const executor = new AgentExecutor({
+  runner,
+  runConfig: {
+    streamingMode: StreamingMode.SSE,   // Enable streaming
+    // streamingMode: StreamingMode.NONE, // Disable (always sync)
+  },
+});
+```
+
+When `StreamingMode.NONE` is set, `message/stream` requests still return a completed Task (not an AsyncGenerator).

--- a/skills/a2x-integration/wiki/tools-and-agents.md
+++ b/skills/a2x-integration/wiki/tools-and-agents.md
@@ -1,0 +1,136 @@
+# Tools & Agent Patterns
+
+---
+
+## FunctionTool
+
+Wrap any async function as a tool the LLM can call:
+
+```typescript
+import { FunctionTool } from '@a2x/sdk';
+
+const weatherTool = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a city.',
+  parameters: {
+    type: 'object',
+    properties: {
+      city: { type: 'string', description: 'City name' },
+      unit: { type: 'string', enum: ['celsius', 'fahrenheit'], description: 'Temperature unit' },
+    },
+    required: ['city'],
+  },
+  execute: async (args, context) => {
+    // args is typed based on the parameters schema
+    const { city, unit } = args as { city: string; unit?: string };
+    // Call your weather API here
+    return { temperature: 22, unit: unit ?? 'celsius', city };
+  },
+});
+
+// Use in an LlmAgent
+const agent = new LlmAgent({
+  name: 'weather-agent',
+  description: 'An agent that reports weather.',
+  provider: provider,
+  instruction: 'You help users check the weather.',
+  tools: [weatherTool],
+});
+```
+
+**Parameters schema** follows JSON Schema format. The `execute` function receives:
+- `args` — The parsed arguments from the LLM
+- `context` — `InvocationContext` with session data
+
+---
+
+## AgentTool
+
+Wrap another agent as a tool, enabling agent delegation:
+
+```typescript
+import { AgentTool, LlmAgent } from '@a2x/sdk';
+
+const researchAgent = new LlmAgent({
+  name: 'researcher',
+  description: 'Researches topics in depth.',
+  provider: provider,
+  instruction: 'You research topics thoroughly.',
+});
+
+const researchTool = new AgentTool({ agent: researchAgent });
+
+const mainAgent = new LlmAgent({
+  name: 'main-agent',
+  description: 'Main orchestrator agent.',
+  provider: provider,
+  instruction: 'You delegate research tasks to the researcher.',
+  tools: [researchTool],
+});
+```
+
+---
+
+## Multi-Agent Patterns
+
+### SequentialAgent
+
+Runs a pipeline of agents in order. Each agent's output feeds into the next.
+
+```typescript
+import { SequentialAgent } from '@a2x/sdk';
+
+const pipeline = new SequentialAgent({
+  name: 'pipeline',
+  description: 'Research then summarize.',
+  subAgents: [researchAgent, summaryAgent],
+});
+```
+
+### ParallelAgent
+
+Runs multiple agents concurrently.
+
+```typescript
+import { ParallelAgent } from '@a2x/sdk';
+
+const parallel = new ParallelAgent({
+  name: 'parallel-search',
+  description: 'Search multiple sources in parallel.',
+  subAgents: [webSearchAgent, dbSearchAgent, cacheAgent],
+});
+```
+
+### LoopAgent
+
+Runs an agent iteratively until an exit condition is met.
+
+```typescript
+import { LoopAgent } from '@a2x/sdk';
+
+const refinementLoop = new LoopAgent({
+  name: 'refiner',
+  description: 'Iteratively refine the answer.',
+  agent: refinementAgent,
+  maxIterations: 5,
+});
+```
+
+---
+
+## Combining Tools and Agents
+
+A common pattern is to have a main agent with both function tools and agent tools:
+
+```typescript
+const agent = new LlmAgent({
+  name: 'orchestrator',
+  description: 'Main orchestrator with tools and sub-agents.',
+  provider: provider,
+  instruction: 'You coordinate between tools and sub-agents.',
+  tools: [
+    weatherTool,                          // FunctionTool
+    new AgentTool({ agent: researcher }), // AgentTool
+  ],
+});
+```


### PR DESCRIPTION
## Summary
- Add `a2x-integration` Claude Code skill with wiki-style structure under `skills/`
- Covers Next.js (App Router, Pages Router), Express, NestJS, and zero-framework quick start via `toA2x()`
- Wiki references for core concepts, LLM providers, tools, security, and SSE streaming

## Structure
```
skills/a2x-integration/
├── SKILL.md                          # Main workflow + wiki index
└── wiki/
    ├── concepts.md                   # Architecture, key classes, protocol versions
    ├── providers.md                  # Google / Anthropic / OpenAI
    ├── tools-and-agents.md           # FunctionTool, multi-agent patterns
    ├── security.md                   # API Key, Bearer, OAuth2, requirements
    ├── streaming.md                  # createSSEStream, SSE headers
    ├── quick-start.md                # toA2x() helper
    ├── nextjs-app-router.md          # Next.js App Router guide
    ├── nextjs-pages-router.md        # Next.js Pages Router guide
    ├── express.md                    # Express guide
    └── nestjs.md                     # NestJS guide
```

## Test plan
- [ ] Verify skill triggers on "add a2x", "integrate a2x", "a2x agent" prompts
- [ ] Test integration workflow against a fresh Next.js project
- [ ] Test integration workflow against a fresh Express project