### PR TITLE
feat(cli): add registry search and register commands

### DIFF
--- a/packages/cli/src/api/agent-registry.ts
+++ b/packages/cli/src/api/agent-registry.ts
@@ -1,0 +1,116 @@
+/**
+ * REST API client for the Agent Registry service.
+ *
+ * Provides functions for searching and registering agents.
+ * Uses native fetch with AbortController for timeout management.
+ */
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Minimal agent representation returned from search results. */
+export interface AgentSummary {
+  name: string;
+  description: string;
+  agentCardUrl: string;
+}
+
+/** Shape of the search API response body. */
+interface SearchResponse {
+  results: AgentSummary[];
+}
+
+/**
+ * Search for agents in the registry.
+ *
+ * @param registryUrl - Base URL of the Agent Registry service.
+ * @param query - Optional free-text search string. When omitted, returns recent agents.
+ * @param limit - Maximum number of results. Defaults to 10.
+ * @returns Array of matching agent summaries.
+ * @throws Error on network failure, timeout, or non-2xx HTTP response.
+ */
+export async function searchAgents(
+  registryUrl: string,
+  query?: string,
+  limit = 10,
+): Promise<AgentSummary[]> {
+  const url = new URL('/api/agents/search', registryUrl);
+  if (query) url.searchParams.set('q', query);
+  url.searchParams.set('limit', String(limit));
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+
+    if (!res.ok) {
+      throw await buildHttpError(res);
+    }
+
+    const body = (await res.json()) as SearchResponse;
+    return body.results;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('Registry request timed out after 10s');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Register an agent in the registry by its Agent Card URL.
+ *
+ * @param registryUrl - Base URL of the Agent Registry service.
+ * @param agentCardUrl - URL pointing to the agent's Agent Card JSON.
+ * @returns The raw response body from the registry (structure varies).
+ * @throws Error on network failure, timeout, or non-2xx HTTP response.
+ */
+export async function registerAgent(
+  registryUrl: string,
+  agentCardUrl: string,
+): Promise<unknown> {
+  const url = new URL('/api/agents', registryUrl);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentCardUrl }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      throw await buildHttpError(res);
+    }
+
+    return await res.json();
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('Registry request timed out after 10s');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Build a descriptive Error from a non-2xx HTTP response.
+ * Attempts to extract an error message from the response body.
+ */
+async function buildHttpError(res: Response): Promise<Error> {
+  let detail = `Registry returned HTTP ${res.status}`;
+  try {
+    const body = (await res.json()) as Record<string, unknown>;
+    if (body.error) detail += `: ${body.error}`;
+    else if (body.message) detail += `: ${body.message}`;
+  } catch {
+    /* ignore parse failure */
+  }
+  return new Error(detail);
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,1 +1,2 @@
 export { a2aCommand } from './a2a/index.js';
+export { registryCommand } from './registry/index.js';

--- a/packages/cli/src/commands/registry/index.ts
+++ b/packages/cli/src/commands/registry/index.ts
@@ -1,0 +1,9 @@
+import { Command } from 'commander';
+import { searchCommand } from './search.js';
+import { registerCommand } from './register.js';
+
+export const registryCommand = new Command('registry')
+  .description('Agent Registry commands');
+
+registryCommand.addCommand(searchCommand);
+registryCommand.addCommand(registerCommand);

--- a/packages/cli/src/commands/registry/register.ts
+++ b/packages/cli/src/commands/registry/register.ts
@@ -1,0 +1,33 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getRegistryUrl } from '../../config.js';
+import { registerAgent } from '../../api/agent-registry.js';
+
+export const registerCommand = new Command('register')
+  .description('Register an A2A agent in the agent registry')
+  .argument('<agent-card-url>', 'URL pointing to the agent\'s Agent Card JSON')
+  .option('--registry <url>', 'Registry URL override')
+  .option('--json', 'Output raw JSON response')
+  .action(
+    async (
+      agentCardUrl: string,
+      opts: { registry?: string; json?: boolean },
+    ) => {
+      try {
+        const registryUrl = getRegistryUrl(opts.registry);
+        const result = await registerAgent(registryUrl, agentCardUrl);
+
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        console.log(chalk.green('Agent registered successfully.'));
+      } catch (err) {
+        console.error(
+          chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`),
+        );
+        process.exit(1);
+      }
+    },
+  );

--- a/packages/cli/src/commands/registry/search.ts
+++ b/packages/cli/src/commands/registry/search.ts
@@ -1,0 +1,97 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getRegistryUrl } from '../../config.js';
+import { searchAgents, type AgentSummary } from '../../api/agent-registry.js';
+
+export const searchCommand = new Command('search')
+  .description('Search for A2A agents in the agent registry')
+  .argument('[query]', 'Free-text search query')
+  .option('-n, --limit <number>', 'Maximum number of results', '10')
+  .option('--registry <url>', 'Registry URL override')
+  .option('--json', 'Output raw JSON response')
+  .action(
+    async (
+      query: string | undefined,
+      opts: { limit: string; registry?: string; json?: boolean },
+    ) => {
+      try {
+        const registryUrl = getRegistryUrl(opts.registry);
+        const limit = parseInt(opts.limit, 10);
+        const results = await searchAgents(registryUrl, query, limit);
+
+        if (opts.json) {
+          console.log(JSON.stringify(results, null, 2));
+          return;
+        }
+
+        if (results.length === 0) {
+          if (query) {
+            console.log(`No agents found matching "${query}".`);
+          } else {
+            console.log('No agents found in the registry.');
+          }
+          return;
+        }
+
+        printTable(results);
+      } catch (err) {
+        console.error(
+          chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`),
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+/**
+ * Print agent search results in a formatted table.
+ */
+function printTable(agents: AgentSummary[]): void {
+  const maxDesc = 48;
+
+  const nameWidth = Math.max(
+    'NAME'.length,
+    ...agents.map((a) => a.name.length),
+  );
+  const descWidth = Math.max(
+    'DESCRIPTION'.length,
+    ...agents.map((a) => Math.min(a.description.length, maxDesc)),
+  );
+  const urlWidth = Math.max(
+    'AGENT CARD URL'.length,
+    ...agents.map((a) => a.agentCardUrl.length),
+  );
+
+  const header =
+    chalk.bold('NAME'.padEnd(nameWidth)) +
+    '  ' +
+    chalk.bold('DESCRIPTION'.padEnd(descWidth)) +
+    '  ' +
+    chalk.bold('AGENT CARD URL'.padEnd(urlWidth));
+
+  const separator =
+    '-'.repeat(nameWidth) +
+    '  ' +
+    '-'.repeat(descWidth) +
+    '  ' +
+    '-'.repeat(urlWidth);
+
+  console.log(header);
+  console.log(separator);
+
+  for (const agent of agents) {
+    const desc =
+      agent.description.length > maxDesc
+        ? agent.description.slice(0, maxDesc - 3) + '...'
+        : agent.description;
+
+    const row =
+      agent.name.padEnd(nameWidth) +
+      '  ' +
+      desc.padEnd(descWidth) +
+      '  ' +
+      agent.agentCardUrl;
+
+    console.log(row);
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,65 @@
+/**
+ * Configuration management for persistent CLI settings.
+ *
+ * Stores configuration at ~/.a2x/config.json.
+ * Provides registry URL resolution with a four-level priority chain.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const CONFIG_DIR = path.join(os.homedir(), '.a2x');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+
+/** Persistent CLI configuration stored at ~/.a2x/config.json. */
+export interface A2xConfig {
+  registryUrl?: string;
+  [key: string]: unknown;
+}
+
+/** Default registry URL used when no override is configured. */
+export const DEFAULT_REGISTRY_URL = 'https://a2a-agent-registry.fly.dev';
+
+/**
+ * Read the config file at ~/.a2x/config.json.
+ * Returns an empty object if the file does not exist or is unparseable.
+ */
+export function readConfig(): A2xConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
+    return JSON.parse(raw) as A2xConfig;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write the config to ~/.a2x/config.json.
+ * Creates the directory if it does not exist.
+ * Preserves file permissions (mode 0o600 for security).
+ */
+export function writeConfig(config: A2xConfig): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+}
+
+/**
+ * Resolve the registry URL using the priority chain:
+ *   1. override parameter (from --registry CLI option)
+ *   2. A2X_REGISTRY_URL environment variable
+ *   3. registryUrl field in ~/.a2x/config.json
+ *   4. DEFAULT_REGISTRY_URL built-in constant
+ *
+ * @param override - Value from the --registry CLI option, if provided.
+ */
+export function getRegistryUrl(override?: string): string {
+  if (override) return override;
+  if (process.env.A2X_REGISTRY_URL) return process.env.A2X_REGISTRY_URL;
+  const config = readConfig();
+  if (config.registryUrl) return config.registryUrl;
+  return DEFAULT_REGISTRY_URL;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { program } from 'commander';
-import { a2aCommand } from './commands/index.js';
+import { a2aCommand, registryCommand } from './commands/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,5 +14,6 @@ program
   .version(pkg.version);
 
 program.addCommand(a2aCommand);
+program.addCommand(registryCommand);
 
 program.parse();


### PR DESCRIPTION
## Summary
- Add `a2x registry search [query]` command to search for A2A agents in the agent registry with formatted table output
- Add `a2x registry register <agent-card-url>` command to register agents by their Agent Card URL
- Add config module (`~/.a2x/config.json`) with four-level registry URL resolution: `--registry` flag > `A2X_REGISTRY_URL` env var > config file > built-in default

## Test plan
- [x] `a2x registry search` lists agents from the default registry
- [x] `a2x registry search "keyword"` filters results correctly
- [x] `a2x registry search --json` outputs raw JSON
- [x] `a2x registry register <url>` registers an agent successfully
- [x] `--registry <url>` flag overrides the default registry URL
- [x] Timeout and error handling work for unreachable registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)