### PR TITLE
feat: implement tasks/pushNotificationConfig/delete JSON-RPC method

### DIFF
--- a/packages/a2x/src/__tests__/push-notification-config-store.test.ts
+++ b/packages/a2x/src/__tests__/push-notification-config-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
+import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
+
+describe('InMemoryPushNotificationConfigStore', () => {
+  let store: InMemoryPushNotificationConfigStore;
+
+  beforeEach(() => {
+    store = new InMemoryPushNotificationConfigStore();
+  });
+
+  const config: TaskPushNotificationConfig = {
+    id: 'config-1',
+    taskId: 'task-1',
+    pushNotificationConfig: {
+      id: 'config-1',
+      url: 'https://example.com/webhook',
+      token: 'tok-123',
+    },
+  };
+
+  describe('set and get', () => {
+    it('should store and retrieve a config', async () => {
+      await store.set(config);
+      const result = await store.get('task-1', 'config-1');
+      expect(result).toEqual(config);
+    });
+
+    it('should return null for non-existent config', async () => {
+      const result = await store.get('task-1', 'non-existent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing config and return true', async () => {
+      await store.set(config);
+      const deleted = await store.delete('task-1', 'config-1');
+      expect(deleted).toBe(true);
+
+      const result = await store.get('task-1', 'config-1');
+      expect(result).toBeNull();
+    });
+
+    it('should return false when deleting non-existent config', async () => {
+      const deleted = await store.delete('task-1', 'non-existent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('list', () => {
+    it('should list all configs for a task', async () => {
+      const config2: TaskPushNotificationConfig = {
+        id: 'config-2',
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          id: 'config-2',
+          url: 'https://example.com/webhook2',
+        },
+      };
+
+      await store.set(config);
+      await store.set(config2);
+      const configs = await store.list('task-1');
+      expect(configs).toHaveLength(2);
+      expect(configs.map(c => c.id)).toContain('config-1');
+      expect(configs.map(c => c.id)).toContain('config-2');
+    });
+
+    it('should return empty array for task with no configs', async () => {
+      const configs = await store.list('no-task');
+      expect(configs).toHaveLength(0);
+    });
+  });
+});

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -9,6 +9,8 @@ import { LlmAgent } from '../agent/llm-agent.js';
 import { BaseLlmProvider } from '../provider/base.js';
 import { A2A_ERROR_CODES } from '../types/errors.js';
 import type { JSONRPCResponse, JSONRPCErrorResponse } from '../types/jsonrpc.js';
+import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
+import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
 import { ApiKeyAuthorization } from '../security/api-key.js';
 import { HttpBearerAuthorization } from '../security/http-bearer.js';
 import type { RequestContext } from '../types/auth.js';
@@ -42,6 +44,36 @@ function createHandler(protocolVersion?: ProtocolVersion): DefaultRequestHandler
   a2xAgent.setDefaultUrl('https://example.com/a2a');
 
   return new DefaultRequestHandler(a2xAgent);
+}
+
+function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
+  handler: DefaultRequestHandler;
+  pushStore: InMemoryPushNotificationConfigStore;
+} {
+  const agent = new LlmAgent({
+    name: 'test-agent',
+    provider: mockProvider,
+    description: 'A test agent',
+    instruction: 'You are a helpful assistant.',
+  });
+
+  const runner = new InMemoryRunner({ agent, appName: 'test' });
+  const executor = new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+  const taskStore = new InMemoryTaskStore();
+  const pushStore = new InMemoryPushNotificationConfigStore();
+  const a2xAgent = new A2XAgent({
+    taskStore,
+    executor,
+    protocolVersion,
+    pushNotificationConfigStore: pushStore,
+  });
+  a2xAgent.setDefaultUrl('https://example.com/a2a');
+  a2xAgent.setCapabilities({ pushNotifications: true });
+
+  return { handler: new DefaultRequestHandler(a2xAgent), pushStore };
 }
 
 function isAsyncGenerator(value: unknown): value is AsyncGenerator {
@@ -715,6 +747,108 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect(isAsyncGenerator(response)).toBe(false);
       const rpc = response as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/delete', () => {
+    it('should return PushNotificationNotSupported when no store configured', async () => {
+      const handler = createHandler();
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
+      );
+    });
+
+    it('should delete an existing config and return null result', async () => {
+      const { handler, pushStore } = createHandlerWithPushNotification();
+
+      const config: TaskPushNotificationConfig = {
+        id: 'config-1',
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          id: 'config-1',
+          url: 'https://example.com/webhook',
+        },
+      };
+      await pushStore.set(config);
+
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(false);
+      expect((rpc as { result: unknown }).result).toBeNull();
+
+      const after = await pushStore.get('task-1', 'config-1');
+      expect(after).toBeNull();
+    });
+
+    it('should return TaskNotFound when config does not exist', async () => {
+      const { handler } = createHandlerWithPushNotification();
+
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { id: 'task-1', pushNotificationConfigId: 'non-existent' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.TASK_NOT_FOUND,
+      );
+    });
+
+    it('should return InvalidParams when id is missing', async () => {
+      const { handler } = createHandlerWithPushNotification();
+
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { pushNotificationConfigId: 'config-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.INVALID_PARAMS,
+      );
+    });
+
+    it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
+      const { handler } = createHandlerWithPushNotification();
+
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { id: 'task-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.INVALID_PARAMS,
+      );
     });
   });
 });

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -757,7 +757,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/pushNotificationConfig/delete',
-        params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+        params: { taskId: 'task-1', id: 'config-1' },
       });
 
       expect(isAsyncGenerator(response)).toBe(false);
@@ -768,87 +768,174 @@ describe('Layer 4: DefaultRequestHandler', () => {
       );
     });
 
-    it('should delete an existing config and return null result', async () => {
-      const { handler, pushStore } = createHandlerWithPushNotification();
+    describe('v1.0 parameter format (taskId + id)', () => {
+      it('should delete an existing config and return null result', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
 
-      const config: TaskPushNotificationConfig = {
-        id: 'config-1',
-        taskId: 'task-1',
-        pushNotificationConfig: {
+        const config: TaskPushNotificationConfig = {
           id: 'config-1',
-          url: 'https://example.com/webhook',
-        },
-      };
-      await pushStore.set(config);
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        };
+        await pushStore.set(config);
 
-      const response = await handler.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tasks/pushNotificationConfig/delete',
-        params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { taskId: 'task-1', id: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toBeNull();
+
+        const after = await pushStore.get('task-1', 'config-1');
+        expect(after).toBeNull();
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(false);
-      expect((rpc as { result: unknown }).result).toBeNull();
+      it('should return TaskNotFound when config does not exist', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
 
-      const after = await pushStore.get('task-1', 'config-1');
-      expect(after).toBeNull();
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { taskId: 'task-1', id: 'non-existent' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.TASK_NOT_FOUND,
+        );
+      });
+
+      it('should return InvalidParams when taskId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { id: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when id is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { taskId: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
     });
 
-    it('should return TaskNotFound when config does not exist', async () => {
-      const { handler } = createHandlerWithPushNotification();
+    describe('v0.3 parameter format (id + pushNotificationConfigId)', () => {
+      it('should delete an existing config and return null result', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-      const response = await handler.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tasks/pushNotificationConfig/delete',
-        params: { id: 'task-1', pushNotificationConfigId: 'non-existent' },
+        const config: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        };
+        await pushStore.set(config);
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toBeNull();
+
+        const after = await pushStore.get('task-1', 'config-1');
+        expect(after).toBeNull();
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.TASK_NOT_FOUND,
-      );
-    });
+      it('should return TaskNotFound when config does not exist', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
 
-    it('should return InvalidParams when id is missing', async () => {
-      const { handler } = createHandlerWithPushNotification();
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { id: 'task-1', pushNotificationConfigId: 'non-existent' },
+        });
 
-      const response = await handler.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tasks/pushNotificationConfig/delete',
-        params: { pushNotificationConfigId: 'config-1' },
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.TASK_NOT_FOUND,
+        );
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.INVALID_PARAMS,
-      );
-    });
+      it('should return InvalidParams when id (task ID) is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
 
-    it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
-      const { handler } = createHandlerWithPushNotification();
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { pushNotificationConfigId: 'config-1' },
+        });
 
-      const response = await handler.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tasks/pushNotificationConfig/delete',
-        params: { id: 'task-1' },
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.INVALID_PARAMS,
-      );
+      it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/delete',
+          params: { id: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
     });
   });
 });

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -17,6 +17,7 @@ import type { SecurityRequirement } from '../types/security.js';
 import { AgentExecutor, StreamingMode } from './agent-executor.js';
 import { AgentCardMapperFactory } from './agent-card-mapper.js';
 import type { TaskStore } from './task-store.js';
+import type { PushNotificationConfigStore } from './push-notification-config-store.js';
 
 // ─── Protocol Version ───
 
@@ -31,12 +32,14 @@ export interface A2XAgentOptions {
   taskStore: TaskStore;
   executor: AgentExecutor;
   protocolVersion?: ProtocolVersion;
+  pushNotificationConfigStore?: PushNotificationConfigStore;
 }
 
 export class A2XAgent {
   private readonly _taskStore: TaskStore;
   private readonly _agentExecutor: AgentExecutor;
   private readonly _protocolVersion: ProtocolVersion;
+  private readonly _pushNotificationConfigStore?: PushNotificationConfigStore;
 
   // ─── Internal mutable state (builder pattern) ───
   private _name?: string;
@@ -77,6 +80,7 @@ export class A2XAgent {
     this._taskStore = options.taskStore;
     this._agentExecutor = options.executor;
     this._protocolVersion = options.protocolVersion ?? '1.0';
+    this._pushNotificationConfigStore = options.pushNotificationConfigStore;
   }
 
   // ─── Builder Methods (return this for chaining) ───
@@ -260,6 +264,10 @@ export class A2XAgent {
 
   get securityRequirements(): readonly SecurityRequirement[] {
     return this._securityRequirements;
+  }
+
+  get pushNotificationConfigStore(): PushNotificationConfigStore | undefined {
+    return this._pushNotificationConfigStore;
   }
 
   // ─── Private Methods ───

--- a/packages/a2x/src/a2x/index.ts
+++ b/packages/a2x/src/a2x/index.ts
@@ -21,6 +21,10 @@ export type {
   CreateTaskParams,
   TaskUpdate,
 } from './task-store.js';
+export { InMemoryPushNotificationConfigStore } from './push-notification-config-store.js';
+export type {
+  PushNotificationConfigStore,
+} from './push-notification-config-store.js';
 
 // ─── Register default agent-card mappers ───
 

--- a/packages/a2x/src/a2x/push-notification-config-store.ts
+++ b/packages/a2x/src/a2x/push-notification-config-store.ts
@@ -1,0 +1,51 @@
+/**
+ * Layer 3: PushNotificationConfigStore interface and InMemory implementation.
+ */
+
+import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
+
+// ─── PushNotificationConfigStore Interface ───
+
+export interface PushNotificationConfigStore {
+  get(taskId: string, configId: string): Promise<TaskPushNotificationConfig | null>;
+  set(config: TaskPushNotificationConfig): Promise<TaskPushNotificationConfig>;
+  delete(taskId: string, configId: string): Promise<boolean>;
+  list(taskId: string): Promise<TaskPushNotificationConfig[]>;
+}
+
+// ─── InMemoryPushNotificationConfigStore ───
+
+export class InMemoryPushNotificationConfigStore implements PushNotificationConfigStore {
+  /** Map<taskId, Map<configId, config>> */
+  private readonly configs = new Map<string, Map<string, TaskPushNotificationConfig>>();
+
+  async get(taskId: string, configId: string): Promise<TaskPushNotificationConfig | null> {
+    return this.configs.get(taskId)?.get(configId) ?? null;
+  }
+
+  async set(config: TaskPushNotificationConfig): Promise<TaskPushNotificationConfig> {
+    let taskConfigs = this.configs.get(config.taskId);
+    if (!taskConfigs) {
+      taskConfigs = new Map();
+      this.configs.set(config.taskId, taskConfigs);
+    }
+    taskConfigs.set(config.id, config);
+    return config;
+  }
+
+  async delete(taskId: string, configId: string): Promise<boolean> {
+    const taskConfigs = this.configs.get(taskId);
+    if (!taskConfigs) return false;
+    const deleted = taskConfigs.delete(configId);
+    if (taskConfigs.size === 0) {
+      this.configs.delete(taskId);
+    }
+    return deleted;
+  }
+
+  async list(taskId: string): Promise<TaskPushNotificationConfig[]> {
+    const taskConfigs = this.configs.get(taskId);
+    if (!taskConfigs) return [];
+    return Array.from(taskConfigs.values());
+  }
+}

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -13,6 +13,7 @@ import type {
   JSONRPCResponse,
   SendMessageParams,
   TaskIdParams,
+  DeletePushNotificationConfigParams,
 } from '../types/jsonrpc.js';
 import { A2A_METHODS } from '../types/jsonrpc.js';
 import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
@@ -27,6 +28,7 @@ import {
   InvalidParamsError,
   InvalidRequestError,
   JSONParseError,
+  PushNotificationNotSupportedError,
   TaskNotCancelableError,
   TaskNotFoundError,
   UnsupportedOperationError,
@@ -285,6 +287,15 @@ export class DefaultRequestHandler {
         return this._handleCancelTask(taskParams);
       },
     );
+
+    // tasks/pushNotificationConfig/delete
+    this.router.registerMethod(
+      A2A_METHODS.DELETE_PUSH_CONFIG,
+      async (params) => {
+        const deleteParams = this._validateDeletePushNotificationConfigParams(params);
+        return this._handleDeletePushNotificationConfig(deleteParams);
+      },
+    );
   }
 
   // ─── Private: Method Handlers ───
@@ -374,6 +385,24 @@ export class DefaultRequestHandler {
     return this.responseMapper.mapTask(canceledTask);
   }
 
+  private async _handleDeletePushNotificationConfig(
+    params: DeletePushNotificationConfigParams,
+  ): Promise<null> {
+    const store = this.a2xAgent.pushNotificationConfigStore;
+    if (!store) {
+      throw new PushNotificationNotSupportedError();
+    }
+
+    const deleted = await store.delete(params.id, params.pushNotificationConfigId);
+    if (!deleted) {
+      throw new TaskNotFoundError(
+        `Push notification config '${params.pushNotificationConfigId}' not found for task '${params.id}'`,
+      );
+    }
+
+    return null;
+  }
+
   // ─── Private: Helpers ───
 
   private _toErrorResponse(
@@ -435,5 +464,34 @@ export class DefaultRequestHandler {
     }
 
     return params as TaskIdParams;
+  }
+
+  private _validateDeletePushNotificationConfigParams(
+    params: unknown,
+  ): DeletePushNotificationConfigParams {
+    if (!params || typeof params !== 'object') {
+      throw new InvalidParamsError(
+        'DeletePushNotificationConfig requires "id" and "pushNotificationConfigId" parameters',
+      );
+    }
+
+    const p = params as Record<string, unknown>;
+
+    if (typeof p.id !== 'string' || p.id.trim() === '') {
+      throw new InvalidParamsError(
+        'DeletePushNotificationConfig: "id" must be a non-empty string',
+      );
+    }
+
+    if (
+      typeof p.pushNotificationConfigId !== 'string' ||
+      p.pushNotificationConfigId.trim() === ''
+    ) {
+      throw new InvalidParamsError(
+        'DeletePushNotificationConfig: "pushNotificationConfigId" must be a non-empty string',
+      );
+    }
+
+    return params as DeletePushNotificationConfigParams;
   }
 }

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -393,10 +393,10 @@ export class DefaultRequestHandler {
       throw new PushNotificationNotSupportedError();
     }
 
-    const deleted = await store.delete(params.id, params.pushNotificationConfigId);
+    const deleted = await store.delete(params.taskId, params.configId);
     if (!deleted) {
       throw new TaskNotFoundError(
-        `Push notification config '${params.pushNotificationConfigId}' not found for task '${params.id}'`,
+        `Push notification config '${params.configId}' not found for task '${params.taskId}'`,
       );
     }
 
@@ -466,32 +466,64 @@ export class DefaultRequestHandler {
     return params as TaskIdParams;
   }
 
+  /**
+   * Validate and normalize delete push notification config params.
+   *
+   * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
+   * v1.0 wire format: { taskId: taskId, id: configId }
+   *
+   * Both are normalized into { taskId, configId }.
+   */
   private _validateDeletePushNotificationConfigParams(
     params: unknown,
   ): DeletePushNotificationConfigParams {
     if (!params || typeof params !== 'object') {
       throw new InvalidParamsError(
-        'DeletePushNotificationConfig requires "id" and "pushNotificationConfigId" parameters',
+        'DeletePushNotificationConfig requires task ID and config ID parameters',
       );
     }
 
     const p = params as Record<string, unknown>;
+    let taskId: string;
+    let configId: string;
 
-    if (typeof p.id !== 'string' || p.id.trim() === '') {
-      throw new InvalidParamsError(
-        'DeletePushNotificationConfig: "id" must be a non-empty string',
-      );
+    if (this.a2xAgent.protocolVersion === '0.3') {
+      // v0.3: { id: taskId, pushNotificationConfigId: configId }
+      if (typeof p.id !== 'string' || p.id.trim() === '') {
+        throw new InvalidParamsError(
+          'DeletePushNotificationConfig: "id" (task ID) must be a non-empty string',
+        );
+      }
+      if (
+        typeof p.pushNotificationConfigId !== 'string' ||
+        (p.pushNotificationConfigId as string).trim() === ''
+      ) {
+        throw new InvalidParamsError(
+          'DeletePushNotificationConfig: "pushNotificationConfigId" must be a non-empty string',
+        );
+      }
+      taskId = p.id as string;
+      configId = p.pushNotificationConfigId as string;
+    } else {
+      // v1.0: { taskId: taskId, id: configId }
+      if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
+        throw new InvalidParamsError(
+          'DeletePushNotificationConfig: "taskId" must be a non-empty string',
+        );
+      }
+      if (typeof p.id !== 'string' || p.id.trim() === '') {
+        throw new InvalidParamsError(
+          'DeletePushNotificationConfig: "id" (config ID) must be a non-empty string',
+        );
+      }
+      taskId = p.taskId as string;
+      configId = p.id as string;
     }
 
-    if (
-      typeof p.pushNotificationConfigId !== 'string' ||
-      p.pushNotificationConfigId.trim() === ''
-    ) {
-      throw new InvalidParamsError(
-        'DeletePushNotificationConfig: "pushNotificationConfigId" must be a non-empty string',
-      );
-    }
-
-    return params as DeletePushNotificationConfigParams;
+    return {
+      taskId,
+      configId,
+      metadata: p.metadata as Record<string, unknown> | undefined,
+    };
   }
 }

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -68,3 +68,33 @@ export interface TaskIdParams {
   id: string;
   metadata?: Record<string, unknown>;
 }
+
+// ─── Push Notification Config Types ───
+
+export interface PushNotificationConfig {
+  id: string;
+  url: string;
+  token?: string;
+  authentication?: PushNotificationAuthenticationInfo;
+}
+
+export interface PushNotificationAuthenticationInfo {
+  schemes: string[];
+  credentials?: string;
+}
+
+export interface TaskPushNotificationConfig {
+  id: string;
+  taskId: string;
+  pushNotificationConfig: PushNotificationConfig;
+}
+
+// ─── Delete Push Notification Config Parameters ───
+
+export interface DeletePushNotificationConfigParams {
+  /** The task ID */
+  id: string;
+  /** The push notification config ID to delete */
+  pushNotificationConfigId: string;
+  metadata?: Record<string, unknown>;
+}

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -91,10 +91,16 @@ export interface TaskPushNotificationConfig {
 
 // ─── Delete Push Notification Config Parameters ───
 
+/**
+ * Version-agnostic internal representation for delete push notification config.
+ *
+ * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
+ * v1.0 wire format: { taskId: taskId, id: configId }
+ *
+ * The validator normalizes both formats into this unified shape.
+ */
 export interface DeletePushNotificationConfigParams {
-  /** The task ID */
-  id: string;
-  /** The push notification config ID to delete */
-  pushNotificationConfigId: string;
+  taskId: string;
+  configId: string;
   metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Implement the `tasks/pushNotificationConfig/delete` A2A JSON-RPC method with full v0.3/v1.0 dual protocol support.

### What's added

- **Types:** `PushNotificationConfig`, `TaskPushNotificationConfig`, and `DeletePushNotificationConfigParams` (version-agnostic internal representation)
- **Store:** `PushNotificationConfigStore` interface + `InMemoryPushNotificationConfigStore` for managing per-task push notification configs
- **Wiring:** `A2XAgent` accepts an optional `pushNotificationConfigStore` via constructor
- **Handler:** `tasks/pushNotificationConfig/delete` route in `DefaultRequestHandler`

### v0.3 / v1.0 parameter handling

The A2A spec defines **different parameter names** between versions — the meaning of `id` is reversed:

| Protocol | Wire format | `id` means |
|----------|------------|------------|
| v0.3 | `{ id, pushNotificationConfigId }` | task ID |
| v1.0 | `{ taskId, id }` | config ID |

The validator normalizes both wire formats into a unified internal shape `{ taskId, configId }` based on `protocolVersion`, so the handler logic is version-agnostic.

### Error handling

| Condition | Error code |
|-----------|-----------|
| No `pushNotificationConfigStore` configured | `-32003 PushNotificationNotSupported` |
| Config not found | `-32001 TaskNotFound` |
| Missing/invalid parameters | `-32602 InvalidParams` |
| Successful deletion | `result: null` (per spec) |

## Test plan

- [x] `InMemoryPushNotificationConfigStore` unit tests (set, get, delete, list) — 6 tests
- [x] `DefaultRequestHandler` v1.0 tests — 4 tests (delete, not found, missing taskId, missing id)
- [x] `DefaultRequestHandler` v0.3 tests — 4 tests (delete, not found, missing id, missing pushNotificationConfigId)
- [x] `DefaultRequestHandler` shared test — 1 test (no store → PushNotificationNotSupported)
- [x] Full test suite passes (229 tests)
- [x] Lint, typecheck, and build all pass