### PR TITLE
fix: add TTL and maxSize eviction to InMemoryTaskStore

### DIFF
--- a/packages/a2x/src/__tests__/task-store.test.ts
+++ b/packages/a2x/src/__tests__/task-store.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { TaskState } from '../types/task.js';
 
 describe('Layer 3: TaskStore', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('InMemoryTaskStore', () => {
     it('should create a task with submitted status', async () => {
       const store = new InMemoryTaskStore();
@@ -87,6 +91,170 @@ describe('Layer 3: TaskStore', () => {
       });
 
       expect(updated.metadata).toEqual({ key1: 'val1', key2: 'val2' });
+    });
+  });
+
+  describe('InMemoryTaskStore TTL eviction', () => {
+    it('should evict a terminal task after ttlMs has passed', async () => {
+      const now = 1000000;
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const store = new InMemoryTaskStore({ ttlMs: 5000 });
+      const task = await store.createTask({});
+
+      // Move to terminal state — starts TTL clock
+      await store.updateTask(task.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+
+      // Before TTL: still accessible
+      vi.spyOn(Date, 'now').mockReturnValue(now + 4999);
+      expect(await store.getTask(task.id)).not.toBeNull();
+
+      // After TTL: evicted on access
+      vi.spyOn(Date, 'now').mockReturnValue(now + 5000);
+      expect(await store.getTask(task.id)).toBeNull();
+    });
+
+    it('should not evict non-terminal tasks regardless of time', async () => {
+      const now = 1000000;
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const store = new InMemoryTaskStore({ ttlMs: 1000 });
+      const task = await store.createTask({});
+
+      // Update to non-terminal state
+      await store.updateTask(task.id, {
+        status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
+      });
+
+      // Way past TTL, but task is non-terminal — should survive
+      vi.spyOn(Date, 'now').mockReturnValue(now + 999999);
+      expect(await store.getTask(task.id)).not.toBeNull();
+    });
+
+    it('should sweep expired tasks on createTask', async () => {
+      const now = 1000000;
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const store = new InMemoryTaskStore({ ttlMs: 5000 });
+
+      const t1 = await store.createTask({});
+      const t2 = await store.createTask({});
+      await store.updateTask(t1.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+      await store.updateTask(t2.id, {
+        status: { state: TaskState.FAILED, timestamp: new Date().toISOString() },
+      });
+
+      expect(store.size).toBe(2);
+
+      // Advance past TTL and create a new task — triggers sweep
+      vi.spyOn(Date, 'now').mockReturnValue(now + 6000);
+      await store.createTask({});
+
+      // t1 and t2 should be swept, only the new task remains
+      expect(store.size).toBe(1);
+    });
+
+    it('should work without options (no TTL, no maxSize)', async () => {
+      const store = new InMemoryTaskStore();
+      const task = await store.createTask({});
+      await store.updateTask(task.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+
+      // No eviction — task persists indefinitely
+      expect(await store.getTask(task.id)).not.toBeNull();
+      expect(store.size).toBe(1);
+    });
+  });
+
+  describe('InMemoryTaskStore maxSize eviction', () => {
+    it('should evict oldest terminal tasks when maxSize is exceeded', async () => {
+      const now = 1000000;
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const store = new InMemoryTaskStore({ maxSize: 3 });
+
+      // Create 3 tasks and complete them in order
+      const t1 = await store.createTask({});
+      vi.spyOn(Date, 'now').mockReturnValue(now + 1);
+      await store.updateTask(t1.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+
+      vi.spyOn(Date, 'now').mockReturnValue(now + 2);
+      const t2 = await store.createTask({});
+      vi.spyOn(Date, 'now').mockReturnValue(now + 3);
+      await store.updateTask(t2.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+
+      vi.spyOn(Date, 'now').mockReturnValue(now + 4);
+      const t3 = await store.createTask({});
+      vi.spyOn(Date, 'now').mockReturnValue(now + 5);
+      await store.updateTask(t3.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+
+      expect(store.size).toBe(3);
+
+      // Creating a 4th task should evict the oldest terminal task (t1)
+      vi.spyOn(Date, 'now').mockReturnValue(now + 6);
+      await store.createTask({});
+
+      expect(store.size).toBe(3);
+      expect(await store.getTask(t1.id)).toBeNull();
+      expect(await store.getTask(t2.id)).not.toBeNull();
+      expect(await store.getTask(t3.id)).not.toBeNull();
+    });
+
+    it('should not evict non-terminal tasks when at capacity', async () => {
+      const store = new InMemoryTaskStore({ maxSize: 2 });
+
+      // Create 2 tasks, keep both in non-terminal state
+      const t1 = await store.createTask({});
+      await store.updateTask(t1.id, {
+        status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
+      });
+      const t2 = await store.createTask({});
+
+      expect(store.size).toBe(2);
+
+      // Creating a 3rd task — no terminal tasks to evict, size goes to 3
+      await store.createTask({});
+      expect(store.size).toBe(3);
+
+      // Both original tasks should survive
+      expect(await store.getTask(t1.id)).not.toBeNull();
+      expect(await store.getTask(t2.id)).not.toBeNull();
+    });
+
+    it('should combine TTL and maxSize', async () => {
+      const now = 1000000;
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const store = new InMemoryTaskStore({ maxSize: 5, ttlMs: 3000 });
+
+      // Create and complete 2 tasks
+      const t1 = await store.createTask({});
+      await store.updateTask(t1.id, {
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+      });
+      const t2 = await store.createTask({});
+      await store.updateTask(t2.id, {
+        status: { state: TaskState.FAILED, timestamp: new Date().toISOString() },
+      });
+
+      // Advance past TTL and create new task — both expired tasks should be swept
+      vi.spyOn(Date, 'now').mockReturnValue(now + 4000);
+      await store.createTask({});
+
+      expect(store.size).toBe(1);
+      expect(await store.getTask(t1.id)).toBeNull();
+      expect(await store.getTask(t2.id)).toBeNull();
     });
   });
 });

--- a/packages/a2x/src/a2x/index.ts
+++ b/packages/a2x/src/a2x/index.ts
@@ -20,6 +20,7 @@ export type {
   TaskStore,
   CreateTaskParams,
   TaskUpdate,
+  InMemoryTaskStoreOptions,
 } from './task-store.js';
 
 // ─── Register default agent-card mappers ───

--- a/packages/a2x/src/a2x/task-store.ts
+++ b/packages/a2x/src/a2x/task-store.ts
@@ -30,12 +30,42 @@ export interface TaskStore {
   deleteTask(taskId: string): Promise<void>;
 }
 
+// ─── InMemoryTaskStore Options ───
+
+export interface InMemoryTaskStoreOptions {
+  /**
+   * Maximum number of tasks to keep in memory.
+   * When exceeded, the oldest terminal-state tasks are evicted first.
+   * Defaults to unlimited (no cap).
+   */
+  maxSize?: number;
+
+  /**
+   * Time-to-live in milliseconds for tasks that reach a terminal state
+   * (completed, failed, canceled, rejected). After this duration the task
+   * is automatically removed on the next access or sweep.
+   * Defaults to unlimited (no expiry).
+   */
+  ttlMs?: number;
+}
+
 // ─── InMemoryTaskStore ───
 
 export class InMemoryTaskStore implements TaskStore {
   private readonly tasks = new Map<string, Task>();
+  private readonly terminalTimestamps = new Map<string, number>();
+  private readonly maxSize: number | undefined;
+  private readonly ttlMs: number | undefined;
+
+  constructor(options?: InMemoryTaskStoreOptions) {
+    this.maxSize = options?.maxSize;
+    this.ttlMs = options?.ttlMs;
+  }
 
   async createTask(params: CreateTaskParams): Promise<Task> {
+    this._evictExpired();
+    this._evictIfOverCapacity();
+
     const taskId = randomUUID();
     const task: Task = {
       id: taskId,
@@ -51,10 +81,13 @@ export class InMemoryTaskStore implements TaskStore {
   }
 
   async getTask(taskId: string): Promise<Task | null> {
+    this._evictIfExpired(taskId);
     return this.tasks.get(taskId) ?? null;
   }
 
   async updateTask(taskId: string, update: TaskUpdate): Promise<Task> {
+    this._evictIfExpired(taskId);
+
     const task = this.tasks.get(taskId);
     if (!task) {
       throw new Error(`Task not found: ${taskId}`);
@@ -80,11 +113,61 @@ export class InMemoryTaskStore implements TaskStore {
       task.metadata = { ...task.metadata, ...update.metadata };
     }
 
+    // Track when a task enters a terminal state for TTL eviction
+    if (update.status && TERMINAL_STATES.has(update.status.state)) {
+      this.terminalTimestamps.set(taskId, Date.now());
+    }
+
     this.tasks.set(taskId, task);
     return task;
   }
 
   async deleteTask(taskId: string): Promise<void> {
     this.tasks.delete(taskId);
+    this.terminalTimestamps.delete(taskId);
+  }
+
+  /** Number of tasks currently stored. */
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  // ─── Private: Eviction ───
+
+  /** Remove a single task if it has expired. */
+  private _evictIfExpired(taskId: string): void {
+    if (this.ttlMs === undefined) return;
+    const enteredAt = this.terminalTimestamps.get(taskId);
+    if (enteredAt !== undefined && Date.now() - enteredAt >= this.ttlMs) {
+      this.tasks.delete(taskId);
+      this.terminalTimestamps.delete(taskId);
+    }
+  }
+
+  /** Sweep all expired terminal tasks. */
+  private _evictExpired(): void {
+    if (this.ttlMs === undefined) return;
+    const now = Date.now();
+    for (const [taskId, enteredAt] of this.terminalTimestamps) {
+      if (now - enteredAt >= this.ttlMs) {
+        this.tasks.delete(taskId);
+        this.terminalTimestamps.delete(taskId);
+      }
+    }
+  }
+
+  /** Evict oldest terminal tasks if over maxSize. */
+  private _evictIfOverCapacity(): void {
+    if (this.maxSize === undefined || this.tasks.size < this.maxSize) return;
+
+    // Collect terminal tasks sorted by entry time (oldest first)
+    const terminalEntries = [...this.terminalTimestamps.entries()]
+      .sort((a, b) => a[1] - b[1]);
+
+    for (const [taskId] of terminalEntries) {
+      if (this.tasks.size < this.maxSize) break;
+      this.tasks.delete(taskId);
+      this.terminalTimestamps.delete(taskId);
+    }
   }
 }


### PR DESCRIPTION
## Summary

`InMemoryTaskStore` previously accumulated tasks indefinitely with no cleanup mechanism, leading to guaranteed OOM in long-running services.

### Changes

Add optional `ttlMs` and `maxSize` to `InMemoryTaskStoreOptions`:

```typescript
const store = new InMemoryTaskStore({
  ttlMs: 30 * 60 * 1000,  // evict completed tasks after 30 min
  maxSize: 10000,          // cap at 10k tasks
});
```

| Option | Behavior |
|--------|----------|
| `ttlMs` | Terminal-state tasks (completed/failed/canceled/rejected) are auto-evicted after this duration |
| `maxSize` | When exceeded, oldest terminal tasks are evicted first on next `createTask` |

### Design decisions

- **Lazy eviction** — no background timers. Sweep runs on `createTask`, per-key check on `getTask`
- **Non-terminal tasks are never evicted** — in-progress work is always preserved
- **Backwards compatible** — default behavior (no options) is unchanged; existing code works without modification
- **`TaskStore` interface unchanged** — only the `InMemoryTaskStore` implementation is affected

## Test plan

- [x] TTL: terminal task evicted after ttlMs on `getTask`
- [x] TTL: non-terminal task survives regardless of time
- [x] TTL: expired tasks swept on `createTask`
- [x] TTL: no eviction when options not set
- [x] maxSize: oldest terminal task evicted when capacity exceeded
- [x] maxSize: non-terminal tasks preserved even when over capacity
- [x] Combined TTL + maxSize interaction
- [x] All existing tests pass unchanged (221 total)
- [x] Lint, typecheck, and build pass