### PR TITLE
fix: pass RequestContext to handler in toA2x() built-in server

### DIFF
--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -13,6 +13,7 @@ import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { A2XAgent } from '../a2x/a2x-agent.js';
 import { DefaultRequestHandler } from './request-handler.js';
 import { createSSEStream } from './sse-handler.js';
+import type { RequestContext } from '../types/auth.js';
 
 export interface ToA2xOptions {
   port?: number;
@@ -135,7 +136,11 @@ export function toA2x(
 
           try {
             const parsed = JSON.parse(body);
-            const result = await handler.handle(parsed);
+            const context: RequestContext = {
+              headers: req.headers as Record<string, string | string[] | undefined>,
+              query: Object.fromEntries(parsedUrl.searchParams.entries()),
+            };
+            const result = await handler.handle(parsed, context);
 
             // Streaming → AsyncGenerator → SSE
             if (


### PR DESCRIPTION
## Summary

Closes #18

The built-in HTTP server created by `toA2x().listen()` was calling `handler.handle(parsed)` without a `RequestContext`, causing all authentication to be silently bypassed even when `securitySchemes` and `securityRequirements` were configured.

### Before

```typescript
const result = await handler.handle(parsed);
//                                         ^ no context — auth skipped
```

### After

```typescript
const context: RequestContext = {
  headers: req.headers,
  query: Object.fromEntries(parsedUrl.searchParams.entries()),
};
const result = await handler.handle(parsed, context);
```

This matches the pattern already used in the Express and Next.js samples.

## Test plan

- [x] All 214 existing tests pass
- [x] Lint, typecheck, and build pass