### PR TITLE
fix: propagate AbortSignal so cancel() actually stops agent execution

### DIFF
--- a/packages/a2x/src/__tests__/agent-executor-cancel.test.ts
+++ b/packages/a2x/src/__tests__/agent-executor-cancel.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent } from '../agent/base-agent.js';
+import type { AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+import { TaskState } from '../types/task.js';
+import type { Task } from '../types/task.js';
+
+// ─── Slow agent that yields multiple events with delays ───
+
+class SlowAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'slow-agent', description: 'Agent that checks abort signal' });
+  }
+
+  async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
+    for (let i = 0; i < 10; i++) {
+      // Check abort signal before each iteration (same pattern as LlmAgent)
+      if (context.signal?.aborted) return;
+
+      yield { type: 'text', text: `chunk-${i}`, role: 'agent' };
+
+      // Small delay to simulate work
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    yield { type: 'done' };
+  }
+}
+
+function createTask(): Task {
+  return {
+    id: 'test-task-1',
+    contextId: 'ctx-1',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  };
+}
+
+function createExecutor(): AgentExecutor {
+  const agent = new SlowAgent();
+  const runner = new InMemoryRunner({ agent, appName: 'test' });
+  return new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+}
+
+const testMessage = {
+  messageId: 'msg-1',
+  role: 'user' as const,
+  parts: [{ text: 'hello' }],
+};
+
+describe('AgentExecutor cancel / abort', () => {
+  it('cancel() should abort a running execute() and stop yielding events', async () => {
+    const executor = createExecutor();
+    const task = createTask();
+
+    // Start execution in background
+    const executePromise = executor.execute(task, testMessage);
+
+    // Give the agent a moment to start producing events
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Cancel mid-flight
+    await executor.cancel(task);
+
+    const result = await executePromise;
+
+    // Task should be in canceled state (set by cancel())
+    expect(result.status.state).toBe(TaskState.CANCELED);
+  });
+
+  it('cancel() should abort a running executeStream() and stop yielding events', async () => {
+    const executor = createExecutor();
+    const task = createTask();
+
+    const events: unknown[] = [];
+    const stream = executor.executeStream(task, testMessage);
+
+    // Collect events with a race: cancel after a short delay
+    const cancelAfterDelay = new Promise<void>((resolve) => {
+      setTimeout(async () => {
+        await executor.cancel(task);
+        resolve();
+      }, 30);
+    });
+
+    // Consume events until generator ends or cancel takes effect
+    const consume = (async () => {
+      for await (const event of stream) {
+        events.push(event);
+      }
+    })();
+
+    await Promise.all([cancelAfterDelay, consume]);
+
+    // Should have received SOME events but NOT all 10 text chunks + done
+    // (SlowAgent yields 10 chunks with 10ms delay each = 100ms total,
+    //  we cancel at 30ms so we should get only a few)
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.length).toBeLessThan(12); // 10 texts + done + working = 12 max
+  });
+
+  it('cancel() on non-running task should just set status', async () => {
+    const executor = createExecutor();
+    const task = createTask();
+
+    // Cancel without ever executing
+    const result = await executor.cancel(task);
+    expect(result.status.state).toBe(TaskState.CANCELED);
+  });
+
+  it('abort signal should be passed through to InvocationContext', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    class SignalCapturingAgent extends BaseAgent {
+      constructor() {
+        super({ name: 'signal-capture', description: 'Captures signal' });
+      }
+      async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
+        receivedSignal = context.signal;
+        yield { type: 'done' };
+      }
+    }
+
+    const agent = new SignalCapturingAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const executor = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.NONE },
+    });
+
+    const task = createTask();
+    await executor.execute(task, testMessage);
+
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal!.aborted).toBe(false);
+  });
+
+  it('abort signal should be aborted after cancel()', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    class HangingAgent extends BaseAgent {
+      constructor() {
+        super({ name: 'hanging', description: 'Hangs until aborted' });
+      }
+      async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
+        receivedSignal = context.signal;
+        // Wait until aborted
+        while (!context.signal?.aborted) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        yield { type: 'done' };
+      }
+    }
+
+    const agent = new HangingAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const executor = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.NONE },
+    });
+
+    const task = createTask();
+
+    // Start in background
+    const executePromise = executor.execute(task, testMessage);
+
+    // Wait for agent to start
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Cancel
+    await executor.cancel(task);
+
+    await executePromise;
+
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal!.aborted).toBe(true);
+  });
+});

--- a/packages/a2x/src/a2x/agent-executor.ts
+++ b/packages/a2x/src/a2x/agent-executor.ts
@@ -35,6 +35,7 @@ export interface AgentExecutorOptions {
 export class AgentExecutor {
   readonly runner: Runner;
   readonly runConfig: RunConfig;
+  private readonly _abortControllers = new Map<string, AbortController>();
 
   constructor(options: AgentExecutorOptions) {
     this.runner = options.runner;
@@ -48,6 +49,8 @@ export class AgentExecutor {
   async execute(task: Task, message: Message): Promise<Task> {
     // Create or retrieve session
     const session = await this.runner.createSession();
+    const abortController = new AbortController();
+    this._abortControllers.set(task.id, abortController);
 
     // Update task status to working
     task.status = {
@@ -59,7 +62,7 @@ export class AgentExecutor {
     const textParts: string[] = [];
 
     try {
-      for await (const event of this.runner.runAsync(session, message)) {
+      for await (const event of this.runner.runAsync(session, message, abortController.signal)) {
         switch (event.type) {
           case 'text':
             textParts.push(event.text);
@@ -87,13 +90,15 @@ export class AgentExecutor {
         }
       }
 
-      // Set completed status
-      task.status = {
-        state: TaskState.COMPLETED,
-        timestamp: new Date().toISOString(),
-      };
-      if (artifacts.length > 0) {
-        task.artifacts = artifacts;
+      // Set completed status (unless aborted by cancel)
+      if (!abortController.signal.aborted) {
+        task.status = {
+          state: TaskState.COMPLETED,
+          timestamp: new Date().toISOString(),
+        };
+        if (artifacts.length > 0) {
+          task.artifacts = artifacts;
+        }
       }
     } catch (error) {
       task.status = {
@@ -112,6 +117,8 @@ export class AgentExecutor {
         },
         timestamp: new Date().toISOString(),
       };
+    } finally {
+      this._abortControllers.delete(task.id);
     }
 
     return task;
@@ -128,6 +135,8 @@ export class AgentExecutor {
 
     // Create session
     const session = await this.runner.createSession();
+    const abortController = new AbortController();
+    this._abortControllers.set(task.id, abortController);
 
     // Emit working status
     task.status = {
@@ -143,7 +152,7 @@ export class AgentExecutor {
     try {
       const textParts: string[] = [];
 
-      for await (const event of this.runner.runAsync(session, message)) {
+      for await (const event of this.runner.runAsync(session, message, abortController.signal)) {
         switch (event.type) {
           case 'text':
             textParts.push(event.text);
@@ -230,13 +239,22 @@ export class AgentExecutor {
         contextId,
         status: task.status,
       } satisfies TaskStatusUpdateEvent;
+    } finally {
+      this._abortControllers.delete(task.id);
     }
   }
 
   /**
-   * Cancel a running task.
+   * Cancel a running task. Aborts in-flight agent execution if running.
    */
   async cancel(task: Task): Promise<Task> {
+    // Abort the running execution
+    const controller = this._abortControllers.get(task.id);
+    if (controller) {
+      controller.abort();
+      this._abortControllers.delete(task.id);
+    }
+
     task.status = {
       state: TaskState.CANCELED,
       timestamp: new Date().toISOString(),

--- a/packages/a2x/src/agent/llm-agent.ts
+++ b/packages/a2x/src/agent/llm-agent.ts
@@ -138,6 +138,9 @@ export class LlmAgent extends BaseAgent {
 
     // 4. LLM call loop
     while (llmCallCount < maxCalls) {
+      // Check for abort before each LLM call
+      if (context.signal?.aborted) return;
+
       // Build LlmRequest
       const llmRequest: LlmRequest = {
         contents,
@@ -215,6 +218,9 @@ export class LlmAgent extends BaseAgent {
       const toolResults: { id: string; name: string; result: unknown }[] = [];
 
       for (const toolCall of response.toolCalls) {
+        // Check for abort before each tool execution
+        if (context.signal?.aborted) return;
+
         yield { type: 'toolCall', toolName: toolCall.name, args: toolCall.args, toolCallId: toolCall.id };
 
         const tool = this.tools.find((t) => t.name === toolCall.name);

--- a/packages/a2x/src/runner/context.ts
+++ b/packages/a2x/src/runner/context.ts
@@ -25,4 +25,5 @@ export interface InvocationContext {
   agentName: string;
   plugins?: BasePlugin[];
   maxLlmCalls?: number;
+  signal?: AbortSignal;
 }

--- a/packages/a2x/src/runner/runner.ts
+++ b/packages/a2x/src/runner/runner.ts
@@ -36,7 +36,7 @@ export class Runner {
   /**
    * Run the agent asynchronously, yielding AgentEvents.
    */
-  async *runAsync(session: Session, message: Message): AsyncGenerator<AgentEvent> {
+  async *runAsync(session: Session, message: Message, signal?: AbortSignal): AsyncGenerator<AgentEvent> {
     // Store the incoming message in session events with user role
     session.events.push({ type: 'text', text: message.parts.map(p => ('text' in p ? p.text : '')).join(''), role: 'user' });
     await this.sessionService.updateSession(session);
@@ -47,10 +47,12 @@ export class Runner {
       state: session.state,
       agentName: this.agent.name,
       plugins: this.plugins,
+      signal,
     };
 
     // Run the agent and yield events
     for await (const event of this.agent.run(context)) {
+      if (signal?.aborted) return;
       session.events.push(event);
       yield event;
     }


### PR DESCRIPTION
## Summary

Closes #19

`AgentExecutor.cancel()` previously only changed the task status to `CANCELED` without stopping in-flight LLM calls or tool executions. The agent loop would continue running (up to 25 LLM calls) wasting API costs and server resources.

### How it works now

```
cancel(task)
  └─ AbortController.abort()
       ├─ Runner.runAsync() checks signal.aborted → stops yielding
       └─ LlmAgent.run() checks signal.aborted → exits loop
            ├─ before each LLM provider call
            └─ before each tool execution
```

### Changes

| File | Change |
|------|--------|
| `runner/context.ts` | Add optional `signal?: AbortSignal` to `InvocationContext` |
| `runner/runner.ts` | Accept `signal` param in `runAsync()`, pass to context, check before yield |
| `agent/llm-agent.ts` | Check `context.signal?.aborted` before each LLM call and tool execution |
| `a2x/agent-executor.ts` | Create `AbortController` per task, `cancel()` calls `abort()`, preserve CANCELED status |

### Backwards compatible

- `signal` is optional on `InvocationContext` — existing code unaffected
- `Runner.runAsync()` new `signal` param is optional
- Default behavior (no cancel) is unchanged

## Test plan

- [x] cancel() aborts running `execute()` and preserves CANCELED status
- [x] cancel() aborts running `executeStream()` and stops event production
- [x] cancel() on non-running task just sets status (no crash)
- [x] AbortSignal is passed through to InvocationContext
- [x] AbortSignal is aborted after cancel() call
- [x] All 219 tests pass (214 existing + 5 new)
- [x] Lint, typecheck, and build pass