### PR TITLE
fix(cli): send client_id in OAuth2 Device Code flow

### DIFF
--- a/packages/cli/src/cli-auth-provider.ts
+++ b/packages/cli/src/cli-auth-provider.ts
@@ -71,6 +71,8 @@ interface TokenErrorResponse {
   error_description?: string;
 }
 
+const CLI_CLIENT_ID = 'a2x-cli';
+
 async function performDeviceCodeFlow(
   scheme: OAuth2DeviceCodeAuthScheme,
 ): Promise<string> {
@@ -82,6 +84,7 @@ async function performDeviceCodeFlow(
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
+      client_id: CLI_CLIENT_ID,
       ...(scopeStr ? { scope: scopeStr } : {}),
     }),
   });
@@ -123,6 +126,7 @@ async function performDeviceCodeFlow(
       body: new URLSearchParams({
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
         device_code: deviceData.device_code,
+        client_id: CLI_CLIENT_ID,
       }),
     });
 


### PR DESCRIPTION
## Summary
- Add `client_id` (`a2x-cli`) to the device authorization request — required by RFC 8628 §3.1
- Add `client_id` to the token polling request — required by RFC 8628 §3.4 for public clients
- Without this, spec-compliant servers reject the flow with HTTP 400 (`invalid_request: client_id is required`)

Closes #24

## Test plan
- [x] `pnpm typecheck` passes in `packages/cli`
- [ ] Manual: `a2x a2a send https://a2x-sample-nextjs.fly.dev/.well-known/agent.json "hi"` reaches the verification URL instead of failing at the device authorization step
- [ ] Manual: token polling returns `access_token` and CLI prints `Authorized!`

## Follow-up (not in this PR)
Per the issue's SDK-side recommendation, extending `OAuth2DeviceCodeAuthScheme` with an optional `clientId` parameter so the agent card can advertise a per-agent expected client identifier will be handled in a separate PR.