### PR TITLE
feat(a2x): emit OAuth2 Device Code flow on v0.3 AgentCards

### DIFF
--- a/.changeset/device-code-v03-extension.md
+++ b/.changeset/device-code-v03-extension.md
@@ -1,0 +1,16 @@
+---
+'@a2x/sdk': minor
+---
+
+Emit and consume OAuth2 Device Code flow as a non-standard extension on A2A
+v0.3 AgentCards.
+
+Previously, `OAuth2DeviceCodeAuthorization.toV03Schema()` returned `null` and
+the scheme was silently stripped from v0.3 cards — headless/CLI clients that
+rely on device code flow could not negotiate against v0.3 peers even though
+both sides already supported it internally.
+
+The scheme now emits `oauth2.flows.deviceCode` on v0.3 cards (mirroring the
+v1.0 shape) and `normalizeOAuth2FlowsV03()` consumes it. OpenAPI 3.0 does
+not standardize this flow, so a warning is still logged on emission and
+strict third-party v0.3 parsers may ignore the unknown flow.

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -277,7 +277,7 @@ describe('Layer 3: A2XAgent', () => {
       expect(card.skills[0].security).toEqual([{ api_key: [] }]);
     });
 
-    it('should exclude DeviceCode scheme from v0.3 with warning', () => {
+    it('should emit DeviceCode as non-standard v0.3 extension with warning', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const a2x = createA2XAgent();
       a2x
@@ -292,8 +292,20 @@ describe('Layer 3: A2XAgent', () => {
         );
 
       const card = a2x.getAgentCard('0.3') as AgentCardV03;
-      expect(card.securitySchemes).toBeUndefined();
-      expect(warnSpy).toHaveBeenCalled();
+      expect(card.securitySchemes).toBeDefined();
+      expect(card.securitySchemes!['device']).toEqual({
+        type: 'oauth2',
+        flows: {
+          deviceCode: {
+            deviceAuthorizationUrl: 'https://auth.example.com/device',
+            tokenUrl: 'https://auth.example.com/token',
+            scopes: { read: 'Read' },
+          },
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('non-standard extension'),
+      );
       warnSpy.mockRestore();
     });
   });

--- a/packages/a2x/src/__tests__/client-auth.test.ts
+++ b/packages/a2x/src/__tests__/client-auth.test.ts
@@ -260,6 +260,53 @@ describe('normalizeScheme', () => {
       expect(result[1]).toBeInstanceOf(OAuth2ClientCredentialsAuthScheme);
     });
 
+    it('normalizes oauth2 deviceCode flow as non-standard v0.3 extension', () => {
+      const raw: SecuritySchemeV03 = {
+        type: 'oauth2',
+        flows: {
+          deviceCode: {
+            deviceAuthorizationUrl: 'http://auth/device',
+            tokenUrl: 'http://auth/token',
+            scopes: { 'agent:invoke': 'Invoke' },
+            refreshUrl: 'http://auth/refresh',
+          },
+        },
+      };
+      const result = normalizeScheme(raw);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(OAuth2DeviceCodeAuthScheme);
+      expect((result[0] as OAuth2DeviceCodeAuthScheme).params).toEqual({
+        deviceAuthorizationUrl: 'http://auth/device',
+        tokenUrl: 'http://auth/token',
+        scopes: { 'agent:invoke': 'Invoke' },
+        refreshUrl: 'http://auth/refresh',
+      });
+    });
+
+    it('normalizes oauth2 with deviceCode alongside a standard flow', () => {
+      const raw: SecuritySchemeV03 = {
+        type: 'oauth2',
+        flows: {
+          deviceCode: {
+            deviceAuthorizationUrl: 'http://auth/device',
+            tokenUrl: 'http://auth/token',
+            scopes: {},
+          },
+          authorizationCode: {
+            authorizationUrl: 'http://auth/authorize',
+            tokenUrl: 'http://auth/token',
+            scopes: {},
+          },
+        },
+      };
+      const result = normalizeScheme(raw);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(OAuth2DeviceCodeAuthScheme);
+      expect(result[1]).toBeInstanceOf(OAuth2AuthorizationCodeAuthScheme);
+    });
+
     it('normalizes openIdConnect scheme', () => {
       const raw: SecuritySchemeV03 = { type: 'openIdConnect', openIdConnectUrl: 'http://auth/.well-known' };
       const result = normalizeScheme(raw);

--- a/packages/a2x/src/__tests__/security.test.ts
+++ b/packages/a2x/src/__tests__/security.test.ts
@@ -169,14 +169,45 @@ describe('Layer 1: SecurityScheme Classes', () => {
       scopes: { read: 'Read' },
     };
 
-    it('toV03Schema should return null and emit warning', () => {
+    it('toV03Schema emits deviceCode as non-standard extension and warns', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const scheme = new OAuth2DeviceCodeAuthorization({
+        ...opts,
+        refreshUrl: 'https://auth.example.com/refresh',
+        description: 'Device flow',
+      });
+      const v03 = scheme.toV03Schema();
+      expect(v03).toEqual({
+        type: 'oauth2',
+        flows: {
+          deviceCode: {
+            deviceAuthorizationUrl: opts.deviceAuthorizationUrl,
+            tokenUrl: opts.tokenUrl,
+            scopes: opts.scopes,
+            refreshUrl: 'https://auth.example.com/refresh',
+          },
+        },
+        description: 'Device flow',
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('non-standard extension'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('toV03Schema omits refreshUrl and description when not provided', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const scheme = new OAuth2DeviceCodeAuthorization(opts);
-      const v03 = scheme.toV03Schema();
-      expect(v03).toBeNull();
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('not supported in A2A v0.3'),
-      );
+      const v03 = scheme.toV03Schema() as Extract<
+        ReturnType<typeof scheme.toV03Schema>,
+        { type: 'oauth2' }
+      >;
+      expect(v03.flows.deviceCode).toEqual({
+        deviceAuthorizationUrl: opts.deviceAuthorizationUrl,
+        tokenUrl: opts.tokenUrl,
+        scopes: opts.scopes,
+      });
+      expect('description' in v03).toBe(false);
       warnSpy.mockRestore();
     });
 

--- a/packages/a2x/src/a2x/v03-mapper.ts
+++ b/packages/a2x/src/a2x/v03-mapper.ts
@@ -119,8 +119,8 @@ export class V03AgentCardMapper implements AgentCardMapper<AgentCardV03> {
       if (v03Schema !== null) {
         schemes[name] = v03Schema;
       }
-      // If null, the scheme is not supported in v0.3 (e.g., DeviceCode).
-      // Warning already emitted by the scheme's toV03Schema().
+      // If null, the scheme has no v0.3 representation; the scheme's
+      // toV03Schema() is expected to have emitted a warning.
     }
 
     return Object.keys(schemes).length > 0 ? schemes : undefined;

--- a/packages/a2x/src/client/auth-normalizer.ts
+++ b/packages/a2x/src/client/auth-normalizer.ts
@@ -171,7 +171,18 @@ function normalizeOAuth2FlowsV03(
 ): AuthScheme[] {
   const result: AuthScheme[] = [];
 
-  // v0.3 spec does not define deviceCode flow
+  // `deviceCode` is a non-standard extension on v0.3. `@a2x/sdk` emits it
+  // alongside standard flows, so consume it the same way v1.0 does.
+  if (flows.deviceCode) {
+    result.push(
+      new OAuth2DeviceCodeAuthScheme(
+        flows.deviceCode.deviceAuthorizationUrl,
+        flows.deviceCode.tokenUrl,
+        flows.deviceCode.scopes ?? {},
+        flows.deviceCode.refreshUrl,
+      ),
+    );
+  }
 
   if (flows.authorizationCode) {
     result.push(

--- a/packages/a2x/src/security/oauth2-device-code.ts
+++ b/packages/a2x/src/security/oauth2-device-code.ts
@@ -1,9 +1,15 @@
 /**
  * Layer 1: OAuth2DeviceCodeAuthorization security scheme.
- * Note: v0.3 does not support deviceCode flow. toV03Schema() returns null.
+ *
+ * A2A v0.3 (OpenAPI 3.0 based) does not standardize a deviceCode flow, but
+ * also does not prohibit vendor extensions inside `oauth2.flows`. toV03Schema()
+ * emits `deviceCode` as a non-standard extension so `@a2x/sdk` clients can
+ * negotiate the flow against v0.3 peers. Strict third-party parsers will
+ * typically ignore the unknown flow and fall back to other configured flows.
  */
 
 import type {
+  DeviceCodeFlowV03,
   DeviceCodeFlowV10,
   SecuritySchemeV03,
   SecuritySchemeV10,
@@ -54,14 +60,25 @@ export class OAuth2DeviceCodeAuthorization extends BaseSecurityScheme {
   }
 
   /**
-   * v0.3 does not support Device Code flow.
-   * Returns null; the caller (Mapper) should exclude this scheme from v0.3 AgentCard.
+   * Emits the Device Code flow on a v0.3 AgentCard as a non-standard extension.
+   * OpenAPI 3.0 does not define `oauth2.flows.deviceCode`, so strict third-party
+   * v0.3 parsers may ignore this flow. `@a2x/sdk` clients consume it natively.
    */
-  toV03Schema(): SecuritySchemeV03 | null {
+  toV03Schema(): SecuritySchemeV03 {
     console.warn(
-      'OAuth2DeviceCodeAuthorization: Device Code flow is not supported in A2A v0.3. This scheme will be excluded from the v0.3 AgentCard.',
+      'OAuth2DeviceCodeAuthorization: Device Code flow is emitted as a non-standard extension on the v0.3 AgentCard. Strict third-party v0.3 parsers may ignore it.',
     );
-    return null;
+    const flow: DeviceCodeFlowV03 = {
+      deviceAuthorizationUrl: this.deviceAuthorizationUrl,
+      tokenUrl: this.tokenUrl,
+      scopes: this.scopes,
+      ...(this.refreshUrl ? { refreshUrl: this.refreshUrl } : {}),
+    };
+    return {
+      type: 'oauth2',
+      flows: { deviceCode: flow },
+      ...(this.description ? { description: this.description } : {}),
+    };
   }
 
   toV10Schema(): SecuritySchemeV10 {

--- a/packages/a2x/src/types/security.ts
+++ b/packages/a2x/src/types/security.ts
@@ -24,6 +24,13 @@ export type SecuritySchemeV03 =
 export interface OAuthFlowsV03 {
   authorizationCode?: AuthorizationCodeFlowV03;
   clientCredentials?: ClientCredentialsFlowV03;
+  /**
+   * Non-standard extension: OpenAPI 3.0 (and therefore A2A v0.3) does not define
+   * a `deviceCode` flow. `@a2x/sdk` emits and consumes this key to bridge the
+   * compatibility gap for headless/CLI clients that still talk to v0.3 peers.
+   * Third-party v0.3 implementations may ignore an unknown flow.
+   */
+  deviceCode?: DeviceCodeFlowV03;
   implicit?: ImplicitFlowV03;
   password?: PasswordFlowV03;
 }
@@ -36,6 +43,13 @@ export interface AuthorizationCodeFlowV03 {
 }
 
 export interface ClientCredentialsFlowV03 {
+  tokenUrl: string;
+  scopes: Record<string, string>;
+  refreshUrl?: string;
+}
+
+export interface DeviceCodeFlowV03 {
+  deviceAuthorizationUrl: string;
   tokenUrl: string;
   scopes: Record<string, string>;
   refreshUrl?: string;


### PR DESCRIPTION
## Summary

- `OAuth2DeviceCodeAuthorization.toV03Schema()` now emits
  `oauth2.flows.deviceCode` as a non-standard extension instead of returning
  `null` and being silently stripped from the v0.3 AgentCard.
- `normalizeOAuth2FlowsV03()` picks up the same key, so `@a2x/sdk`
  clients can negotiate device code flow against v0.3 peers end-to-end.
- A warning is still logged on emission so operators understand strict
  third-party v0.3 parsers may ignore the unknown flow.

Closes #23.

## Why a non-standard extension

A2A v0.3's `SecurityScheme` is OpenAPI 3.0 shaped, and OpenAPI 3.0 does
not define a `deviceCode` flow. The alternative — downgrading device
code to a generic `http/bearer` scheme on v0.3 — drops the discovery
metadata (`deviceAuthorizationUrl`, `tokenUrl`, `scopes`) and forces
clients to learn those out-of-band, defeating AgentCard-based
negotiation. Headless agents, CLIs, and IoT-style clients realistically
need this flow, so we opt in operators who want it via the
`OAuth2DeviceCodeAuthorization` scheme they already pass in.

## Changes

- `packages/a2x/src/types/security.ts` — add optional `deviceCode?: DeviceCodeFlowV03` to `OAuthFlowsV03`; declare `DeviceCodeFlowV03`.
- `packages/a2x/src/security/oauth2-device-code.ts` — `toV03Schema()` populates `oauth2.flows.deviceCode` and refreshes the warning copy.
- `packages/a2x/src/client/auth-normalizer.ts` — v0.3 branch consumes `deviceCode` analogously to v1.0.
- `packages/a2x/src/a2x/v03-mapper.ts` — comment touch-up; still tolerates any scheme returning `null`.
- Tests updated in `security.test.ts`, `client-auth.test.ts`, `a2x-agent.test.ts` to cover v0.3 emission + consumption.
- Changeset: minor bump for `@a2x/sdk`.

## Compatibility

Strict superset of current v0.3 behavior — no existing card or client is
affected. Interop with third-party v0.3 parsers depends on their
tolerance for unknown flow keys; operators who need strict conformance
can continue to expose only standard flows.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 239 tests passing (added 4 new)
- [x] `pnpm build` passes
- [x] `pnpm lint` — only a pre-existing warning on `cli/bin-bundle/a2x.cjs`