### PR TITLE
ci: notify a2x-web docs site on successful SDK release

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -16,30 +16,26 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.A2X_WEB_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.A2X_WEB_DISPATCHER_PRIVATE_KEY }}
+          owner: planetarium
+          repositories: a2x-web
+
       - name: Send repository_dispatch to planetarium/a2x-web
         env:
-          DISPATCH_TOKEN: ${{ secrets.A2X_WEB_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.run_id }}
         run: |
-          if [ -z "$DISPATCH_TOKEN" ]; then
-            echo "::error::A2X_WEB_DISPATCH_TOKEN is not set"
-            exit 1
-          fi
-          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
-          RUN_ID="${{ github.event.workflow_run.id || github.run_id }}"
-          curl -fSsL -X POST \
-            -H "Authorization: token ${DISPATCH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/planetarium/a2x-web/dispatches \
-            -d "$(cat <<EOF
-          {
-            "event_type": "a2x-sdk-updated",
-            "client_payload": {
-              "sha": "${SHA}",
-              "run_id": "${RUN_ID}",
-              "source": "planetarium/a2x"
-            }
-          }
-          EOF
-          )"
+          gh api repos/planetarium/a2x-web/dispatches \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --raw-field event_type=a2x-sdk-updated \
+            --raw-field "client_payload[sha]=${SHA}" \
+            --raw-field "client_payload[run_id]=${RUN_ID}" \
+            --raw-field "client_payload[source]=planetarium/a2x"
           echo "Dispatched a2x-sdk-updated to planetarium/a2x-web"

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,45 @@
+name: Notify a2x-web
+
+on:
+  workflow_run:
+    workflows: ["Release SDK"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to planetarium/a2x-web
+        env:
+          DISPATCH_TOKEN: ${{ secrets.A2X_WEB_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "::error::A2X_WEB_DISPATCH_TOKEN is not set"
+            exit 1
+          fi
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          RUN_ID="${{ github.event.workflow_run.id || github.run_id }}"
+          curl -fSsL -X POST \
+            -H "Authorization: token ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/planetarium/a2x-web/dispatches \
+            -d "$(cat <<EOF
+          {
+            "event_type": "a2x-sdk-updated",
+            "client_payload": {
+              "sha": "${SHA}",
+              "run_id": "${RUN_ID}",
+              "source": "planetarium/a2x"
+            }
+          }
+          EOF
+          )"
+          echo "Dispatched a2x-sdk-updated to planetarium/a2x-web"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/notify-docs.yml` that listens for the `Release SDK` workflow completing on `main`.
- On success, fires a `repository_dispatch` event (`a2x-sdk-updated`) at the private `planetarium/a2x-web` repo, which installs the freshly published `@a2x/sdk@latest` from npm, regenerates TypeDoc-based API references, and redeploys the documentation site to Fly.io.
- Uses a **GitHub App installation token** (minted via `actions/create-github-app-token@v1`) — no long-lived PAT required.
- Supports `workflow_dispatch` for manual re-triggering and smoke tests.

## Required secrets before merge

On `planetarium/a2x`:

| Secret | Source |
|---|---|
| `A2X_WEB_DISPATCHER_APP_ID` | App ID of the `a2x-docs-dispatcher` GitHub App |
| `A2X_WEB_DISPATCHER_PRIVATE_KEY` | Contents of the downloaded `.pem` private-key file |

The App is installed only on `planetarium/a2x-web` with `Actions: Read and write` + `Metadata: Read-only` permissions.

## Test plan

- [ ] Merge this PR with both secrets present on `planetarium/a2x`.
- [ ] Trigger manually: `gh workflow run notify-docs.yml --repo planetarium/a2x`.
- [ ] Confirm a fresh `Deploy Docs` run (event = `repository_dispatch`) appears on `planetarium/a2x-web`.
- [ ] Publish the next SDK version and confirm https://a2x-web.fly.dev/ updates its version badge within ~3 minutes.