### PR TITLE
fix(cli): set restrictive file permissions on tokens.json

### DIFF
--- a/packages/cli/src/token-store.ts
+++ b/packages/cli/src/token-store.ts
@@ -30,7 +30,10 @@ function readStore(): StoreData {
 
 function writeStore(data: StoreData): void {
   fs.mkdirSync(STORE_DIR, { recursive: true });
-  fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2), 'utf-8');
+  fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
 }
 
 export function loadCredentials(agentUrl: string): StoredCredential[] | undefined {

--- a/packages/cli/src/token-store.ts
+++ b/packages/cli/src/token-store.ts
@@ -29,11 +29,12 @@ function readStore(): StoreData {
 }
 
 function writeStore(data: StoreData): void {
-  fs.mkdirSync(STORE_DIR, { recursive: true });
+  fs.mkdirSync(STORE_DIR, { recursive: true, mode: 0o700 });
   fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2), {
     encoding: 'utf-8',
     mode: 0o600,
   });
+  fs.chmodSync(STORE_PATH, 0o600);
 }
 
 export function loadCredentials(agentUrl: string): StoredCredential[] | undefined {


### PR DESCRIPTION
## Summary

Closes #32

`writeStore()` in `token-store.ts` was writing `~/.a2x/tokens.json` without setting file permissions, defaulting to umask (typically `0o644`, world-readable). This exposes stored credentials to other users on shared systems.

### Fix

Add `mode: 0o600` (owner read/write only), matching the pattern already used by `config.ts`.

```diff
- fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2), 'utf-8');
+ fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2), {
+   encoding: 'utf-8',
+   mode: 0o600,
+ });
```

## Test plan

- [x] Lint passes
- [x] Build passes