### PR TITLE
fix: remove updateTask() after cancel to avoid terminal state guard collision

### DIFF
--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -8,6 +8,7 @@ import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { LlmAgent } from '../agent/llm-agent.js';
 import { BaseLlmProvider } from '../provider/base.js';
 import { A2A_ERROR_CODES } from '../types/errors.js';
+import { TaskState } from '../types/task.js';
 import type { JSONRPCResponse, JSONRPCErrorResponse } from '../types/jsonrpc.js';
 import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
 import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
@@ -413,6 +414,46 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.TASK_NOT_FOUND,
       );
+    });
+
+    it('should cancel a working task without terminal state guard collision', async () => {
+      // Set up handler with access to taskStore
+      const agent = new LlmAgent({
+        name: 'test-agent',
+        provider: mockProvider,
+        description: 'A test agent',
+        instruction: 'You are a helpful assistant.',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.SSE },
+      });
+      const taskStore = new InMemoryTaskStore();
+      const a2xAgent = new A2XAgent({ taskStore, executor });
+      a2xAgent.setDefaultUrl('https://example.com/a2a');
+      const handler = new DefaultRequestHandler(a2xAgent);
+
+      // Create a task and set it to WORKING state directly
+      const task = await taskStore.createTask({});
+      await taskStore.updateTask(task.id, {
+        status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
+      });
+
+      // Cancel the WORKING task — this should NOT throw InternalError
+      // Before fix: cancel() mutated task to CANCELED, then updateTask()
+      // hit the terminal state guard and threw "Cannot update task in terminal state"
+      const cancelResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/cancel',
+        params: { id: task.id },
+      });
+
+      expect(isAsyncGenerator(cancelResponse)).toBe(false);
+      const rpc = cancelResponse as JSONRPCResponse;
+      expect('error' in rpc).toBe(false);
+      expect('result' in rpc).toBe(true);
     });
   });
 

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -378,10 +378,6 @@ export class DefaultRequestHandler {
 
     const canceledTask = await this.a2xAgent.agentExecutor.cancel(task);
 
-    await this.a2xAgent.taskStore.updateTask(task.id, {
-      status: canceledTask.status,
-    });
-
     return this.responseMapper.mapTask(canceledTask);
   }
 


### PR DESCRIPTION
## Summary

Closes #34

`tasks/cancel` on a running task always returned `InternalError (-32603)` instead of the canceled task.

### Root cause

`cancel()` directly mutates the task object's status to `CANCELED`. Since `InMemoryTaskStore` holds the same object reference in its `Map`, the subsequent `updateTask()` call sees the task already in a terminal state and throws:

```
cancel(task)      → task.status = "canceled" (same reference in Map)
updateTask(task)  → guard: TERMINAL_STATES.has("canceled") → 💥 throw
```

### Fix

Remove the redundant `updateTask()` call from `_handleCancelTask()`. The state change is already persisted through the shared object reference.

## Test plan

- [x] New test: cancel a WORKING task returns success (not InternalError)
- [x] Existing test: cancel non-existent task returns TaskNotFound
- [x] All 245 tests pass
- [x] Lint and build pass