### PR TITLE
docs: bundle Guides directory with the SDK

### DIFF
--- a/.changeset/initial-guides-docs.md
+++ b/.changeset/initial-guides-docs.md
@@ -1,0 +1,11 @@
+---
+"@a2x/sdk": minor
+---
+
+Bundle a Guides directory (`docs/`) with the npm package. The new tree under
+`node_modules/@a2x/sdk/docs/` contains progressive-disclosure guides (Getting
+Started → Agent → Client → Advanced) plus a `manifest.json` describing the
+navigation. The `a2x-web` documentation site consumes these files at build
+time so guides stay version-locked to the SDK that introduced them.
+
+No API surface change; this release only enlarges the published tarball.

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -1,0 +1,67 @@
+# AgentCard v0.3 vs v1.0
+
+A2A has two spec versions in active use. The **AgentCard** — the JSON your agent serves at `/.well-known/agent.json` — differs in shape between them. A2X hides most of the difference behind a single `A2XAgent` instance that can emit either version.
+
+You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` default to **v1.0**. If a client specifically asks for v0.3 (via `Accept` header or protocol negotiation), A2X transparently emits the v0.3 shape from the same underlying state.
+
+## The key differences
+
+| Concept | v0.3 | v1.0 |
+|---|---|---|
+| Where the endpoint URL lives | top-level `url` | `supportedInterfaces[].url` |
+| Transport selection | `preferredTransport` string | `supportedInterfaces[].protocolBinding` |
+| Security declarations | `security` array + `securitySchemes` map | `securityRequirements` array + `securitySchemes` map |
+| Multiple transports on one agent | not supported | supported via multiple `supportedInterfaces` |
+
+A2X models everything internally in the v1.0 shape and down-converts to v0.3 on demand. This means:
+
+- Every declaration you make on `A2XAgent` (skills, security, default URL) works for both versions.
+- Consumers on either spec see a valid card.
+- You don't write version branches in your own code.
+
+## Emitting a specific version
+
+```ts
+const v10 = a2xAgent.getAgentCard();          // v1.0 (default)
+const v03 = a2xAgent.getAgentCard('0.3');      // v0.3 explicit
+```
+
+Both paths are pre-wired when you use `toA2x()` or `DefaultRequestHandler` — callers negotiating over HTTP get the version they asked for.
+
+## When this matters to you
+
+Three scenarios where you actually need to care:
+
+### 1. Deploying alongside legacy v0.3 clients
+
+If you have CLI tools or third-party agents still pinned to v0.3, they read `url` and `preferredTransport` — not `supportedInterfaces`. A2X's v0.3 emission handles this automatically.
+
+### 2. Emitting a non-standard scheme on v0.3
+
+OAuth 2.0 Device Code is a v1.0-native security flow. A2X extends it onto v0.3 cards as a non-standard extension so headless clients can still negotiate it. See [Protocol Extensions](./extensions.md) for details.
+
+### 3. Multi-transport agents
+
+If you plan to expose JSON-RPC over HTTP **and** another transport (e.g. gRPC), only v1.0 expresses this cleanly. Legacy v0.3 consumers will only see the first/primary interface.
+
+## Consuming: what `A2XClient` does
+
+On the client side, `A2XClient` reads the remote card's `protocolVersion` field (or infers v0.3 when absent) and routes calls accordingly. You usually don't need to pick a version yourself:
+
+```ts
+const resolved = await client.resolveAgentCard();
+console.log(resolved.version);   // '0.3' | '1.0'
+console.log(resolved.card);      // the parsed card for that version
+```
+
+To force a preference when the remote supports both:
+
+```ts
+const client = new A2XClient(url, { preferredVersion: '1.0' });
+```
+
+## Recommendation
+
+- **Serve v1.0 as primary**, let A2X down-convert for v0.3 consumers. This is the default; you don't have to do anything.
+- **Pin your own clients to v1.0** when calling agents that support both. Future-facing.
+- **Only override defaults** when you need cross-version compatibility for a specific deployment target.

--- a/packages/a2x/docs/guides/advanced/authentication.md
+++ b/packages/a2x/docs/guides/advanced/authentication.md
@@ -1,0 +1,186 @@
+# Authentication
+
+A2X ships adapters for the auth schemes A2A defines plus OpenID Connect and Mutual TLS. This guide walks each scheme, how to declare it on the server, and how the client sees it.
+
+## Declaring auth on the server
+
+Every scheme follows the same two-step pattern:
+
+1. Register the scheme with `a2xAgent.addSecurityScheme(id, scheme)`. This publishes it on the AgentCard so clients know what to expect.
+2. Add a `SecurityRequirement` with `a2xAgent.addSecurityRequirement({ id: [] })` to enforce it.
+
+Multiple requirements act as **OR** (any satisfies); multiple schemes inside one requirement act as **AND** (all required).
+
+```ts
+a2xAgent
+  .addSecurityScheme('apiKey', apiKeyScheme)
+  .addSecurityScheme('bearer', bearerScheme)
+  // OR: either apiKey OR bearer is enough
+  .addSecurityRequirement({ apiKey: [] })
+  .addSecurityRequirement({ bearer: [] });
+```
+
+## API Key
+
+Simplest scheme — a static secret in a header, query, or cookie.
+
+```ts
+import { ApiKeyAuthorization } from '@a2x/sdk';
+
+a2xAgent
+  .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+    in: 'header',
+    name: 'x-api-key',
+    keys: [process.env.API_KEY_A!, process.env.API_KEY_B!],
+  }))
+  .addSecurityRequirement({ apiKey: [] });
+```
+
+`keys` is the list of accepted values. Rotate by appending the new key, deploying, then removing the old.
+
+## HTTP Bearer
+
+Opaque tokens validated by your own logic — useful when you issue tokens from your own auth service.
+
+```ts
+import { HttpBearerAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('bearer', new HttpBearerAuthorization({
+  validator: async (token) => {
+    const session = await lookupSession(token);
+    return session
+      ? { authenticated: true, principal: session.userId }
+      : { authenticated: false };
+  },
+}));
+```
+
+The validator returns `{ authenticated, principal? }`. `principal` is whatever identity representation is useful to your downstream code — it's available on `RequestContext`.
+
+## OAuth 2.0
+
+Three standard flows are supported out of the box.
+
+### Authorization Code
+
+```ts
+import { OAuth2AuthorizationCodeAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('oauthCode', new OAuth2AuthorizationCodeAuthorization({
+  authorizationUrl: 'https://auth.example.com/authorize',
+  tokenUrl: 'https://auth.example.com/token',
+  scopes: { read: 'Read access', write: 'Write access' },
+  validator: async (token) => { /* verify against your provider */ },
+}));
+```
+
+Use this for user-driven flows where the client can open a browser.
+
+### Client Credentials
+
+```ts
+import { OAuth2ClientCredentialsAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('oauthService', new OAuth2ClientCredentialsAuthorization({
+  tokenUrl: 'https://auth.example.com/token',
+  scopes: { api: 'API access' },
+  validator: async (token) => { /* verify */ },
+}));
+```
+
+For service-to-service calls where no human is present.
+
+### Device Code
+
+For headless devices / CLIs without a browser.
+
+```ts
+import { OAuth2DeviceCodeAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('deviceCode', new OAuth2DeviceCodeAuthorization({
+  deviceAuthorizationUrl: 'https://auth.example.com/device/code',
+  tokenUrl: 'https://auth.example.com/token',
+  scopes: { api: 'API access' },
+  validator: async (token) => { /* verify */ },
+}));
+```
+
+The CLI consumes this scheme via `DeviceFlowClient` — see [Protocol Extensions](./extensions.md) for how A2X surfaces Device Code on v0.3 cards.
+
+## OpenID Connect
+
+Standard OIDC discovery endpoint.
+
+```ts
+import { OpenIdConnectAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('oidc', new OpenIdConnectAuthorization({
+  openIdConnectUrl: 'https://auth.example.com/.well-known/openid-configuration',
+  validator: async (token) => { /* verify id_token or access_token */ },
+}));
+```
+
+## Mutual TLS
+
+Client-certificate-based auth.
+
+```ts
+import { MutualTlsAuthorization } from '@a2x/sdk';
+
+a2xAgent.addSecurityScheme('mtls', new MutualTlsAuthorization({
+  validator: async (context) => {
+    const cert = context.clientCertificate;
+    return cert && isTrusted(cert)
+      ? { authenticated: true, principal: cert.subject.CN }
+      : { authenticated: false };
+  },
+}));
+```
+
+Your HTTP layer must terminate TLS with client-cert verification enabled and pass the cert through on `RequestContext.clientCertificate`.
+
+## Client side: handling auth
+
+### Static headers
+
+For API keys and bearer tokens, pass them as headers on the client:
+
+```ts
+const client = new A2XClient(url, {
+  auth: { apiKey: 'your-secret-key' },
+});
+```
+
+### OAuth flows
+
+`AuthenticatedA2AClient` (exported from `@a2x/sdk/auth`) wraps `A2XClient` and adds token acquisition/refresh. For Device Code specifically:
+
+```ts
+import { DeviceFlowClient } from '@a2x/sdk/auth';
+
+const flow = new DeviceFlowClient({
+  deviceAuthorizationUrl: 'https://auth.example.com/device/code',
+  tokenUrl: 'https://auth.example.com/token',
+  clientId: 'your-client-id',
+  scopes: ['api'],
+});
+
+const { userCode, verificationUri } = await flow.start();
+console.log(`Go to ${verificationUri} and enter code: ${userCode}`);
+
+const tokens = await flow.pollForTokens();
+```
+
+Use the returned `access_token` as the bearer on subsequent `A2XClient` calls.
+
+## Inspecting what an agent requires
+
+Clients can introspect expected auth before calling:
+
+```ts
+const resolved = await client.resolveAgentCard();
+console.log(resolved.card.securitySchemes);
+console.log(resolved.card.securityRequirements);
+```
+
+This lets UI clients surface the right login flow to users dynamically.

--- a/packages/a2x/docs/guides/advanced/extensions.md
+++ b/packages/a2x/docs/guides/advanced/extensions.md
@@ -1,0 +1,62 @@
+# Protocol Extensions
+
+A2A accommodates non-standard capabilities via extensions — fields the core spec doesn't mandate but that participants agree on. A2X uses this mechanism to expose features that don't map cleanly onto an older spec version.
+
+## Built-in: OAuth 2.0 Device Code on v0.3
+
+Device Code flow was formalized in A2A v1.0. Many real-world deployments are still on v0.3 cards, but headless clients (CLIs, IoT) need Device Code regardless.
+
+A2X emits `oauth2.flows.deviceCode` on v0.3 cards as a non-standard extension, and `A2XClient` consumes it on the reading side. Both sides need no additional work — declare the scheme once:
+
+```ts
+import { OAuth2DeviceCodeAuthorization } from '@a2x/sdk';
+
+a2xAgent
+  .addSecurityScheme('deviceCode', new OAuth2DeviceCodeAuthorization({ /* ... */ }))
+  .addSecurityRequirement({ deviceCode: [] });
+```
+
+And it appears in both v1.0 and v0.3 forms of the card. OpenAPI 3.0 doesn't standardize this flow, so strict third-party v0.3 parsers may ignore the field — in practice, clients that care about Device Code also understand this extension.
+
+You'll see a warning in logs when emitting this on a v0.3 card; it's informational, not a problem.
+
+## Writing your own extension
+
+Extensions live on the AgentCard as additional JSON properties. Pick a namespace you control (a domain you own, a prefix like `x-<team>-`) to avoid collisions.
+
+```ts
+const a2xAgent = new A2XAgent({ taskStore, executor })
+  .setDefaultUrl('...')
+  .setExtension('x-acme-pricing', {
+    tier: 'enterprise',
+    rateLimit: { rpm: 1000 },
+  });
+```
+
+Clients that understand the `x-acme-pricing` namespace can read it off the card:
+
+```ts
+const resolved = await client.resolveAgentCard();
+const pricing = (resolved.card as any)['x-acme-pricing'];
+```
+
+A2X treats extension fields opaquely — it copies them through on emission and exposes them on parse. Interpretation is your protocol to write down.
+
+## Versioning extensions
+
+Two techniques are common:
+
+1. **Embed a version in the extension field name**: `x-acme-pricing-v2`. Clean breaks, no backward compat in the field itself.
+2. **Embed a version inside the payload**: `{ version: 2, tier: '...' }`. More flexible but requires handling mixed versions.
+
+Use approach (1) for major shape changes, (2) for incremental additions.
+
+## When not to use extensions
+
+If the thing you're adding will eventually be part of A2A itself, push the proposal to the A2A spec repo instead of locking users into your private extension. Extensions are for:
+
+- Adapting to older spec versions (like Device Code on v0.3).
+- Company-specific metadata that won't ever be standardized (pricing, SLA, internal routing hints).
+- Experimental features you want to ship before they're ratified.
+
+For everything else, stick to the spec.

--- a/packages/a2x/docs/guides/advanced/manual-wiring.md
+++ b/packages/a2x/docs/guides/advanced/manual-wiring.md
@@ -1,0 +1,129 @@
+# Manual Wiring
+
+`toA2x()` is a convenience wrapper. Underneath, it composes five pieces: the agent, a **runner**, an **executor**, a **task store**, and an **A2XAgent** that binds everything to a **request handler**. This guide unpacks that stack so you can customize any of it.
+
+Reach for manual wiring when you need to:
+
+- Mount A2X into an existing HTTP stack (Express, Next.js, etc.). → See also [Framework Integration](../agent/framework-integration.md).
+- Swap the in-memory task store for Redis or Postgres.
+- Customize the AgentCard beyond what `toA2x()` auto-extracts.
+- Add A2A skills, security schemes, or extensions.
+
+## The full stack
+
+```ts
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+} from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+// 1. The agent — what actually runs when a message arrives.
+const agent = new LlmAgent({
+  name: 'my_agent',
+  description: 'My A2A agent.',
+  instruction: 'You are a helpful assistant.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+});
+
+// 2. Runner — drives the agent loop (tool calls, multi-turn, etc.).
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+
+// 3. Executor — adapts the runner into the task/streaming model A2A expects.
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+
+// 4. Task store — persists task state across calls (getTask, cancelTask).
+const taskStore = new InMemoryTaskStore();
+
+// 5. A2XAgent — emits the AgentCard and owns skills, security, versioning.
+const a2xAgent = new A2XAgent({ taskStore, executor })
+  .setDefaultUrl('https://my-agent.example.com/a2a')
+  .addSkill({
+    id: 'chat',
+    name: 'Chat',
+    description: 'General conversation.',
+    tags: ['chat'],
+  });
+
+// 6. Request handler — the thing your HTTP layer calls.
+const handler = new DefaultRequestHandler(a2xAgent);
+```
+
+`handler.getAgentCard()` returns the AgentCard JSON. `handler.handle(body, context)` processes a JSON-RPC request and returns either a plain object or an async iterable (for streams).
+
+## Customizing each piece
+
+### Runner
+
+`InMemoryRunner` is the default. It keeps session state in memory per agent instance — fine for single-process deployments and stateless serverless functions. Swap it if you need shared state across workers.
+
+### Executor / streaming mode
+
+- `StreamingMode.SSE` — incremental Server-Sent Events (default, recommended).
+- omit it — unary responses only.
+
+### Task store
+
+`InMemoryTaskStore` is the default. It loses state on restart, which is fine for stateless deployments but not for production long-running tasks. See [Custom Task Stores](./task-store.md).
+
+### AgentCard skills and metadata
+
+```ts
+a2xAgent
+  .setDefaultUrl('https://my-agent.example.com/a2a')
+  .setIconUrl('https://my-agent.example.com/icon.png')
+  .addSkill({
+    id: 'weather',
+    name: 'Weather lookup',
+    description: 'Returns current weather for a city.',
+    tags: ['weather', 'tools'],
+  })
+  .addSkill({
+    id: 'summarize',
+    name: 'Summarize text',
+    description: 'Produces a 1-paragraph summary.',
+    tags: ['text'],
+  });
+```
+
+Skills are how other agents and directories understand what yours does. Prefer descriptive, stable IDs — they're part of your public contract.
+
+### Security schemes
+
+```ts
+import { ApiKeyAuthorization } from '@a2x/sdk';
+
+a2xAgent
+  .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+    in: 'header',
+    name: 'x-api-key',
+    keys: [process.env.API_KEY!],
+  }))
+  .addSecurityRequirement({ apiKey: [] });
+```
+
+See [Authentication](./authentication.md) for all available schemes.
+
+## Serving the handler
+
+Once you have `handler`, mount it in any HTTP framework. The recipe is in [Framework Integration](../agent/framework-integration.md).
+
+## When `toA2x()` is enough
+
+If you don't need any of the customizations above, don't bother with manual wiring. `toA2x()` produces the same handler internally and exposes it if you need to reach back in:
+
+```ts
+const app = toA2x(agent, { port: 4000, defaultUrl: '...' });
+// app gives you the running server; access .handler if you need it.
+```

--- a/packages/a2x/docs/guides/advanced/task-store.md
+++ b/packages/a2x/docs/guides/advanced/task-store.md
@@ -1,0 +1,88 @@
+# Custom Task Stores
+
+The **task store** is where A2X persists the state of every in-flight and recently-completed A2A task. Clients call `tasks/get` to poll long-running work and `tasks/cancel` to abort it; both read/write through the task store.
+
+## The default: `InMemoryTaskStore`
+
+```ts
+import { InMemoryTaskStore } from '@a2x/sdk';
+
+const taskStore = new InMemoryTaskStore();
+```
+
+Characteristics:
+
+- All state lives in the process's memory.
+- Lost on restart. Not shared across replicas.
+- Has a TTL and max-size cap so it doesn't leak (default values are sane; tune via constructor options).
+
+Good for: local development, stateless serverless functions where each invocation owns its own tasks, demos.
+
+Not good for: multi-replica deployments where one worker might submit a task and another reply to `tasks/get` for the same `id`.
+
+## When you need to swap it
+
+- You deploy multiple agent replicas behind a load balancer.
+- Tasks can outlive the process (long-running pipelines).
+- You want to inspect tasks from an admin tool (Postgres/Redis are easier to query than process memory).
+
+## Implementing a custom store
+
+`TaskStore` is a narrow interface. The methods you implement:
+
+```ts
+interface TaskStore {
+  save(task: Task): Promise<void>;
+  get(id: string): Promise<Task | null>;
+  delete(id: string): Promise<void>;
+}
+```
+
+A Redis-backed version in its entirety:
+
+```ts
+import type { Task, TaskStore } from '@a2x/sdk';
+import { Redis } from 'ioredis';
+
+const KEY = (id: string) => `a2x:task:${id}`;
+
+export class RedisTaskStore implements TaskStore {
+  constructor(private redis: Redis, private ttlSeconds = 3600) {}
+
+  async save(task: Task): Promise<void> {
+    await this.redis.set(KEY(task.id), JSON.stringify(task), 'EX', this.ttlSeconds);
+  }
+
+  async get(id: string): Promise<Task | null> {
+    const raw = await this.redis.get(KEY(id));
+    return raw ? (JSON.parse(raw) as Task) : null;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.redis.del(KEY(id));
+  }
+}
+```
+
+Wire it in:
+
+```ts
+const taskStore = new RedisTaskStore(new Redis(process.env.REDIS_URL!));
+const a2xAgent = new A2XAgent({ taskStore, executor });
+```
+
+## Choosing a TTL
+
+Tasks should live long enough for a reasonable client to:
+
+- Poll `tasks/get` after a unary call (seconds to minutes).
+- Cancel a streaming task that went rogue (seconds to minutes).
+- Retrieve the result of a long-running job (hours).
+
+For most deployments, 1 hour is fine. Lengthen it for human-in-the-loop workflows.
+
+## Pitfalls
+
+- **Don't share a single Redis key prefix across agents** if they have overlapping task-id spaces. Namespace per agent (`a2x:support:task:*` vs `a2x:billing:task:*`).
+- **Serialize carefully.** `Task` objects contain nested message parts and artifacts. `JSON.stringify` works but be aware that binary file parts (as base64 strings) can grow large; consider offloading to object storage and storing just a URI.
+- **Monitor cardinality.** A task store that grows unboundedly is a memory/disk leak waiting to happen. Always use a TTL or periodic cleanup.

--- a/packages/a2x/docs/guides/agent/build-an-agent.md
+++ b/packages/a2x/docs/guides/agent/build-an-agent.md
@@ -1,0 +1,73 @@
+# Build an Agent
+
+The [Quickstart](../quickstart.md) shows the shortest path. This guide explains each field so you can tailor the agent to your use case.
+
+## Anatomy of `LlmAgent`
+
+```ts
+import { LlmAgent } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const agent = new LlmAgent({
+  name: 'support_agent',
+  description: 'Answers customer support questions about the Acme API.',
+  instruction: `
+    You are a support agent for Acme.
+    Always cite the section of the docs you used to answer.
+    If you don't know, say so.
+  `,
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+});
+```
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable identifier; surfaced on the AgentCard and used for routing when composed. Use `snake_case`. |
+| `description` | One-liner that tells other agents (and humans reading the card) what this agent does. |
+| `instruction` | System prompt — shapes every response. Treat this as product copy; iterate on it. |
+| `provider` | The LLM backend. See [Choose an LLM Provider](./providers.md). |
+| `tools` | Optional functions the agent can invoke. See [Add Tools](./tools.md). |
+
+## Serving the agent
+
+`toA2x()` is the one-liner that turns an agent into a running HTTP server:
+
+```ts
+import { toA2x } from '@a2x/sdk';
+
+toA2x(agent, {
+  port: 4000,
+  defaultUrl: 'http://localhost:4000/a2a',
+});
+```
+
+`defaultUrl` is the **public URL** other agents should use to reach you. In production this is your deployed domain; locally it's fine to use `localhost`. This value ends up on the AgentCard.
+
+When `toA2x()` is too opinionated — e.g. you already have an Express app, you need custom middleware, or you want fine-grained control over the AgentCard — see [Manual Wiring](../advanced/manual-wiring.md).
+
+## Verifying the agent is up
+
+With the server running, hit the well-known endpoint:
+
+```bash
+curl http://localhost:4000/.well-known/agent.json | jq
+```
+
+You should see an AgentCard echoing your `name`, `description`, and the transport (`JSONRPC` by default). If another agent or a client calls this URL, they get exactly the same answer — that's how discovery works in A2A.
+
+## Iterating on the instruction
+
+The `instruction` field is where most of your agent's behavior lives. A few practical tips:
+
+- **Describe the persona and the guardrails separately.** Persona first ("You are…"), then what to do and what not to do.
+- **Tell the model how to handle unknowns.** "If you don't know, say so" prevents hallucination more reliably than "be accurate".
+- **Keep tool usage hints here, not in the tool definitions.** "Always call `get_weather` before guessing a temperature" belongs in the instruction; the tool's own `description` should just describe the tool.
+
+## Next
+
+- [Choose an LLM Provider](./providers.md) — swap between Gemini, Claude, and GPT.
+- [Add Tools](./tools.md) — give the agent functions it can call.
+- [Multi-Agent Patterns](./multi-agent.md) — delegate, pipeline, fan out.

--- a/packages/a2x/docs/guides/agent/framework-integration.md
+++ b/packages/a2x/docs/guides/agent/framework-integration.md
@@ -1,0 +1,139 @@
+# Framework Integration
+
+`toA2x()` starts a standalone HTTP server. If you already have an Express, Next.js, Fastify, or Hono app — or you need custom middleware, auth, or routing — use **manual wiring** and mount A2X's request handler yourself.
+
+This guide shows the two most common hosts: Express and Next.js App Router. The same pattern works in any framework; the only thing that changes is how you read the request body and write the response.
+
+## The shared setup
+
+Regardless of host, you build the same pieces up front:
+
+```ts
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+  createSSEStream,
+} from '@a2x/sdk';
+import type { RequestContext } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const agent = new LlmAgent({
+  name: 'my_agent',
+  description: 'My A2A agent.',
+  instruction: 'You are a helpful assistant.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+});
+
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+const taskStore = new InMemoryTaskStore();
+
+const a2xAgent = new A2XAgent({ taskStore, executor })
+  .setDefaultUrl('https://my-agent.example.com/a2a')
+  .addSkill({
+    id: 'chat',
+    name: 'Chat',
+    description: 'General conversation.',
+    tags: ['chat'],
+  });
+
+const handler = new DefaultRequestHandler(a2xAgent);
+```
+
+`handler` is what you mount. See [Manual Wiring](../advanced/manual-wiring.md) for why each step exists.
+
+## Express
+
+```ts
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.get('/.well-known/agent.json', (_req, res) => {
+  res.json(handler.getAgentCard());
+});
+
+app.post('/a2a', async (req, res) => {
+  const context: RequestContext = { headers: req.headers, query: req.query };
+  const result = await handler.handle(req.body, context);
+
+  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    const stream = createSSEStream(result);
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+    }
+    res.end();
+  } else {
+    res.json(result);
+  }
+});
+
+app.listen(4000);
+```
+
+Two things to notice:
+
+1. `handler.handle()` returns either a plain object (regular response) or an async iterable (streaming response). Branch on `Symbol.asyncIterator`.
+2. `createSSEStream()` wraps the async iterable as an SSE-formatted `ReadableStream`.
+
+## Next.js App Router
+
+```ts
+// app/.well-known/agent.json/route.ts
+export async function GET() {
+  return Response.json(handler.getAgentCard());
+}
+```
+
+```ts
+// app/a2a/route.ts
+export async function POST(request: Request) {
+  const body = await request.json();
+  const result = await handler.handle(body, { headers: request.headers });
+
+  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    const stream = createSSEStream(result);
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
+    });
+  }
+
+  return Response.json(result);
+}
+```
+
+`createSSEStream()` returns a `ReadableStream`, which the standard `Response` constructor accepts directly — no manual pump loop needed.
+
+## Fastify, Hono, etc.
+
+The recipe is always the same:
+
+1. Expose `GET /.well-known/agent.json` → `handler.getAgentCard()`.
+2. Expose `POST /a2a` → `handler.handle(body, { headers, query })`.
+3. Detect async iterable → stream with `createSSEStream()`; otherwise respond with JSON.
+
+The only framework-specific bit is how the framework reads bodies and writes streams.
+
+## Where to mount
+
+The URLs above are conventions, not requirements — but they're what clients and the A2A discovery flow expect. If you host multiple agents on the same domain, use per-agent prefixes (`/agents/:name/.well-known/agent.json` + `/agents/:name/a2a`) and reflect that in each agent's `defaultUrl`.

--- a/packages/a2x/docs/guides/agent/multi-agent.md
+++ b/packages/a2x/docs/guides/agent/multi-agent.md
@@ -1,0 +1,109 @@
+# Multi-Agent Patterns
+
+A2X ships three composition primitives for fixed topologies plus the dynamic `AgentTool` delegation (see [Add Tools](./tools.md)).
+
+| Pattern | Shape | When to use |
+|---|---|---|
+| `SequentialAgent` | A → B → C | Pipelines where each step refines the previous one. |
+| `ParallelAgent` | A, B, C run concurrently | Fan-out/fan-in. Independent subtasks. |
+| `LoopAgent` | Repeat A until condition | Iterative refinement, review cycles. |
+
+All three implement the same interface as `LlmAgent`, so they can be served by `toA2x()` or nested inside other patterns.
+
+## Sequential — pipeline
+
+```ts
+import { SequentialAgent, LlmAgent } from '@a2x/sdk';
+
+const outline = new LlmAgent({
+  name: 'outline',
+  description: 'Produces an outline.',
+  instruction: 'Return a 5-point outline.',
+  provider,
+});
+
+const draft = new LlmAgent({
+  name: 'draft',
+  description: 'Writes a full draft from an outline.',
+  instruction: 'Expand each outline point into 1-2 paragraphs.',
+  provider,
+});
+
+const edit = new LlmAgent({
+  name: 'edit',
+  description: 'Tightens prose.',
+  instruction: 'Reduce word count by 30% without losing meaning.',
+  provider,
+});
+
+const pipeline = new SequentialAgent({
+  name: 'writer',
+  description: 'Outline → draft → edit pipeline.',
+  agents: [outline, draft, edit],
+});
+```
+
+Input to the pipeline flows into the first agent; each agent's output becomes the next agent's input.
+
+## Parallel — fan-out
+
+```ts
+import { ParallelAgent, LlmAgent } from '@a2x/sdk';
+
+const summarizer = new LlmAgent({ /* summarizes */ });
+const translator = new LlmAgent({ /* translates */ });
+const sentiment = new LlmAgent({ /* classifies tone */ });
+
+const fanout = new ParallelAgent({
+  name: 'analyze',
+  description: 'Analyzes a document from three angles in parallel.',
+  agents: [summarizer, translator, sentiment],
+});
+```
+
+All three agents run concurrently on the same input. Use this when the sub-tasks are independent — no agent needs another's output.
+
+## Loop — iterative refinement
+
+```ts
+import { LoopAgent, LlmAgent } from '@a2x/sdk';
+
+const reviewer = new LlmAgent({
+  name: 'reviewer',
+  description: 'Reviews a draft and decides whether to stop.',
+  instruction: `
+    Score the draft 0-10. If score >= 8, start your response with "DONE:".
+    Otherwise start with "REVISE:" and explain what to fix.
+  `,
+  provider,
+});
+
+const iterativeWriter = new LoopAgent({
+  name: 'iterative_writer',
+  description: 'Refines a draft until the reviewer says DONE.',
+  agents: [writer, reviewer],
+  maxIterations: 5,
+  shouldExit: (output) => output?.startsWith('DONE:') ?? false,
+});
+```
+
+`shouldExit` receives each iteration's output and returns `true` when the loop is done. `maxIterations` is a hard cap to prevent runaway costs.
+
+## Nesting
+
+Patterns compose freely:
+
+```ts
+const research = new ParallelAgent({ agents: [webSearch, kbSearch] });
+const analyze = new SequentialAgent({ agents: [research, summarize, critique] });
+const refine = new LoopAgent({ agents: [analyze, reviewer], maxIterations: 3 });
+```
+
+Any of these can be served directly by `toA2x(refine, { ... })`.
+
+## When to use `AgentTool` instead
+
+- Use a **pattern** when the topology is known up-front.
+- Use `AgentTool` when the outer agent should decide at runtime which sub-agent to invoke and how many times.
+
+Patterns are cheaper (no LLM routing overhead) and easier to reason about. `AgentTool` is more flexible.

--- a/packages/a2x/docs/guides/agent/providers.md
+++ b/packages/a2x/docs/guides/agent/providers.md
@@ -1,0 +1,86 @@
+# Choose an LLM Provider
+
+A2X ships three providers out of the box. Install the underlying SDK and import the corresponding A2X adapter.
+
+## Google Gemini
+
+```bash
+npm install @google/genai
+```
+
+```ts
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const provider = new GoogleProvider({
+  model: 'gemini-2.5-flash',
+  apiKey: process.env.GOOGLE_API_KEY!,
+});
+```
+
+## Anthropic Claude
+
+```bash
+npm install @anthropic-ai/sdk
+```
+
+```ts
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+
+const provider = new AnthropicProvider({
+  model: 'claude-sonnet-4-20250514',
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+});
+```
+
+## OpenAI GPT
+
+```bash
+npm install openai
+```
+
+```ts
+import { OpenAIProvider } from '@a2x/sdk/openai';
+
+const provider = new OpenAIProvider({
+  model: 'gpt-4o',
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+```
+
+## Picking a model
+
+| Concern | Good default |
+|---|---|
+| Fast, cheap, general-purpose | `gemini-2.5-flash`, `claude-haiku-4-5`, `gpt-4o-mini` |
+| High reasoning quality | `claude-sonnet-4-*`, `gpt-4o`, `gemini-2.5-pro` |
+| Long-context (100k+ tokens) | any current-gen model; check the provider's docs for limits |
+| Tool use / structured output | all three providers support tool calls; Claude and GPT tend to be the most reliable |
+
+Swap providers freely — the rest of the agent definition is identical.
+
+## Mixing providers across agents
+
+You can use a different provider per agent in the same process. This is the usual pattern when one agent is optimized for latency and another for reasoning:
+
+```ts
+const router = new LlmAgent({
+  name: 'router',
+  description: 'Routes requests to a specialist agent.',
+  instruction: 'Pick the best specialist.',
+  provider: googleFast,           // fast classifier
+  tools: [new AgentTool({ agent: analyst })],
+});
+
+const analyst = new LlmAgent({
+  name: 'analyst',
+  description: 'Deep analysis agent.',
+  instruction: 'Think step by step.',
+  provider: claudeSonnet,          // slower but higher-quality
+});
+```
+
+See [Multi-Agent Patterns](./multi-agent.md) for composition options.
+
+## Custom providers
+
+If you need to target a provider A2X doesn't ship (e.g. a self-hosted model), implement the `BaseLlmProvider` interface. The shape is small — `generateContent()` and `generateContentStream()`. See the API reference for the exact contract.

--- a/packages/a2x/docs/guides/agent/streaming.md
+++ b/packages/a2x/docs/guides/agent/streaming.md
@@ -1,0 +1,77 @@
+# Streaming Responses
+
+A2A defines two transport modes: **unary** (`message/send` — one request, one response) and **streaming** (`message/stream` — Server-Sent Events with incremental updates). A2X supports both and picks the right one automatically based on the client's request.
+
+## When to enable streaming
+
+Enable SSE when any of these apply:
+
+- Your agent's responses are long enough that users would feel a "typing" pause.
+- You want to show intermediate tool-call events ("thinking…", "searching…").
+- You're orchestrating multi-agent pipelines and want to surface progress.
+
+Skip it when responses are short and latency-insensitive — the unary path is simpler to reason about.
+
+## Server side: already on by default
+
+If you're using `toA2x()`, streaming is already wired up. The short version:
+
+```ts
+toA2x(agent, { port: 4000, defaultUrl: 'http://localhost:4000/a2a' });
+```
+
+The AgentCard emitted at `/.well-known/agent.json` advertises `capabilities.streaming: true`, and the `POST /a2a` endpoint serves SSE for `message/stream` requests.
+
+If you're wiring manually (see [Framework Integration](./framework-integration.md)), the key piece is:
+
+```ts
+import { AgentExecutor, StreamingMode } from '@a2x/sdk';
+
+const executor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+```
+
+`StreamingMode.SSE` lets the runner emit incremental events. The rest is automatic.
+
+## What the client actually receives
+
+For a `message/stream` call, the client gets an SSE stream of typed events. Each event is one of:
+
+| Event | Meaning |
+|---|---|
+| `task` | Initial snapshot of the task, created server-side. |
+| `status-update` | Task state transition (`submitted` → `working` → `completed`/`failed`/`canceled`). |
+| `artifact-update` | A chunk of output (message parts, tool calls, tool results). |
+
+See [Consuming Streams](../client/streaming.md) for the client-side iteration pattern.
+
+## Disabling streaming
+
+If you want a deliberately non-streaming agent (e.g. for backpressure reasons), drop `streamingMode`:
+
+```ts
+const executor = new AgentExecutor({ runner, runConfig: {} });
+```
+
+The server will still accept `message/stream` requests, but responses come as single-chunk streams. Most clients handle this correctly.
+
+## Debugging SSE
+
+SSE is plain text over HTTP. `curl` works:
+
+```bash
+curl -N \
+  -H 'Accept: text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -X POST http://localhost:4000/a2a \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/stream",
+    "params": { "message": { "role": "user", "parts": [{ "text": "Hi" }] } }
+  }'
+```
+
+The `-N` flag disables `curl`'s output buffering so you see events as they arrive.

--- a/packages/a2x/docs/guides/agent/tools.md
+++ b/packages/a2x/docs/guides/agent/tools.md
@@ -1,0 +1,99 @@
+# Add Tools
+
+Tools are functions the LLM can decide to call. A2X supports two tool shapes: plain functions (`FunctionTool`) and sub-agents used as tools (`AgentTool`).
+
+## FunctionTool
+
+Define what the tool does, describe its parameters with JSON Schema, and hand A2X the implementation. The LLM sees the `name`, `description`, and `parameters` and decides when to call it.
+
+```ts
+import { FunctionTool, LlmAgent } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+const getWeather = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a city.',
+  parameters: {
+    type: 'object',
+    properties: {
+      location: { type: 'string', description: 'City name, e.g. "Seoul".' },
+    },
+    required: ['location'],
+  },
+  execute: async ({ location }) => {
+    const res = await fetch(`https://wttr.in/${encodeURIComponent(location)}?format=j1`);
+    const data = await res.json();
+    return {
+      temp_c: data.current_condition[0].temp_C,
+      description: data.current_condition[0].weatherDesc[0].value,
+    };
+  },
+});
+
+const agent = new LlmAgent({
+  name: 'weather_bot',
+  description: 'Tells you the weather.',
+  instruction: 'Use get_weather before guessing a temperature.',
+  provider: new GoogleProvider({
+    model: 'gemini-2.5-flash',
+    apiKey: process.env.GOOGLE_API_KEY!,
+  }),
+  tools: [getWeather],
+});
+```
+
+### Writing good tool descriptions
+
+The `description` field is what the LLM reads. Keep it **behavioral**:
+
+- Bad: "A function that returns weather data."
+- Good: "Get the current weather for a city. Returns `temp_c` and `description`. Call this before answering any weather question."
+
+Tell the model **when to call** and **what it gets back**.
+
+### Returning structured data
+
+`execute` can return any JSON-serializable value. Objects and arrays are passed to the LLM as JSON strings under the hood. Prefer small, flat objects — the LLM will summarize them better.
+
+## AgentTool — use an agent as a tool
+
+Wrap another `LlmAgent` (or any `BaseAgent`) and hand it to the outer agent. The outer agent can delegate by "calling the tool".
+
+```ts
+import { AgentTool, LlmAgent } from '@a2x/sdk';
+
+const researcher = new LlmAgent({
+  name: 'researcher',
+  description: 'Searches the knowledge base.',
+  instruction: 'Be thorough. Cite sources.',
+  provider: claudeSonnet,
+  tools: [searchKb],
+});
+
+const orchestrator = new LlmAgent({
+  name: 'orchestrator',
+  description: 'Delegates research tasks.',
+  instruction: 'Use the researcher tool for any fact-finding question.',
+  provider: geminiFast,
+  tools: [new AgentTool({ agent: researcher })],
+});
+```
+
+`AgentTool` is the building block for ad-hoc delegation. For fixed topologies (pipeline, parallel, loop) prefer the dedicated patterns in [Multi-Agent Patterns](./multi-agent.md).
+
+## Tool-call lifecycle
+
+1. User message arrives.
+2. LLM emits a tool-call with `{ name, arguments }`.
+3. A2X finds the matching `FunctionTool`/`AgentTool` and runs `execute`.
+4. Result is sent back to the LLM as a tool result.
+5. LLM produces the final answer (or chains another tool call).
+
+All of this is automatic — you never handle raw tool-call messages yourself.
+
+## Things to watch out for
+
+- **Keep tool `execute` idempotent where possible.** The LLM may retry on transient errors.
+- **Validate inputs defensively.** LLMs occasionally invent fields.
+- **Short-circuit on obvious misuse.** Throwing from `execute` with a clear error string is fine; the LLM will see it and can react.
+- **Don't expose dangerous capabilities behind vague descriptions.** "Run shell command" without constraints is how you get owned.

--- a/packages/a2x/docs/guides/client/agent-card-discovery.md
+++ b/packages/a2x/docs/guides/client/agent-card-discovery.md
@@ -1,0 +1,53 @@
+# Agent Card Discovery
+
+The AgentCard is how one A2A participant describes itself to another. When you hand `A2XClient` a `.well-known/agent.json` URL, it fetches this card and uses it for every subsequent call.
+
+## What's on the card
+
+Useful fields at a glance:
+
+- `name`, `description` — human-readable identity.
+- `url` or `supportedInterfaces[].url` — where to send JSON-RPC. Field location depends on protocol version; A2X normalizes this for you.
+- `capabilities.streaming` — whether `message/stream` is supported.
+- `skills[]` — declared capabilities (ids, tags).
+- `securityRequirements` / `securitySchemes` — what auth the agent expects.
+- `protocolVersion` — the A2A version the card was issued under (`0.3` or `1.0`).
+
+## Resolving a card manually
+
+```ts
+import { A2XClient } from '@a2x/sdk/client';
+
+const client = new A2XClient('https://agent.example.com/.well-known/agent.json');
+const resolved = await client.resolveAgentCard();
+
+console.log(resolved.version);  // '0.3' | '1.0'
+console.log(resolved.card);     // parsed AgentCard for that version
+```
+
+`ResolvedAgentCard` is the union of "which version we ended up with" plus "the parsed card". Use it when you need to branch on version or inspect declared skills before calling the agent.
+
+## Version negotiation
+
+A2A has two spec versions in the wild. You don't pick — the remote agent declares, and the client adapts:
+
+- If the card declares `protocolVersion: '1.0'`, `A2XClient` uses the v1.0 endpoints and shapes.
+- If it declares `0.3` (or omits the field), the client uses v0.3.
+
+You can force a preference:
+
+```ts
+const client = new A2XClient(url, { preferredVersion: '1.0' });
+```
+
+When the remote supports both, this picks your preference; when it only supports one, the client falls back gracefully.
+
+## Calling non-A2X agents
+
+`A2XClient` is a protocol-level client, not an A2X-only one. Any agent whose AgentCard is valid A2A works, regardless of what SDK produced it. The only thing that changes is the URL you pass.
+
+## Caching and refreshing
+
+`A2XClient` caches the card after the first fetch. If the remote agent rolls out a new version, drop the client and construct a new one, or use `resolveAgentCard({ force: true })` to bypass the cache.
+
+For long-running processes you can add a periodic refresh yourself — the card is cheap to refetch.

--- a/packages/a2x/docs/guides/client/basics.md
+++ b/packages/a2x/docs/guides/client/basics.md
@@ -1,0 +1,88 @@
+# Client Basics
+
+`A2XClient` calls any A2A-compliant agent — not just A2X ones — from TypeScript. Give it a URL, call methods, get typed results.
+
+## Create a client
+
+```ts
+import { A2XClient } from '@a2x/sdk/client';
+
+const client = new A2XClient('https://agent.example.com/.well-known/agent.json');
+```
+
+Pass the AgentCard URL (the `.well-known` path). The client fetches and caches the card on first use and uses it to figure out how to route subsequent calls.
+
+You can also pass the JSON-RPC endpoint directly, but the card URL is preferred — it supports discovery, version negotiation, and auth scheme introspection.
+
+## Send a message
+
+```ts
+const task = await client.sendMessage({
+  message: {
+    role: 'user',
+    parts: [{ text: 'Summarize the attached log.' }],
+  },
+});
+
+console.log(task.status.state);           // 'completed'
+console.log(task.status.message?.parts);  // agent's reply parts
+```
+
+`sendMessage()` is **unary**: one request, one response. It blocks until the task completes (or fails).
+
+The return value is a full `Task` object with status, artifacts, and the agent's final message. See the API reference for the exact shape.
+
+## Get or cancel an existing task
+
+```ts
+const existing = await client.getTask('task-abc123');
+console.log(existing.status.state);
+
+const canceled = await client.cancelTask('task-abc123');
+```
+
+`task-abc123` is the `id` from the task you previously submitted. This is how you poll long-running work or abort something the user changed their mind about.
+
+## Message parts
+
+`parts` is an array — you can send text plus other modalities:
+
+```ts
+await client.sendMessage({
+  message: {
+    role: 'user',
+    parts: [
+      { text: 'What does this image show?' },
+      {
+        file: {
+          mimeType: 'image/png',
+          bytes: base64Png,    // or: uri: 'https://…'
+        },
+      },
+    ],
+  },
+});
+```
+
+Whether a particular agent accepts image/file parts depends on its capabilities (check the AgentCard's `inputs`/`outputs` fields).
+
+## Handling errors
+
+```ts
+try {
+  const task = await client.sendMessage({ message });
+  if (task.status.state === 'failed') {
+    console.error(task.status.message);
+  }
+} catch (err) {
+  // Network or protocol-level error.
+}
+```
+
+Failed tasks are a normal return path — the agent reports the failure via `task.status.state === 'failed'` and the message explains why. A thrown exception usually means the network or the AgentCard URL itself is broken.
+
+## Next
+
+- [Consuming Streams](./streaming.md) — when you want incremental updates instead of a single blocking call.
+- [Agent Card Discovery](./agent-card-discovery.md) — version negotiation, multiple transports, auth introspection.
+- [Authentication](../advanced/authentication.md) — client-side auth scheme handling.

--- a/packages/a2x/docs/guides/client/streaming.md
+++ b/packages/a2x/docs/guides/client/streaming.md
@@ -1,0 +1,98 @@
+# Consuming Streams
+
+For responses you want incrementally — token-by-token output, progress events, long-running pipelines — use `sendMessageStream()`.
+
+## The basic loop
+
+```ts
+import { A2XClient } from '@a2x/sdk/client';
+
+const client = new A2XClient('https://agent.example.com/.well-known/agent.json');
+
+for await (const event of client.sendMessageStream({
+  message: {
+    role: 'user',
+    parts: [{ text: 'Write a short story about a robot.' }],
+  },
+})) {
+  console.log(event);
+}
+```
+
+`sendMessageStream()` returns an `AsyncIterable` of typed events. The for-await loop surfaces them as they arrive.
+
+## Event types
+
+Each yielded event is one of:
+
+| Kind | What it tells you |
+|---|---|
+| `task` | Initial task snapshot — you now have the `task.id`. |
+| `status-update` | State transition: `submitted` → `working` → `completed` / `failed` / `canceled`. |
+| `artifact-update` | A chunk of output — text fragments, tool calls, tool results. |
+
+Narrow by checking the event shape:
+
+```ts
+for await (const event of stream) {
+  if ('kind' in event && event.kind === 'status-update') {
+    console.log('state:', event.status.state);
+  } else if ('kind' in event && event.kind === 'artifact-update') {
+    for (const part of event.artifact.parts) {
+      if ('text' in part) process.stdout.write(part.text);
+    }
+  }
+}
+```
+
+Check `client` types in the API reference for the exact discriminated union.
+
+## Stopping early
+
+Break out of the loop whenever you want — the underlying connection is closed automatically:
+
+```ts
+for await (const event of stream) {
+  if (userClickedCancel) break;
+  render(event);
+}
+```
+
+If you want the agent itself to stop doing work (not just your client to stop listening), call `client.cancelTask(taskId)` using the `id` from the first `task` event.
+
+## Accumulating output
+
+A common pattern — render text as it arrives, keep a running buffer:
+
+```ts
+let fullText = '';
+
+for await (const event of stream) {
+  if ('kind' in event && event.kind === 'artifact-update') {
+    for (const part of event.artifact.parts) {
+      if ('text' in part) {
+        fullText += part.text;
+        updateUI(fullText);
+      }
+    }
+  }
+}
+```
+
+## Error handling
+
+Errors surface as either a `status-update` with `state: 'failed'`, or as a thrown exception from the iterator (for network/protocol failures). Wrap the loop in `try/catch`:
+
+```ts
+try {
+  for await (const event of client.sendMessageStream({ message })) {
+    handle(event);
+  }
+} catch (err) {
+  console.error('stream broken', err);
+}
+```
+
+## When streaming is not available
+
+Some A2A agents don't advertise `capabilities.streaming`. `A2XClient` handles this transparently — it falls back to `sendMessage()` and yields a single synthetic event sequence. Your code doesn't change.

--- a/packages/a2x/docs/guides/introduction.md
+++ b/packages/a2x/docs/guides/introduction.md
@@ -1,0 +1,33 @@
+# What is A2X?
+
+A2X is a TypeScript SDK for building and consuming [A2A (Agent-to-Agent)](https://a2a-protocol.org/) protocol agents. It lets you expose any LLM-backed workflow as a standards-compliant endpoint other agents and clients can discover, call, and stream from.
+
+## Mental model
+
+An A2A agent is an HTTP service with two surfaces:
+
+- `GET /.well-known/agent.json` — a discoverable **AgentCard** that describes what the agent can do, how to authenticate, and how to reach it.
+- `POST /a2a` — a JSON-RPC endpoint that accepts `message/send`, `message/stream`, `tasks/get`, and `tasks/cancel`.
+
+A2X gives you two things:
+
+1. **Server-side ergonomics** — define your agent in plain TypeScript, plug in an LLM provider, and A2X emits a correct AgentCard and wires up the JSON-RPC handler for you.
+2. **Client-side ergonomics** — `A2XClient` calls any A2A-compliant agent (not just A2X ones) with a typed, Promise/AsyncIterator surface.
+
+## When to reach for A2X
+
+- You want to expose an LLM workflow as an A2A endpoint without hand-authoring AgentCards.
+- You want to compose agents (delegation, pipelines, parallel fan-out, iterative refinement).
+- You want to call third-party A2A agents from TypeScript code with type safety.
+- You want to stay framework-agnostic — A2X plugs into Express, Fastify, Hono, Next.js, or any Node.js HTTP stack.
+
+## When A2X is overkill
+
+- You're calling a single LLM once and don't need discovery, streaming, or multi-agent composition. Use the provider SDK directly.
+- You need a UI framework — A2X is a protocol layer, not a frontend.
+
+## What's next
+
+- [Quickstart](./quickstart.md) — your first agent in under 30 lines of code.
+- [Agent guides](./agent/build-an-agent.md) — the primary path for building agents.
+- [Client guides](./client/basics.md) — consuming remote A2A agents.

--- a/packages/a2x/docs/guides/quickstart.md
+++ b/packages/a2x/docs/guides/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart
+
+Get a working agent and a client talking to each other in under five minutes.
+
+## 1. Install
+
+```bash
+npm install @a2x/sdk @google/genai
+```
+
+Pick any LLM provider. This guide uses Google Gemini; swap in Anthropic or OpenAI any time (see [Choose an LLM Provider](./agent/providers.md)).
+
+## 2. Run your first agent
+
+```ts
+import { LlmAgent, toA2x } from '@a2x/sdk';
+import { GoogleProvider } from '@a2x/sdk/google';
+
+toA2x(
+  new LlmAgent({
+    name: 'hello_agent',
+    description: 'A friendly assistant.',
+    instruction: 'You are a helpful assistant. Keep answers short.',
+    provider: new GoogleProvider({
+      model: 'gemini-2.5-flash',
+      apiKey: process.env.GOOGLE_API_KEY!,
+    }),
+  }),
+  { port: 4000, defaultUrl: 'http://localhost:4000/a2a' },
+);
+```
+
+Run it:
+
+```bash
+GOOGLE_API_KEY=... npx tsx server.ts
+```
+
+That's the whole server. Your agent now responds at:
+
+- `GET http://localhost:4000/.well-known/agent.json` — AgentCard for discovery.
+- `POST http://localhost:4000/a2a` — JSON-RPC endpoint.
+
+## 3. Call it from another process
+
+```ts
+import { A2XClient } from '@a2x/sdk/client';
+
+const client = new A2XClient('http://localhost:4000/.well-known/agent.json');
+
+const task = await client.sendMessage({
+  message: { role: 'user', parts: [{ text: 'Say hi in three words.' }] },
+});
+
+console.log(task.status.message?.parts);
+```
+
+That's it. You've shipped an A2A-compliant agent and called it from TypeScript.
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| Customize the agent's behavior | [Build an Agent](./agent/build-an-agent.md) |
+| Give the agent tools it can call | [Add Tools](./agent/tools.md) |
+| Compose multiple agents | [Multi-Agent Patterns](./agent/multi-agent.md) |
+| Mount the agent into Express/Next.js | [Framework Integration](./agent/framework-integration.md) |
+| Stream responses token-by-token | [Streaming Responses](./agent/streaming.md) |
+| Lock the agent behind auth | [Authentication](./advanced/authentication.md) |

--- a/packages/a2x/docs/manifest.json
+++ b/packages/a2x/docs/manifest.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "sections": [
+    {
+      "id": "getting-started",
+      "label": "Getting Started",
+      "pages": [
+        { "slug": "introduction", "title": "What is A2X?" },
+        { "slug": "quickstart", "title": "Quickstart" }
+      ]
+    },
+    {
+      "id": "agent",
+      "label": "Agent (Server)",
+      "description": "Build and run A2A-compliant agents.",
+      "pages": [
+        { "slug": "agent/build-an-agent", "title": "Build an Agent" },
+        { "slug": "agent/providers", "title": "Choose an LLM Provider" },
+        { "slug": "agent/tools", "title": "Add Tools" },
+        { "slug": "agent/multi-agent", "title": "Multi-Agent Patterns" },
+        { "slug": "agent/framework-integration", "title": "Framework Integration" },
+        { "slug": "agent/streaming", "title": "Streaming Responses" }
+      ]
+    },
+    {
+      "id": "client",
+      "label": "Client",
+      "description": "Call remote A2A agents from your application.",
+      "pages": [
+        { "slug": "client/basics", "title": "Client Basics" },
+        { "slug": "client/streaming", "title": "Consuming Streams" },
+        { "slug": "client/agent-card-discovery", "title": "Agent Card Discovery" }
+      ]
+    },
+    {
+      "id": "advanced",
+      "label": "Advanced",
+      "description": "Customize, secure, and version your agents.",
+      "pages": [
+        { "slug": "advanced/manual-wiring", "title": "Manual Wiring" },
+        { "slug": "advanced/authentication", "title": "Authentication" },
+        { "slug": "advanced/task-store", "title": "Custom Task Stores" },
+        { "slug": "advanced/agent-card-versioning", "title": "AgentCard v0.3 vs v1.0" },
+        { "slug": "advanced/extensions", "title": "Protocol Extensions" }
+      ]
+    }
+  ]
+}

--- a/packages/a2x/package.json
+++ b/packages/a2x/package.json
@@ -39,7 +39,8 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "docs"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary

Ships a `packages/a2x/docs/` directory alongside the SDK source. It's included in the npm tarball via `package.json#files`, so every install of `@a2x/sdk` drops a `node_modules/@a2x/sdk/docs/` tree that `planetarium/a2x-web` will sync into its documentation site on each release.

### Structure

```
packages/a2x/docs/
├── manifest.json                       # sidebar order + titles
└── guides/
    ├── introduction.md
    ├── quickstart.md
    ├── agent/
    │   ├── build-an-agent.md
    │   ├── providers.md
    │   ├── tools.md
    │   ├── multi-agent.md
    │   ├── framework-integration.md
    │   └── streaming.md
    ├── client/
    │   ├── basics.md
    │   ├── streaming.md
    │   └── agent-card-discovery.md
    └── advanced/
        ├── manual-wiring.md
        ├── authentication.md
        ├── task-store.md
        ├── agent-card-versioning.md
        └── extensions.md
```

### Design choices

- **Agent-side content is primary.** The manifest puts the Agent (Server) section ahead of Client — building an agent is the typical first thing a user does with A2X.
- **Progressive disclosure.** The Quickstart is deliberately minimal (~30 lines, one provider, no auth, no extensions) so the first-impression surface stays small. Auth, task-store customization, protocol versioning, and extensions all live in a separate `advanced/` section.
- **Narrative first, API reference second.** These guides complement the auto-generated TypeDoc output already served at `/api-reference` on the docs site.
- **Version-locked to the SDK.** The docs ride inside the npm tarball, so the guides a reader sees always match the published types they're about to install.

### Follow-up (separate PRs, not in this one)

- `planetarium/a2x-web`: add `scripts/sync-guides.ts` to copy `node_modules/@a2x/sdk/docs/` into `content/guides/`, a `lib/guide-catalog.ts` that reads `manifest.json`, and an `app/docs/guides/[[...slug]]/page.tsx` renderer. No change to the existing automation pipeline — `docs:prepare` just gains one more step.
- Agent-assisted guide review workflow (separate PR on this repo).

## Test plan

- [x] `pnpm build` still produces clean `dist/` (no new TypeScript surface added).
- [x] `npm pack --dry-run` from `packages/a2x/` shows `docs/**/*.md` and `docs/manifest.json` are included.
- [x] After merging and releasing, `node_modules/@a2x/sdk/docs/manifest.json` exists in a fresh `npm install @a2x/sdk`.