### PR TITLE
feat(transport): register push notification config set/get/list routes

### DIFF
--- a/.changeset/issue-30-push-notification-config-wiring.md
+++ b/.changeset/issue-30-push-notification-config-wiring.md
@@ -1,0 +1,21 @@
+---
+"@a2x/sdk": minor
+---
+
+Wire the missing JSON-RPC methods for push notification config management.
+
+`DefaultRequestHandler` now routes the following methods to
+`PushNotificationConfigStore` when one is injected:
+
+- `tasks/pushNotificationConfig/set`
+- `tasks/pushNotificationConfig/get`
+- `tasks/pushNotificationConfig/list`
+
+Both A2A v0.3 (`{ id, pushNotificationConfigId }`) and v1.0 (`{ taskId, id }`)
+wire shapes are normalized by the handlers, mirroring the existing
+`tasks/pushNotificationConfig/delete` behavior. Agents that do not inject a
+`pushNotificationConfigStore` continue to receive
+`PushNotificationNotSupportedError` (-32003) as before.
+
+`tasks/resubscribe` and `agent/authenticatedExtendedCard` remain unimplemented
+and will be addressed in a follow-up phase.

--- a/packages/a2x/src/__tests__/push-notification-config-store.test.ts
+++ b/packages/a2x/src/__tests__/push-notification-config-store.test.ts
@@ -10,7 +10,6 @@ describe('InMemoryPushNotificationConfigStore', () => {
   });
 
   const config: TaskPushNotificationConfig = {
-    id: 'config-1',
     taskId: 'task-1',
     pushNotificationConfig: {
       id: 'config-1',
@@ -29,6 +28,14 @@ describe('InMemoryPushNotificationConfigStore', () => {
     it('should return null for non-existent config', async () => {
       const result = await store.get('task-1', 'non-existent');
       expect(result).toBeNull();
+    });
+
+    it('should throw when pushNotificationConfig.id is missing', async () => {
+      const noId: TaskPushNotificationConfig = {
+        taskId: 'task-1',
+        pushNotificationConfig: { url: 'https://example.com/webhook' },
+      };
+      await expect(store.set(noId)).rejects.toThrow(/pushNotificationConfig\.id is required/);
     });
   });
 
@@ -51,7 +58,6 @@ describe('InMemoryPushNotificationConfigStore', () => {
   describe('list', () => {
     it('should list all configs for a task', async () => {
       const config2: TaskPushNotificationConfig = {
-        id: 'config-2',
         taskId: 'task-1',
         pushNotificationConfig: {
           id: 'config-2',
@@ -63,8 +69,8 @@ describe('InMemoryPushNotificationConfigStore', () => {
       await store.set(config2);
       const configs = await store.list('task-1');
       expect(configs).toHaveLength(2);
-      expect(configs.map(c => c.id)).toContain('config-1');
-      expect(configs.map(c => c.id)).toContain('config-2');
+      expect(configs.map((c) => c.pushNotificationConfig.id)).toContain('config-1');
+      expect(configs.map((c) => c.pushNotificationConfig.id)).toContain('config-2');
     });
 
     it('should return empty array for task with no configs', async () => {

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -814,7 +814,6 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const { handler, pushStore } = createHandlerWithPushNotification('1.0');
 
         const config: TaskPushNotificationConfig = {
-          id: 'config-1',
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
@@ -899,7 +898,6 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
         const config: TaskPushNotificationConfig = {
-          id: 'config-1',
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
@@ -989,7 +987,6 @@ describe('Layer 4: DefaultRequestHandler', () => {
         method: 'tasks/pushNotificationConfig/set',
         params: {
           taskId: 'task-1',
-          id: 'config-1',
           pushNotificationConfig: {
             id: 'config-1',
             url: 'https://example.com/webhook',
@@ -1005,36 +1002,115 @@ describe('Layer 4: DefaultRequestHandler', () => {
       );
     });
 
-    describe('v1.0 parameter format (taskId + id + pushNotificationConfig)', () => {
-      it('should store a new config and echo it back', async () => {
-        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+    describe('v0.3 wire format (TaskPushNotificationConfig nested)', () => {
+      it('should store a new config and return the v0.3 nested shape', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-        const config: TaskPushNotificationConfig = {
-          id: 'config-1',
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              token: 't1',
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual({
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
             url: 'https://example.com/webhook',
             token: 't1',
           },
-        };
+        });
+
+        const stored = await pushStore.get('task-1', 'config-1');
+        expect(stored).toEqual({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+            token: 't1',
+          },
+        });
+      });
+
+      it('should auto-generate pushNotificationConfig.id when client omits it', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
         const response = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
-          params: config,
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: { url: 'https://example.com/webhook' },
+          },
         });
 
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        expect((rpc as { result: unknown }).result).toEqual(config);
+        const result = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
+        const generatedId = result.pushNotificationConfig.id;
+        expect(typeof generatedId).toBe('string');
+        expect(generatedId).not.toEqual('');
+
+        // Round-trip: the auto-generated id indexes the store.
+        const stored = await pushStore.get('task-1', generatedId!);
+        expect(stored?.pushNotificationConfig.id).toBe(generatedId);
+      });
+    });
+
+    describe('v1.0 wire format (flattened response)', () => {
+      it('should store a new config and return the v1.0 flattened shape', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              token: 't1',
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual({
+          id: 'config-1',
+          taskId: 'task-1',
+          url: 'https://example.com/webhook',
+          token: 't1',
+        });
 
         const stored = await pushStore.get('task-1', 'config-1');
-        expect(stored).toEqual(config);
+        expect(stored).toEqual({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+            token: 't1',
+          },
+        });
       });
+    });
 
+    describe('validation', () => {
       it('should return InvalidParams when params is not an object', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
@@ -1061,7 +1137,6 @@ describe('Layer 4: DefaultRequestHandler', () => {
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
           params: {
-            id: 'config-1',
             pushNotificationConfig: {
               id: 'config-1',
               url: 'https://example.com/webhook',
@@ -1077,20 +1152,14 @@ describe('Layer 4: DefaultRequestHandler', () => {
         );
       });
 
-      it('should return InvalidParams when id is missing', async () => {
+      it('should return InvalidParams when pushNotificationConfig is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
         const response = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
-          params: {
-            taskId: 'task-1',
-            pushNotificationConfig: {
-              id: 'config-1',
-              url: 'https://example.com/webhook',
-            },
-          },
+          params: { taskId: 'task-1' },
         });
 
         expect(isAsyncGenerator(response)).toBe(false);
@@ -1110,10 +1179,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
           method: 'tasks/pushNotificationConfig/set',
           params: {
             taskId: 'task-1',
-            id: 'config-1',
-            pushNotificationConfig: {
-              id: 'config-1',
-            },
+            pushNotificationConfig: { id: 'config-1' },
           },
         });
 
@@ -1146,15 +1212,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
     });
 
     describe('v1.0 parameter format (taskId + id)', () => {
-      it('should return an existing config', async () => {
+      it('should return an existing config in v1.0 flattened shape', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('1.0');
 
         const config: TaskPushNotificationConfig = {
-          id: 'config-1',
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
             url: 'https://example.com/webhook',
+            token: 'tok-1',
           },
         };
         await pushStore.set(config);
@@ -1169,7 +1235,12 @@ describe('Layer 4: DefaultRequestHandler', () => {
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        expect((rpc as { result: unknown }).result).toEqual(config);
+        expect((rpc as { result: unknown }).result).toEqual({
+          id: 'config-1',
+          taskId: 'task-1',
+          url: 'https://example.com/webhook',
+          token: 'tok-1',
+        });
       });
 
       it('should return TaskNotFound when config does not exist', async () => {
@@ -1228,11 +1299,10 @@ describe('Layer 4: DefaultRequestHandler', () => {
     });
 
     describe('v0.3 parameter format (id + pushNotificationConfigId)', () => {
-      it('should return an existing config', async () => {
+      it('should return an existing config in v0.3 nested shape', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
         const config: TaskPushNotificationConfig = {
-          id: 'config-1',
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
@@ -1251,7 +1321,13 @@ describe('Layer 4: DefaultRequestHandler', () => {
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        expect((rpc as { result: unknown }).result).toEqual(config);
+        expect((rpc as { result: unknown }).result).toEqual({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        });
       });
 
       it('should return TaskNotFound when config does not exist', async () => {
@@ -1290,8 +1366,17 @@ describe('Layer 4: DefaultRequestHandler', () => {
         );
       });
 
-      it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
-        const { handler } = createHandlerWithPushNotification('0.3');
+      it('should return the first stored config when pushNotificationConfigId is omitted (TaskIdParams variant)', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
+
+        const first: TaskPushNotificationConfig = {
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-first',
+            url: 'https://example.com/first',
+          },
+        };
+        await pushStore.set(first);
 
         const response = await handler.handle({
           jsonrpc: '2.0',
@@ -1302,9 +1387,31 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-first',
+            url: 'https://example.com/first',
+          },
+        });
+      });
+
+      it('should return TaskNotFound when pushNotificationConfigId is omitted and no configs exist', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { id: 'task-without-configs' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-          A2A_ERROR_CODES.INVALID_PARAMS,
+          A2A_ERROR_CODES.TASK_NOT_FOUND,
         );
       });
     });
@@ -1328,28 +1435,24 @@ describe('Layer 4: DefaultRequestHandler', () => {
       );
     });
 
-    describe('v1.0 parameter format (taskId)', () => {
-      it('should return all configs for the given task', async () => {
+    describe('v1.0 parameter format (taskId) — paginated response', () => {
+      it('should return { configs, nextPageToken } for the given task', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('1.0');
 
-        const config1: TaskPushNotificationConfig = {
-          id: 'config-1',
+        await pushStore.set({
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
             url: 'https://example.com/webhook-1',
           },
-        };
-        const config2: TaskPushNotificationConfig = {
-          id: 'config-2',
+        });
+        await pushStore.set({
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-2',
             url: 'https://example.com/webhook-2',
           },
-        };
-        await pushStore.set(config1);
-        await pushStore.set(config2);
+        });
 
         const response = await handler.handle({
           jsonrpc: '2.0',
@@ -1361,13 +1464,27 @@ describe('Layer 4: DefaultRequestHandler', () => {
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: unknown }).result as TaskPushNotificationConfig[];
-        expect(Array.isArray(result)).toBe(true);
-        expect(result).toHaveLength(2);
-        expect(result).toEqual(expect.arrayContaining([config1, config2]));
+        const result = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
+        expect(result.nextPageToken).toBe('');
+        expect(Array.isArray(result.configs)).toBe(true);
+        expect(result.configs).toHaveLength(2);
+        expect(result.configs).toEqual(
+          expect.arrayContaining([
+            {
+              id: 'config-1',
+              taskId: 'task-1',
+              url: 'https://example.com/webhook-1',
+            },
+            {
+              id: 'config-2',
+              taskId: 'task-1',
+              url: 'https://example.com/webhook-2',
+            },
+          ]),
+        );
       });
 
-      it('should return an empty array when no configs exist', async () => {
+      it('should return { configs: [], nextPageToken: "" } when no configs exist', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
         const response = await handler.handle({
@@ -1380,7 +1497,30 @@ describe('Layer 4: DefaultRequestHandler', () => {
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        expect((rpc as { result: unknown }).result).toEqual([]);
+        expect((rpc as { result: unknown }).result).toEqual({ configs: [], nextPageToken: '' });
+      });
+
+      it('should accept pageSize/pageToken params and ignore them', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        await pushStore.set({
+          taskId: 'task-1',
+          pushNotificationConfig: { id: 'config-1', url: 'https://example.com/webhook' },
+        });
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { taskId: 'task-1', pageSize: 10, pageToken: 'ignored' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
+        expect(result.configs).toHaveLength(1);
+        expect(result.nextPageToken).toBe('');
       });
 
       it('should return InvalidParams when taskId is missing', async () => {
@@ -1402,19 +1542,17 @@ describe('Layer 4: DefaultRequestHandler', () => {
       });
     });
 
-    describe('v0.3 parameter format (id)', () => {
-      it('should return all configs for the given task', async () => {
+    describe('v0.3 parameter format (id) — bare array response', () => {
+      it('should return a bare array of nested TaskPushNotificationConfig', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-        const config: TaskPushNotificationConfig = {
-          id: 'config-1',
+        await pushStore.set({
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
             url: 'https://example.com/webhook',
           },
-        };
-        await pushStore.set(config);
+        });
 
         const response = await handler.handle({
           jsonrpc: '2.0',
@@ -1426,10 +1564,32 @@ describe('Layer 4: DefaultRequestHandler', () => {
         expect(isAsyncGenerator(response)).toBe(false);
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: unknown }).result as TaskPushNotificationConfig[];
+        const result = (rpc as { result: unknown }).result as unknown[];
         expect(Array.isArray(result)).toBe(true);
         expect(result).toHaveLength(1);
-        expect(result[0]).toEqual(config);
+        expect(result[0]).toEqual({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        });
+      });
+
+      it('should return an empty bare array when no configs exist', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { id: 'unknown-task' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual([]);
       });
 
       it('should return InvalidParams when id is missing', async () => {

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1068,6 +1068,31 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const stored = await pushStore.get('task-1', generatedId!);
         expect(stored?.pushNotificationConfig.id).toBe(generatedId);
       });
+
+      it('should treat empty-string pushNotificationConfig.id as absent and auto-generate', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: { id: '', url: 'https://example.com/webhook' },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
+        const generatedId = result.pushNotificationConfig.id;
+        expect(typeof generatedId).toBe('string');
+        expect(generatedId).not.toEqual('');
+
+        const stored = await pushStore.get('task-1', generatedId!);
+        expect(stored?.pushNotificationConfig.id).toBe(generatedId);
+      });
     });
 
     describe('v1.0 wire format (flattened response)', () => {

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1190,6 +1190,55 @@ describe('Layer 4: DefaultRequestHandler', () => {
           A2A_ERROR_CODES.INVALID_PARAMS,
         );
       });
+
+      it('should return InvalidParams when authentication.schemes is empty', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              authentication: { schemes: [] },
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should accept valid authentication info', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              authentication: { schemes: ['Bearer'], credentials: 'abc123' },
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { authentication: unknown } }).result;
+        expect(result.authentication).toEqual({ schemes: ['Bearer'], credentials: 'abc123' });
+      });
     });
   });
 

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -979,4 +979,476 @@ describe('Layer 4: DefaultRequestHandler', () => {
       });
     });
   });
+
+  describe('tasks/pushNotificationConfig/set', () => {
+    it('should return PushNotificationNotSupported when no store configured', async () => {
+      const handler = createHandler();
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/set',
+        params: {
+          taskId: 'task-1',
+          id: 'config-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
+      );
+    });
+
+    describe('v1.0 parameter format (taskId + id + pushNotificationConfig)', () => {
+      it('should store a new config and echo it back', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        const config: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+            token: 't1',
+          },
+        };
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: config,
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual(config);
+
+        const stored = await pushStore.get('task-1', 'config-1');
+        expect(stored).toEqual(config);
+      });
+
+      it('should return InvalidParams when params is not an object', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: 'not-an-object',
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when taskId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            id: 'config-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when id is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when pushNotificationConfig.url is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            id: 'config-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/get', () => {
+    it('should return PushNotificationNotSupported when no store configured', async () => {
+      const handler = createHandler();
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/get',
+        params: { taskId: 'task-1', id: 'config-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
+      );
+    });
+
+    describe('v1.0 parameter format (taskId + id)', () => {
+      it('should return an existing config', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        const config: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        };
+        await pushStore.set(config);
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { taskId: 'task-1', id: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual(config);
+      });
+
+      it('should return TaskNotFound when config does not exist', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { taskId: 'task-1', id: 'non-existent' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.TASK_NOT_FOUND,
+        );
+      });
+
+      it('should return InvalidParams when taskId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { id: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when id is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { taskId: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+    });
+
+    describe('v0.3 parameter format (id + pushNotificationConfigId)', () => {
+      it('should return an existing config', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
+
+        const config: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        };
+        await pushStore.set(config);
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual(config);
+      });
+
+      it('should return TaskNotFound when config does not exist', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { id: 'task-1', pushNotificationConfigId: 'nope' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.TASK_NOT_FOUND,
+        );
+      });
+
+      it('should return InvalidParams when id (task ID) is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { pushNotificationConfigId: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { id: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/list', () => {
+    it('should return PushNotificationNotSupported when no store configured', async () => {
+      const handler = createHandler();
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/pushNotificationConfig/list',
+        params: { taskId: 'task-1' },
+      });
+
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
+      );
+    });
+
+    describe('v1.0 parameter format (taskId)', () => {
+      it('should return all configs for the given task', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        const config1: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook-1',
+          },
+        };
+        const config2: TaskPushNotificationConfig = {
+          id: 'config-2',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-2',
+            url: 'https://example.com/webhook-2',
+          },
+        };
+        await pushStore.set(config1);
+        await pushStore.set(config2);
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { taskId: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: unknown }).result as TaskPushNotificationConfig[];
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(2);
+        expect(result).toEqual(expect.arrayContaining([config1, config2]));
+      });
+
+      it('should return an empty array when no configs exist', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { taskId: 'unknown-task' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        expect((rpc as { result: unknown }).result).toEqual([]);
+      });
+
+      it('should return InvalidParams when taskId is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: {},
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+    });
+
+    describe('v0.3 parameter format (id)', () => {
+      it('should return all configs for the given task', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
+
+        const config: TaskPushNotificationConfig = {
+          id: 'config-1',
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+          },
+        };
+        await pushStore.set(config);
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { id: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: unknown }).result as TaskPushNotificationConfig[];
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual(config);
+      });
+
+      it('should return InvalidParams when id is missing', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: {},
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+    });
+  });
 });

--- a/packages/a2x/src/a2x/push-notification-config-store.ts
+++ b/packages/a2x/src/a2x/push-notification-config-store.ts
@@ -24,12 +24,18 @@ export class InMemoryPushNotificationConfigStore implements PushNotificationConf
   }
 
   async set(config: TaskPushNotificationConfig): Promise<TaskPushNotificationConfig> {
+    const configId = config.pushNotificationConfig.id;
+    if (!configId) {
+      throw new Error(
+        'InMemoryPushNotificationConfigStore.set: pushNotificationConfig.id is required for indexing',
+      );
+    }
     let taskConfigs = this.configs.get(config.taskId);
     if (!taskConfigs) {
       taskConfigs = new Map();
       this.configs.set(config.taskId, taskConfigs);
     }
-    taskConfigs.set(config.id, config);
+    taskConfigs.set(configId, config);
     return config;
   }
 

--- a/packages/a2x/src/a2x/response-mapper.ts
+++ b/packages/a2x/src/a2x/response-mapper.ts
@@ -7,6 +7,7 @@
 
 import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../types/task.js';
 import type { Message } from '../types/common.js';
+import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
 
 // ─── ResponseMapper Interface ───
 
@@ -29,6 +30,20 @@ export interface ResponseMapper {
    * Map an internal TaskArtifactUpdateEvent to its version-specific output.
    */
   mapArtifactUpdateEvent(event: TaskArtifactUpdateEvent): unknown;
+
+  /**
+   * Map a single push notification config to the version-specific wire shape.
+   * v0.3: `{ taskId, pushNotificationConfig }` (nested).
+   * v1.0: `{ id, taskId, url, token?, authentication?, tenant }` (flattened).
+   */
+  mapPushNotificationConfig(config: TaskPushNotificationConfig): unknown;
+
+  /**
+   * Map a list of push notification configs to the version-specific wire shape.
+   * v0.3: bare array.
+   * v1.0: `{ configs: [...], nextPageToken: "" }` (paginated object).
+   */
+  mapPushNotificationConfigList(configs: TaskPushNotificationConfig[]): unknown;
 }
 
 // ─── ResponseMapperFactory ───

--- a/packages/a2x/src/a2x/v03-response-mapper.ts
+++ b/packages/a2x/src/a2x/v03-response-mapper.ts
@@ -16,6 +16,10 @@ import type {
 import type { Message, Part, Artifact } from '../types/common.js';
 import { isTextPart, isFilePart, isDataPart } from '../types/common.js';
 import type { ResponseMapper } from './response-mapper.js';
+import type {
+  PushNotificationConfig,
+  TaskPushNotificationConfig,
+} from '../types/jsonrpc.js';
 
 export class V03ResponseMapper implements ResponseMapper {
   readonly version = '0.3';
@@ -83,7 +87,28 @@ export class V03ResponseMapper implements ResponseMapper {
     return mapped;
   }
 
+  mapPushNotificationConfig(config: TaskPushNotificationConfig): unknown {
+    return {
+      taskId: config.taskId,
+      pushNotificationConfig: this._mapNestedConfig(config.pushNotificationConfig),
+    };
+  }
+
+  mapPushNotificationConfigList(configs: TaskPushNotificationConfig[]): unknown {
+    return configs.map((c) => this.mapPushNotificationConfig(c));
+  }
+
   // ─── Private Helpers ───
+
+  private _mapNestedConfig(inner: PushNotificationConfig): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+      url: inner.url,
+    };
+    if (inner.id !== undefined) out.id = inner.id;
+    if (inner.token !== undefined) out.token = inner.token;
+    if (inner.authentication !== undefined) out.authentication = inner.authentication;
+    return out;
+  }
 
   private _mapStatus(status: TaskStatus): Record<string, unknown> {
     const mapped: Record<string, unknown> = {

--- a/packages/a2x/src/a2x/v10-response-mapper.ts
+++ b/packages/a2x/src/a2x/v10-response-mapper.ts
@@ -18,6 +18,7 @@ import type { TaskState } from '../types/task.js';
 import type { Message, Part, Artifact, Role } from '../types/common.js';
 import { ROLE_TO_V10 } from '../types/common.js';
 import type { ResponseMapper } from './response-mapper.js';
+import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
 
 export class V10ResponseMapper implements ResponseMapper {
   readonly version = '1.0';
@@ -78,6 +79,25 @@ export class V10ResponseMapper implements ResponseMapper {
     }
 
     return mapped;
+  }
+
+  mapPushNotificationConfig(config: TaskPushNotificationConfig): unknown {
+    const inner = config.pushNotificationConfig;
+    const flat: Record<string, unknown> = {
+      id: inner.id ?? '',
+      taskId: config.taskId,
+      url: inner.url,
+    };
+    if (inner.token !== undefined) flat.token = inner.token;
+    if (inner.authentication !== undefined) flat.authentication = inner.authentication;
+    return flat;
+  }
+
+  mapPushNotificationConfigList(configs: TaskPushNotificationConfig[]): unknown {
+    return {
+      configs: configs.map((c) => this.mapPushNotificationConfig(c)),
+      nextPageToken: '',
+    };
   }
 
   // ─── Private Helpers ───

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -661,13 +661,30 @@ export class DefaultRequestHandler {
         'SetPushNotificationConfig: "pushNotificationConfig.token" must be a string when provided',
       );
     }
-    if (
-      n.authentication !== undefined &&
-      (n.authentication === null || typeof n.authentication !== 'object')
-    ) {
-      throw new InvalidParamsError(
-        'SetPushNotificationConfig: "pushNotificationConfig.authentication" must be an object when provided',
-      );
+    if (n.authentication !== undefined) {
+      if (n.authentication === null || typeof n.authentication !== 'object') {
+        throw new InvalidParamsError(
+          'SetPushNotificationConfig: "pushNotificationConfig.authentication" must be an object when provided',
+        );
+      }
+      const auth = n.authentication as Record<string, unknown>;
+      if (!Array.isArray(auth.schemes) || auth.schemes.length === 0) {
+        throw new InvalidParamsError(
+          'SetPushNotificationConfig: "pushNotificationConfig.authentication.schemes" must be a non-empty array of strings',
+        );
+      }
+      for (const scheme of auth.schemes) {
+        if (typeof scheme !== 'string' || scheme.trim() === '') {
+          throw new InvalidParamsError(
+            'SetPushNotificationConfig: "pushNotificationConfig.authentication.schemes" entries must be non-empty strings',
+          );
+        }
+      }
+      if (auth.credentials !== undefined && typeof auth.credentials !== 'string') {
+        throw new InvalidParamsError(
+          'SetPushNotificationConfig: "pushNotificationConfig.authentication.credentials" must be a string when provided',
+        );
+      }
     }
 
     const innerConfig: PushNotificationConfig = {

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -7,6 +7,7 @@
  * on the result to decide between a JSON response and an SSE stream.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { A2XAgent } from '../a2x/a2x-agent.js';
 import type {
   JSONRPCRequest,
@@ -16,6 +17,7 @@ import type {
   DeletePushNotificationConfigParams,
   GetPushNotificationConfigParams,
   ListPushNotificationConfigsParams,
+  PushNotificationConfig,
   TaskPushNotificationConfig,
 } from '../types/jsonrpc.js';
 import { A2A_METHODS } from '../types/jsonrpc.js';
@@ -431,42 +433,57 @@ export class DefaultRequestHandler {
 
   private async _handleSetPushNotificationConfig(
     params: TaskPushNotificationConfig,
-  ): Promise<TaskPushNotificationConfig> {
+  ): Promise<unknown> {
     const store = this.a2xAgent.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
 
-    return store.set(params);
+    const saved = await store.set(params);
+    return this.responseMapper.mapPushNotificationConfig(saved);
   }
 
   private async _handleGetPushNotificationConfig(
     params: GetPushNotificationConfigParams,
-  ): Promise<TaskPushNotificationConfig> {
+  ): Promise<unknown> {
     const store = this.a2xAgent.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
 
-    const config = await store.get(params.taskId, params.configId);
-    if (!config) {
-      throw new TaskNotFoundError(
-        `Push notification config '${params.configId}' not found for task '${params.taskId}'`,
-      );
+    let config: TaskPushNotificationConfig | null = null;
+    if (params.configId) {
+      config = await store.get(params.taskId, params.configId);
+      if (!config) {
+        throw new TaskNotFoundError(
+          `Push notification config '${params.configId}' not found for task '${params.taskId}'`,
+        );
+      }
+    } else {
+      // v0.3 spec allows { id: taskId } without pushNotificationConfigId; fall
+      // back to the first stored config for the task.
+      const all = await store.list(params.taskId);
+      if (all.length === 0) {
+        throw new TaskNotFoundError(
+          `No push notification configs found for task '${params.taskId}'`,
+        );
+      }
+      config = all[0]!;
     }
 
-    return config;
+    return this.responseMapper.mapPushNotificationConfig(config);
   }
 
   private async _handleListPushNotificationConfigs(
     params: ListPushNotificationConfigsParams,
-  ): Promise<TaskPushNotificationConfig[]> {
+  ): Promise<unknown> {
     const store = this.a2xAgent.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
 
-    return store.list(params.taskId);
+    const configs = await store.list(params.taskId);
+    return this.responseMapper.mapPushNotificationConfigList(configs);
   }
 
   // ─── Private: Helpers ───
@@ -596,16 +613,20 @@ export class DefaultRequestHandler {
   /**
    * Validate set push notification config params.
    *
-   * Both v0.3 and v1.0 use the same nested shape — the wire params themselves
-   * are a TaskPushNotificationConfig object. The v1.0 top-level flattened form
-   * is not accepted in Phase A.
+   * Per v0.3 spec `SetTaskPushNotificationConfigRequest.params` is a
+   * `TaskPushNotificationConfig` with shape `{ taskId, pushNotificationConfig }`
+   * (no top-level `id`). `pushNotificationConfig.id` is optional per spec; the
+   * server assigns a UUID when the client omits it so the store can key it.
+   * v1.0 does not define a Set method; the SDK exposes the same JSON-RPC
+   * method name for both protocol versions as an extension and accepts the
+   * same nested shape.
    */
   private _validateSetPushNotificationConfigParams(
     params: unknown,
   ): TaskPushNotificationConfig {
     if (!params || typeof params !== 'object') {
       throw new InvalidParamsError(
-        'SetPushNotificationConfig requires a "taskId", "id", and "pushNotificationConfig" parameter',
+        'SetPushNotificationConfig requires a "taskId" and "pushNotificationConfig" parameter',
       );
     }
 
@@ -614,11 +635,6 @@ export class DefaultRequestHandler {
     if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
       throw new InvalidParamsError(
         'SetPushNotificationConfig: "taskId" must be a non-empty string',
-      );
-    }
-    if (typeof p.id !== 'string' || (p.id as string).trim() === '') {
-      throw new InvalidParamsError(
-        'SetPushNotificationConfig: "id" must be a non-empty string',
       );
     }
 
@@ -654,47 +670,65 @@ export class DefaultRequestHandler {
       );
     }
 
-    return params as TaskPushNotificationConfig;
+    const innerConfig: PushNotificationConfig = {
+      id: typeof n.id === 'string' ? n.id : randomUUID(),
+      url: n.url,
+      ...(n.token !== undefined ? { token: n.token as string } : {}),
+      ...(n.authentication !== undefined
+        ? { authentication: n.authentication as PushNotificationConfig['authentication'] }
+        : {}),
+    };
+
+    return {
+      taskId: p.taskId,
+      pushNotificationConfig: innerConfig,
+    };
   }
 
   /**
    * Validate and normalize get push notification config params.
    *
-   * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
-   * v1.0 wire format: { taskId: taskId, id: configId }
+   * v0.3 wire: anyOf(TaskIdParams, GetTaskPushNotificationConfigParams)
+   *   - TaskIdParams: { id: taskId }  → configId undefined (handler returns
+   *     the first config for that task).
+   *   - Get...Params: { id: taskId, pushNotificationConfigId?: configId }
+   * v1.0 wire: { taskId, id: configId }
    *
-   * Both are normalized into { taskId, configId }.
+   * Both are normalized into { taskId, configId? } so the handler can
+   * branch on whether a specific config was requested.
    */
   private _validateGetPushNotificationConfigParams(
     params: unknown,
   ): GetPushNotificationConfigParams {
     if (!params || typeof params !== 'object') {
       throw new InvalidParamsError(
-        'GetPushNotificationConfig requires task ID and config ID parameters',
+        'GetPushNotificationConfig requires a task ID parameter',
       );
     }
 
     const p = params as Record<string, unknown>;
     let taskId: string;
-    let configId: string;
+    let configId: string | undefined;
 
     if (this.a2xAgent.protocolVersion === '0.3') {
-      // v0.3: { id: taskId, pushNotificationConfigId: configId }
+      // v0.3: { id: taskId, pushNotificationConfigId?: configId }
       if (typeof p.id !== 'string' || p.id.trim() === '') {
         throw new InvalidParamsError(
           'GetPushNotificationConfig: "id" (task ID) must be a non-empty string',
         );
       }
-      if (
-        typeof p.pushNotificationConfigId !== 'string' ||
-        (p.pushNotificationConfigId as string).trim() === ''
-      ) {
-        throw new InvalidParamsError(
-          'GetPushNotificationConfig: "pushNotificationConfigId" must be a non-empty string',
-        );
-      }
       taskId = p.id as string;
-      configId = p.pushNotificationConfigId as string;
+      if (p.pushNotificationConfigId !== undefined) {
+        if (
+          typeof p.pushNotificationConfigId !== 'string' ||
+          (p.pushNotificationConfigId as string).trim() === ''
+        ) {
+          throw new InvalidParamsError(
+            'GetPushNotificationConfig: "pushNotificationConfigId" must be a non-empty string when provided',
+          );
+        }
+        configId = p.pushNotificationConfigId as string;
+      }
     } else {
       // v1.0: { taskId: taskId, id: configId }
       if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
@@ -713,7 +747,7 @@ export class DefaultRequestHandler {
 
     return {
       taskId,
-      configId,
+      ...(configId !== undefined ? { configId } : {}),
       metadata: p.metadata as Record<string, unknown> | undefined,
     };
   }

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -687,8 +687,11 @@ export class DefaultRequestHandler {
       }
     }
 
+    // Empty-string id is treated as absent (v1.0 proto-default semantic);
+    // the server assigns a UUID so the store can key the entry.
+    const clientId = typeof n.id === 'string' && n.id.length > 0 ? n.id : undefined;
     const innerConfig: PushNotificationConfig = {
-      id: typeof n.id === 'string' ? n.id : randomUUID(),
+      id: clientId ?? randomUUID(),
       url: n.url,
       ...(n.token !== undefined ? { token: n.token as string } : {}),
       ...(n.authentication !== undefined

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -14,6 +14,9 @@ import type {
   SendMessageParams,
   TaskIdParams,
   DeletePushNotificationConfigParams,
+  GetPushNotificationConfigParams,
+  ListPushNotificationConfigsParams,
+  TaskPushNotificationConfig,
 } from '../types/jsonrpc.js';
 import { A2A_METHODS } from '../types/jsonrpc.js';
 import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
@@ -296,6 +299,33 @@ export class DefaultRequestHandler {
         return this._handleDeletePushNotificationConfig(deleteParams);
       },
     );
+
+    // tasks/pushNotificationConfig/set
+    this.router.registerMethod(
+      A2A_METHODS.SET_PUSH_CONFIG,
+      async (params) => {
+        const setParams = this._validateSetPushNotificationConfigParams(params);
+        return this._handleSetPushNotificationConfig(setParams);
+      },
+    );
+
+    // tasks/pushNotificationConfig/get
+    this.router.registerMethod(
+      A2A_METHODS.GET_PUSH_CONFIG,
+      async (params) => {
+        const getParams = this._validateGetPushNotificationConfigParams(params);
+        return this._handleGetPushNotificationConfig(getParams);
+      },
+    );
+
+    // tasks/pushNotificationConfig/list
+    this.router.registerMethod(
+      A2A_METHODS.LIST_PUSH_CONFIGS,
+      async (params) => {
+        const listParams = this._validateListPushNotificationConfigParams(params);
+        return this._handleListPushNotificationConfigs(listParams);
+      },
+    );
   }
 
   // ─── Private: Method Handlers ───
@@ -397,6 +427,46 @@ export class DefaultRequestHandler {
     }
 
     return null;
+  }
+
+  private async _handleSetPushNotificationConfig(
+    params: TaskPushNotificationConfig,
+  ): Promise<TaskPushNotificationConfig> {
+    const store = this.a2xAgent.pushNotificationConfigStore;
+    if (!store) {
+      throw new PushNotificationNotSupportedError();
+    }
+
+    return store.set(params);
+  }
+
+  private async _handleGetPushNotificationConfig(
+    params: GetPushNotificationConfigParams,
+  ): Promise<TaskPushNotificationConfig> {
+    const store = this.a2xAgent.pushNotificationConfigStore;
+    if (!store) {
+      throw new PushNotificationNotSupportedError();
+    }
+
+    const config = await store.get(params.taskId, params.configId);
+    if (!config) {
+      throw new TaskNotFoundError(
+        `Push notification config '${params.configId}' not found for task '${params.taskId}'`,
+      );
+    }
+
+    return config;
+  }
+
+  private async _handleListPushNotificationConfigs(
+    params: ListPushNotificationConfigsParams,
+  ): Promise<TaskPushNotificationConfig[]> {
+    const store = this.a2xAgent.pushNotificationConfigStore;
+    if (!store) {
+      throw new PushNotificationNotSupportedError();
+    }
+
+    return store.list(params.taskId);
   }
 
   // ─── Private: Helpers ───
@@ -519,6 +589,175 @@ export class DefaultRequestHandler {
     return {
       taskId,
       configId,
+      metadata: p.metadata as Record<string, unknown> | undefined,
+    };
+  }
+
+  /**
+   * Validate set push notification config params.
+   *
+   * Both v0.3 and v1.0 use the same nested shape — the wire params themselves
+   * are a TaskPushNotificationConfig object. The v1.0 top-level flattened form
+   * is not accepted in Phase A.
+   */
+  private _validateSetPushNotificationConfigParams(
+    params: unknown,
+  ): TaskPushNotificationConfig {
+    if (!params || typeof params !== 'object') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig requires a "taskId", "id", and "pushNotificationConfig" parameter',
+      );
+    }
+
+    const p = params as Record<string, unknown>;
+
+    if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "taskId" must be a non-empty string',
+      );
+    }
+    if (typeof p.id !== 'string' || (p.id as string).trim() === '') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "id" must be a non-empty string',
+      );
+    }
+
+    const nested = p.pushNotificationConfig;
+    if (!nested || typeof nested !== 'object') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig" must be an object',
+      );
+    }
+
+    const n = nested as Record<string, unknown>;
+    if (typeof n.url !== 'string' || (n.url as string).trim() === '') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.url" must be a non-empty string',
+      );
+    }
+    if (n.id !== undefined && typeof n.id !== 'string') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.id" must be a string when provided',
+      );
+    }
+    if (n.token !== undefined && typeof n.token !== 'string') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.token" must be a string when provided',
+      );
+    }
+    if (
+      n.authentication !== undefined &&
+      (n.authentication === null || typeof n.authentication !== 'object')
+    ) {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.authentication" must be an object when provided',
+      );
+    }
+
+    return params as TaskPushNotificationConfig;
+  }
+
+  /**
+   * Validate and normalize get push notification config params.
+   *
+   * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
+   * v1.0 wire format: { taskId: taskId, id: configId }
+   *
+   * Both are normalized into { taskId, configId }.
+   */
+  private _validateGetPushNotificationConfigParams(
+    params: unknown,
+  ): GetPushNotificationConfigParams {
+    if (!params || typeof params !== 'object') {
+      throw new InvalidParamsError(
+        'GetPushNotificationConfig requires task ID and config ID parameters',
+      );
+    }
+
+    const p = params as Record<string, unknown>;
+    let taskId: string;
+    let configId: string;
+
+    if (this.a2xAgent.protocolVersion === '0.3') {
+      // v0.3: { id: taskId, pushNotificationConfigId: configId }
+      if (typeof p.id !== 'string' || p.id.trim() === '') {
+        throw new InvalidParamsError(
+          'GetPushNotificationConfig: "id" (task ID) must be a non-empty string',
+        );
+      }
+      if (
+        typeof p.pushNotificationConfigId !== 'string' ||
+        (p.pushNotificationConfigId as string).trim() === ''
+      ) {
+        throw new InvalidParamsError(
+          'GetPushNotificationConfig: "pushNotificationConfigId" must be a non-empty string',
+        );
+      }
+      taskId = p.id as string;
+      configId = p.pushNotificationConfigId as string;
+    } else {
+      // v1.0: { taskId: taskId, id: configId }
+      if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
+        throw new InvalidParamsError(
+          'GetPushNotificationConfig: "taskId" must be a non-empty string',
+        );
+      }
+      if (typeof p.id !== 'string' || p.id.trim() === '') {
+        throw new InvalidParamsError(
+          'GetPushNotificationConfig: "id" (config ID) must be a non-empty string',
+        );
+      }
+      taskId = p.taskId as string;
+      configId = p.id as string;
+    }
+
+    return {
+      taskId,
+      configId,
+      metadata: p.metadata as Record<string, unknown> | undefined,
+    };
+  }
+
+  /**
+   * Validate and normalize list push notification configs params.
+   *
+   * v0.3 wire format: { id: taskId }
+   * v1.0 wire format: { taskId, pageSize?, pageToken? }
+   *
+   * Pagination fields (pageSize/pageToken) are accepted but ignored.
+   */
+  private _validateListPushNotificationConfigParams(
+    params: unknown,
+  ): ListPushNotificationConfigsParams {
+    if (!params || typeof params !== 'object') {
+      throw new InvalidParamsError(
+        'ListPushNotificationConfig requires a task ID parameter',
+      );
+    }
+
+    const p = params as Record<string, unknown>;
+    let taskId: string;
+
+    if (this.a2xAgent.protocolVersion === '0.3') {
+      // v0.3: { id: taskId }
+      if (typeof p.id !== 'string' || p.id.trim() === '') {
+        throw new InvalidParamsError(
+          'ListPushNotificationConfig: "id" (task ID) must be a non-empty string',
+        );
+      }
+      taskId = p.id as string;
+    } else {
+      // v1.0: { taskId: taskId, pageSize?, pageToken? }
+      if (typeof p.taskId !== 'string' || (p.taskId as string).trim() === '') {
+        throw new InvalidParamsError(
+          'ListPushNotificationConfig: "taskId" must be a non-empty string',
+        );
+      }
+      taskId = p.taskId as string;
+    }
+
+    return {
+      taskId,
       metadata: p.metadata as Record<string, unknown> | undefined,
     };
   }

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -83,8 +83,16 @@ export interface PushNotificationAuthenticationInfo {
   credentials?: string;
 }
 
+/**
+ * Spec-canonical v0.3 TaskPushNotificationConfig shape:
+ *   { taskId, pushNotificationConfig }
+ *
+ * The config identifier lives at `pushNotificationConfig.id` and is
+ * optional per spec; server-side handlers assign a UUID when clients omit
+ * it so the store can key it. v1.0 wire responses are produced by the
+ * response mapper (flattened shape) — do not add top-level `id` here.
+ */
 export interface TaskPushNotificationConfig {
-  id: string;
   taskId: string;
   pushNotificationConfig: PushNotificationConfig;
 }
@@ -110,14 +118,17 @@ export interface DeletePushNotificationConfigParams {
 /**
  * Version-agnostic internal representation for get push notification config.
  *
- * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
+ * v0.3 wire format: anyOf(TaskIdParams, GetTaskPushNotificationConfigParams)
+ *   - TaskIdParams: { id: taskId }  → configId omitted (return first config)
+ *   - Get...Params: { id: taskId, pushNotificationConfigId?: configId }
  * v1.0 wire format: { taskId: taskId, id: configId }
  *
- * The validator normalizes both formats into this unified shape.
+ * `configId` is optional because v0.3 spec marks `pushNotificationConfigId`
+ * optional; handlers fall back to the first stored config when absent.
  */
 export interface GetPushNotificationConfigParams {
   taskId: string;
-  configId: string;
+  configId?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -104,3 +104,35 @@ export interface DeletePushNotificationConfigParams {
   configId: string;
   metadata?: Record<string, unknown>;
 }
+
+// ─── Get Push Notification Config Parameters ───
+
+/**
+ * Version-agnostic internal representation for get push notification config.
+ *
+ * v0.3 wire format: { id: taskId, pushNotificationConfigId: configId }
+ * v1.0 wire format: { taskId: taskId, id: configId }
+ *
+ * The validator normalizes both formats into this unified shape.
+ */
+export interface GetPushNotificationConfigParams {
+  taskId: string;
+  configId: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ─── List Push Notification Configs Parameters ───
+
+/**
+ * Version-agnostic internal representation for list push notification configs.
+ *
+ * v0.3 wire format: { id: taskId }
+ * v1.0 wire format: { taskId, pageSize?, pageToken? }
+ *
+ * The validator normalizes both formats into this unified shape. Pagination
+ * fields are accepted on the wire but ignored in Phase A.
+ */
+export interface ListPushNotificationConfigsParams {
+  taskId: string;
+  metadata?: Record<string, unknown>;
+}

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -4,6 +4,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
+  InMemoryPushNotificationConfigStore,
   A2XAgent,
   DefaultRequestHandler,
   OAuth2DeviceCodeAuthorization,
@@ -27,8 +28,14 @@ const executor = new AgentExecutor({
 });
 
 const taskStore = new InMemoryTaskStore();
+const pushNotificationConfigStore = new InMemoryPushNotificationConfigStore();
 
-export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+export const a2xAgent = new A2XAgent({
+  taskStore,
+  executor,
+  protocolVersion: '1.0',
+  pushNotificationConfigStore,
+})
   .setDefaultUrl("http://localhost:3000/api/a2a")
   .addSkill({
     id: "chat",
@@ -36,7 +43,7 @@ export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.
     description: "General conversation and Q&A",
     tags: ["chat", "general"],
   })
-  .setCapabilities({ streaming: true })
+  .setCapabilities({ streaming: true, pushNotifications: true })
   .addSecurityScheme(
     'deviceCode',
     new OAuth2DeviceCodeAuthorization({


### PR DESCRIPTION
## Summary

- Wire three JSON-RPC methods that were declared in `A2A_METHODS` but never routed in `DefaultRequestHandler._registerRoutes()`: `tasks/pushNotificationConfig/set`, `tasks/pushNotificationConfig/get`, `tasks/pushNotificationConfig/list`.
- Each handler delegates to `PushNotificationConfigStore` and mirrors the existing `delete` handler one-for-one (validator, wire-shape normalizer, error mapping). Missing configs surface `TaskNotFoundError(-32001)`; agents without a store inject still see `PushNotificationNotSupportedError(-32003)`.
- v0.3 (`{ id: taskId, pushNotificationConfigId }`) and v1.0 (`{ taskId, id }`) wire shapes are normalized; pagination fields (`pageSize`, `pageToken`) are accepted but ignored in Phase A.
- `samples/nextjs/src/lib/a2x-setup.ts` now permanently injects `InMemoryPushNotificationConfigStore` so end-to-end clients can exercise the full lifecycle.
- Changeset adds a `@a2x/sdk` minor bump.

**Out of scope (Phase B)**: `tasks/resubscribe` and `agent/authenticatedExtendedCard` remain unimplemented; they need separate design work (resubscribe event bus, extended-card API surface) and should ship as follow-up issues.

Closes #30

## Test plan

- [x] `pnpm lint` (no new warnings; the `bin-bundle` warning is pre-existing)
- [x] `pnpm --filter @a2x/sdk typecheck`
- [x] `pnpm test` — 266 tests pass, including 55 in `request-handler.test.ts` (20 new cases covering set/get/list happy-path, 404, v0.3/v1.0 wire shapes, and invalid-params)
- [x] `pnpm changeset status` — `@a2x/sdk` scheduled for minor bump
- [x] E2E against `samples/nextjs` (dev server, raw JSON-RPC via curl):
  - `set` → persists and echoes `TaskPushNotificationConfig`
  - `set` second config → second entry persisted under the same task
  - `get` → returns stored config
  - `list` → returns both entries for the task
  - `get` non-existent → `{ code: -32001, message: "Push notification config 'cfg-NOPE' not found for task ..." }`
  - `list` unknown task → `[]`
  - `delete` → returns `null`, subsequent `list` reflects removal
  - `set` missing `taskId` → `{ code: -32602, message: "SetPushNotificationConfig: \"taskId\" must be a non-empty string" }`
- [x] `@a2x/cli a2a agent-card http://localhost:3123` confirms the sample still serves the updated card.