### PR TITLE
feat(a2x): implement agent/getAuthenticatedExtendedCard

### DIFF
--- a/.changeset/feat-authenticated-extended-card-40.md
+++ b/.changeset/feat-authenticated-extended-card-40.md
@@ -1,0 +1,22 @@
+---
+"@a2x/sdk": minor
+---
+
+feat(a2x): implement `agent/getAuthenticatedExtendedCard` JSON-RPC method
+
+Adds a builder API `A2XAgent.setAuthenticatedExtendedCardProvider(fn)` that
+lets agent authors declare how to enrich the AgentCard for authenticated
+callers. When set, the SDK automatically advertises the capability on the
+base card (`supportsAuthenticatedExtendedCard` for v0.3,
+`capabilities.extendedAgentCard` for v1.0) and the new JSON-RPC method
+returns a merged card built from the base state plus the provider's overlay.
+Returns `AuthenticationRequiredError` when the call is unauthenticated and
+`AuthenticatedExtendedCardNotConfiguredError` when no provider is
+registered.
+
+Also corrects the method-name constant in `A2A_METHODS.GET_EXTENDED_CARD`
+from the non-compliant `'agent/authenticatedExtendedCard'` to the
+spec-defined `'agent/getAuthenticatedExtendedCard'`. This was never a
+functional method before, so no external callers are affected.
+
+Closes #40.

--- a/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
+++ b/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { DefaultRequestHandler } from '../transport/request-handler.js';
+import { A2XAgent } from '../a2x/a2x-agent.js';
+import type { ProtocolVersion } from '../a2x/a2x-agent.js';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryTaskStore } from '../a2x/task-store.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { LlmAgent } from '../agent/llm-agent.js';
+import { BaseLlmProvider } from '../provider/base.js';
+import { A2A_ERROR_CODES } from '../types/errors.js';
+import { A2A_METHODS } from '../types/jsonrpc.js';
+import type { JSONRPCResponse, JSONRPCErrorResponse } from '../types/jsonrpc.js';
+import { ApiKeyAuthorization } from '../security/api-key.js';
+import type { RequestContext, AuthResult } from '../types/auth.js';
+import type {
+  A2XAgentState,
+  AgentCardV03,
+  AgentCardV10,
+} from '../types/agent-card.js';
+
+// Ensure mappers are registered
+import '../a2x/index.js';
+
+const mockProvider = new (class extends BaseLlmProvider {
+  readonly name = 'mock';
+  constructor() {
+    super({ model: 'gpt-4' });
+  }
+  async generateContent() {
+    return { content: [], finishReason: 'stop' };
+  }
+})();
+
+interface HandlerBuildOptions {
+  protocolVersion?: ProtocolVersion;
+  withProvider?: (authResult: AuthResult) => Partial<A2XAgentState> | Promise<Partial<A2XAgentState>>;
+  withAuth?: boolean;
+}
+
+function createHandler(options: HandlerBuildOptions = {}): DefaultRequestHandler {
+  const agent = new LlmAgent({
+    name: 'test-agent',
+    provider: mockProvider,
+    description: 'A test agent',
+    instruction: 'You are a helpful assistant.',
+  });
+
+  const runner = new InMemoryRunner({ agent, appName: 'test' });
+  const executor = new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+  const taskStore = new InMemoryTaskStore();
+  const a2xAgent = new A2XAgent({
+    taskStore,
+    executor,
+    protocolVersion: options.protocolVersion,
+  });
+  a2xAgent.setDefaultUrl('https://example.com/a2a');
+
+  if (options.withAuth) {
+    a2xAgent
+      .addSecurityScheme(
+        'apiKey',
+        new ApiKeyAuthorization({
+          in: 'header',
+          name: 'x-api-key',
+          keys: ['secret-123'],
+        }),
+      )
+      .addSecurityRequirement({ apiKey: [] });
+  }
+
+  if (options.withProvider) {
+    a2xAgent.setAuthenticatedExtendedCardProvider(options.withProvider);
+  }
+
+  return new DefaultRequestHandler(a2xAgent);
+}
+
+function isAsyncGenerator(value: unknown): value is AsyncGenerator {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    Symbol.asyncIterator in (value as object)
+  );
+}
+
+const validContext: RequestContext = {
+  headers: { 'x-api-key': 'secret-123' },
+};
+
+const extendedCardRequest = {
+  jsonrpc: '2.0' as const,
+  id: 1,
+  method: A2A_METHODS.GET_EXTENDED_CARD,
+};
+
+describe('agent/getAuthenticatedExtendedCard', () => {
+  it('method constant is spec-compliant', () => {
+    expect(A2A_METHODS.GET_EXTENDED_CARD).toBe(
+      'agent/getAuthenticatedExtendedCard',
+    );
+  });
+
+  it('returns AuthenticatedExtendedCardNotConfiguredError when no provider is registered', async () => {
+    const handler = createHandler({ withAuth: true });
+
+    const response = await handler.handle(extendedCardRequest, validContext);
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('error' in rpc).toBe(true);
+    expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+      A2A_ERROR_CODES.AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED,
+    );
+  });
+
+  it('returns AuthenticationRequiredError when the call is unauthenticated', async () => {
+    const handler = createHandler({
+      withAuth: true,
+      withProvider: () => ({ description: 'Extended' }),
+    });
+
+    // Missing API key — auth will fail and the pre-dispatch block returns
+    // AUTHENTICATION_REQUIRED before the special-case branch runs.
+    const response = await handler.handle(extendedCardRequest, {
+      headers: {},
+    });
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('error' in rpc).toBe(true);
+    expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+      A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+    );
+  });
+
+  it('returns AuthenticationRequiredError when no context is provided but provider is configured', async () => {
+    // Provider configured but also requires auth. Without a context, the
+    // pre-dispatch auth step is skipped, so the special-case branch trips
+    // on missing authResult and raises AUTHENTICATION_REQUIRED itself.
+    const handler = createHandler({
+      withAuth: true,
+      withProvider: () => ({ description: 'Extended' }),
+    });
+
+    const response = await handler.handle(extendedCardRequest);
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('error' in rpc).toBe(true);
+    expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+      A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+    );
+  });
+
+  it('returns merged card (v0.3) with overlay description and skills', async () => {
+    const extraSkill = {
+      id: 'premium-skill',
+      name: 'Premium Skill',
+      description: 'Only for authenticated users',
+      tags: ['premium'],
+    };
+
+    const handler = createHandler({
+      protocolVersion: '0.3',
+      withAuth: true,
+      withProvider: () => ({
+        description: 'Extended desc',
+        skills: [extraSkill],
+      }),
+    });
+
+    const response = await handler.handle(extendedCardRequest, validContext);
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('result' in rpc).toBe(true);
+    const card = (rpc as { result: unknown }).result as AgentCardV03;
+
+    expect(card.protocolVersion).toBe('0.3.0');
+    expect(card.description).toBe('Extended desc');
+    expect(card.skills).toHaveLength(1);
+    expect(card.skills[0].id).toBe('premium-skill');
+    expect(card.supportsAuthenticatedExtendedCard).toBe(true);
+  });
+
+  it('returns merged card (v1.0) with capability flag and overlay reflected', async () => {
+    const extraSkill = {
+      id: 'premium-skill',
+      name: 'Premium Skill',
+      description: 'Only for authenticated users',
+      tags: ['premium'],
+    };
+
+    const handler = createHandler({
+      protocolVersion: '1.0',
+      withAuth: true,
+      withProvider: () => ({
+        description: 'Extended desc v1',
+        skills: [extraSkill],
+      }),
+    });
+
+    const response = await handler.handle(extendedCardRequest, validContext);
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('result' in rpc).toBe(true);
+    const card = (rpc as { result: unknown }).result as AgentCardV10;
+
+    expect(card.description).toBe('Extended desc v1');
+    expect(card.skills).toHaveLength(1);
+    expect(card.skills[0].id).toBe('premium-skill');
+    expect(card.capabilities.extendedAgentCard).toBe(true);
+  });
+
+  it('passes the resolved AuthResult to the provider', async () => {
+    let captured: AuthResult | undefined;
+
+    const handler = createHandler({
+      withAuth: true,
+      withProvider: (authResult) => {
+        captured = authResult;
+        return { description: 'Extended' };
+      },
+    });
+
+    const response = await handler.handle(extendedCardRequest, validContext);
+
+    expect(isAsyncGenerator(response)).toBe(false);
+    const rpc = response as JSONRPCResponse;
+    expect('result' in rpc).toBe(true);
+
+    expect(captured).toBeDefined();
+    expect(captured!.authenticated).toBe(true);
+    expect(captured!.principal).toEqual({ apiKey: 'secret-123' });
+  });
+});

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -14,6 +14,8 @@ import type {
   AgentCardV10,
 } from '../types/agent-card.js';
 import type { SecurityRequirement } from '../types/security.js';
+import type { AuthResult } from '../types/auth.js';
+import { AuthenticatedExtendedCardNotConfiguredError } from '../types/errors.js';
 import { AgentExecutor, StreamingMode } from './agent-executor.js';
 import { AgentCardMapperFactory } from './agent-card-mapper.js';
 import type { TaskStore } from './task-store.js';
@@ -61,6 +63,9 @@ export class A2XAgent {
   private _documentationUrl?: string;
   private _iconUrl?: string;
   private _supportsAuthenticatedExtendedCard?: boolean;
+  private _authenticatedExtendedCardProvider?: (
+    authResult: AuthResult,
+  ) => Partial<A2XAgentState> | Promise<Partial<A2XAgentState>>;
 
   // ─── AgentCard cache ───
   private _cardCache = new Map<string, AgentCardV03 | AgentCardV10>();
@@ -187,6 +192,30 @@ export class A2XAgent {
     return this;
   }
 
+  /**
+   * Register a provider that enriches the AgentCard for authenticated users.
+   *
+   * When set, the JSON-RPC method `agent/getAuthenticatedExtendedCard`
+   * becomes available. The provider is invoked with the resolved AuthResult
+   * and returns a Partial<A2XAgentState> overlay that is merged on top of
+   * the base state before mapping to the target protocol version.
+   *
+   * Automatically advertises the capability on the base AgentCard:
+   *   - v0.3: `supportsAuthenticatedExtendedCard: true`
+   *   - v1.0: `capabilities.extendedAgentCard: true`
+   */
+  setAuthenticatedExtendedCardProvider(
+    provider: (
+      authResult: AuthResult,
+    ) => Partial<A2XAgentState> | Promise<Partial<A2XAgentState>>,
+  ): this {
+    this._authenticatedExtendedCardProvider = provider;
+    this._supportsAuthenticatedExtendedCard = true;
+    this._capabilities = { ...this._capabilities, extendedAgentCard: true };
+    this._invalidateCache();
+    return this;
+  }
+
   // ─── Core Method ───
 
   getAgentCard(version?: string): AgentCardV03 | AgentCardV10 {
@@ -277,6 +306,61 @@ export class A2XAgent {
 
   get taskEventBus(): TaskEventBus {
     return this._taskEventBus;
+  }
+
+  get hasAuthenticatedExtendedCardProvider(): boolean {
+    return this._authenticatedExtendedCardProvider !== undefined;
+  }
+
+  /**
+   * Build the authenticated extended AgentCard.
+   *
+   * Throws `AuthenticatedExtendedCardNotConfiguredError` if no provider
+   * has been registered. Does NOT perform authentication itself — the
+   * caller is responsible for passing an authenticated AuthResult.
+   */
+  async getAuthenticatedExtendedCard(
+    authResult: AuthResult,
+    version?: string,
+  ): Promise<AgentCardV03 | AgentCardV10> {
+    const provider = this._authenticatedExtendedCardProvider;
+    if (!provider) {
+      throw new AuthenticatedExtendedCardNotConfiguredError();
+    }
+
+    const baseState = this._buildState();
+    const overlay = await provider(authResult);
+
+    // Shallow merge for top-level fields; deep merge for capabilities and
+    // arrays (skills, interfaces, securityRequirements) are replaced wholesale
+    // by the overlay when present. This keeps semantics simple and predictable.
+    const mergedState: A2XAgentState = {
+      ...baseState,
+      ...overlay,
+      capabilities: {
+        ...baseState.capabilities,
+        ...(overlay.capabilities ?? {}),
+      },
+      // If overlay supplies securitySchemes (rare), merge Maps; otherwise keep base.
+      securitySchemes: overlay.securitySchemes
+        ? new Map([...baseState.securitySchemes, ...overlay.securitySchemes])
+        : baseState.securitySchemes,
+    };
+
+    if (!mergedState.name) {
+      throw new Error(
+        'A2XAgent.getAuthenticatedExtendedCard: name is required on the merged state',
+      );
+    }
+    if (!mergedState.description) {
+      throw new Error(
+        'A2XAgent.getAuthenticatedExtendedCard: description is required on the merged state',
+      );
+    }
+
+    const resolvedVersion = version ?? this._protocolVersion;
+    const mapper = AgentCardMapperFactory.getMapper(resolvedVersion);
+    return mapper.map(mergedState) as AgentCardV03 | AgentCardV10;
   }
 
   // ─── Private Methods ───

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -28,6 +28,7 @@ import type {
 } from '../types/task.js';
 import { TERMINAL_STATES } from '../types/task.js';
 import {
+  AuthenticatedExtendedCardNotConfiguredError,
   AuthenticationRequiredError,
   InternalError,
   InvalidParamsError,
@@ -120,9 +121,12 @@ export class DefaultRequestHandler {
       };
     }
 
-    // Authenticate if context is provided and security requirements exist
+    // Authenticate if context is provided and security requirements exist.
+    // Capture authResult so special-case handlers (e.g. the authenticated
+    // extended card) can consume the resolved principal/scopes.
+    let authResult: AuthResult | undefined;
     if (context && this.a2xAgent.securityRequirements.length > 0) {
-      const authResult = await this._authenticate(context);
+      authResult = await this._authenticate(context);
       if (!authResult.authenticated) {
         const error = new AuthenticationRequiredError(
           authResult.error ?? 'Authentication required',
@@ -132,6 +136,29 @@ export class DefaultRequestHandler {
           id: request.id,
           error: error.toJSONRPCError(),
         };
+      }
+    }
+
+    // Special-case: authenticated extended card needs authResult; do not
+    // route via JsonRpcRouter because that layer has no access to auth.
+    if (request.method === A2A_METHODS.GET_EXTENDED_CARD) {
+      try {
+        if (!this.a2xAgent.hasAuthenticatedExtendedCardProvider) {
+          throw new AuthenticatedExtendedCardNotConfiguredError();
+        }
+        if (!authResult || !authResult.authenticated) {
+          throw new AuthenticationRequiredError(
+            'Authentication is required for the authenticated extended card',
+          );
+        }
+        const card = await this.a2xAgent.getAuthenticatedExtendedCard(authResult);
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: card,
+        };
+      } catch (err) {
+        return this._toErrorResponse(request.id, err);
       }
     }
 

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -45,7 +45,7 @@ export const A2A_METHODS = {
   GET_PUSH_CONFIG: 'tasks/pushNotificationConfig/get',
   LIST_PUSH_CONFIGS: 'tasks/pushNotificationConfig/list',
   DELETE_PUSH_CONFIG: 'tasks/pushNotificationConfig/delete',
-  GET_EXTENDED_CARD: 'agent/authenticatedExtendedCard',
+  GET_EXTENDED_CARD: 'agent/getAuthenticatedExtendedCard',
 } as const;
 
 // ─── SendMessage Parameters ───


### PR DESCRIPTION
## Summary

Implements #40. Wires the A2A v0.3 `agent/getAuthenticatedExtendedCard` JSON-RPC method end-to-end and introduces a builder-level hook (`setAuthenticatedExtendedCardProvider`) that lets agent authors declare an authentication-aware enrichment of their AgentCard.

Also corrects a pre-existing spec bug: the `A2A_METHODS.GET_EXTENDED_CARD` constant was declared as `'agent/authenticatedExtendedCard'`, missing the `get` prefix that the v0.3 spec mandates (`agent/getAuthenticatedExtendedCard`). Since the method was never wired, no external callers depend on the old value.

## Spec conformance

- **v0.3** (`specification/a2a-v0.3.0.json`): `GetAuthenticatedExtendedCardRequest` has no `params`; response `result` is `AgentCard`. Method name matches exactly after the constant fix.
- **v1.0** (`specification/a2a-v1.0.0.json`): the spec does not bind a JSON-RPC method for this. The SDK exposes the same method name as an extension on v1.0; the response is mapped through the v1.0 card mapper. The v1.0-flavored capability flag is `capabilities.extendedAgentCard`.
- **Error codes** (`specification/a2a-v0.3.0.json`): `AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED` (-32007) when no provider; `AUTHENTICATION_REQUIRED` (-32008) when the request is unauthenticated. Both error classes already existed in `types/errors.ts`.

## Changes

### `packages/a2x/src/types/jsonrpc.ts`
Constant corrected: `GET_EXTENDED_CARD: 'agent/authenticatedExtendedCard'` → `'agent/getAuthenticatedExtendedCard'`.

### `packages/a2x/src/a2x/a2x-agent.ts`
- New builder: `setAuthenticatedExtendedCardProvider(fn)` stores the callback and auto-flips both `supportsAuthenticatedExtendedCard` (v0.3) and `capabilities.extendedAgentCard` (v1.0) so discovery clients can tell the extended card is available.
- New accessor: `hasAuthenticatedExtendedCardProvider`.
- New method: `getAuthenticatedExtendedCard(authResult, version?)` — builds base state, applies the overlay (top-level fields replaced, `capabilities` deep-merged, `securitySchemes` Map merged), and maps through the target card mapper. Does **not** perform auth; the caller is responsible for passing an authenticated `AuthResult`.

### `packages/a2x/src/transport/request-handler.ts`
- `handle()` now captures `authResult` from the pre-dispatch auth flow into a local variable.
- Added a special-case branch for `GET_EXTENDED_CARD` that runs **before** routing (so `JsonRpcRouter`, which has no auth context, stays untouched). Returns `AuthenticatedExtendedCardNotConfiguredError` when no provider, `AuthenticationRequiredError` when no authResult or auth failed.

## Tests

New `packages/a2x/src/__tests__/authenticated-extended-card.test.ts` — 7 tests (all pass):

1. Method constant is spec-compliant.
2. No provider → `AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED`.
3. Invalid auth context → `AUTHENTICATION_REQUIRED`.
4. Missing context (with provider configured) → `AUTHENTICATION_REQUIRED`.
5. v0.3 merged card — overlay `description` + `skills` win, `supportsAuthenticatedExtendedCard === true`.
6. v1.0 merged card — overlay reflected, `capabilities.extendedAgentCard === true`.
7. Provider receives the resolved `AuthResult` (including principal).

Suite: **282 tests pass** (up from 275 baseline). `pnpm typecheck`, `pnpm lint`, `pnpm -r build` all clean.

## Test plan

- [x] `pnpm test` — 282 tests pass (+7 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm -r build` — succeeds
- [ ] Manual: run a sample with `setAuthenticatedExtendedCardProvider` configured, call `agent/getAuthenticatedExtendedCard` with valid auth, confirm the returned card is enriched (reviewer)

## Changeset

`@a2x/sdk` minor bump (`.changeset/feat-authenticated-extended-card-40.md`).