### PR TITLE
docs: cover SSE disconnect, tasks/resubscribe, and authenticated extended card

### DIFF
--- a/.changeset/docs-guides-for-issue-46.md
+++ b/.changeset/docs-guides-for-issue-46.md
@@ -1,0 +1,15 @@
+---
+"@a2x/sdk": patch
+---
+
+docs: cover SSE disconnect handling, `tasks/resubscribe`, and the authenticated extended card
+
+Extends the bundled guides to reflect the features landed in PRs #42, #43, #44:
+
+- `guides/agent/streaming.md` — new "Client disconnect stops the work" and "Resuming a dropped SSE stream" sections, with guidance on wiring `res.on('close')` when hand-rolling an HTTP handler.
+- `guides/client/streaming.md` — new "Resuming a dropped stream" section showing the raw-JSON-RPC `tasks/resubscribe` pattern plus a note on the new cancel-on-disconnect contract.
+- `guides/advanced/manual-wiring.md` — documents `A2XAgentOptions.taskEventBus` with a sketch of a cross-process custom bus.
+- `guides/advanced/extended-agent-card.md` — **new** page covering `setAuthenticatedExtendedCardProvider`, overlay merge semantics, per-principal enrichment, and the `-32007` / `-32008` error codes. Linked from `authentication.md`, `agent-card-versioning.md`, and `manifest.json`.
+- `guides/agent/framework-integration.md` — Express snippet updated to include the `res.on('close')` disconnect wiring.
+
+Closes #46.

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -40,6 +40,15 @@ If you have CLI tools or third-party agents still pinned to v0.3, they read `url
 
 OAuth 2.0 Device Code is a v1.0-native security flow. A2X extends it onto v0.3 cards as a non-standard extension so headless clients can still negotiate it. See [Protocol Extensions](./extensions.md) for details.
 
+### Advertising the authenticated extended card
+
+When you call `a2xAgent.setAuthenticatedExtendedCardProvider(...)`, A2X flips the version-specific capability flag on the base card automatically:
+
+- v0.3: top-level `supportsAuthenticatedExtendedCard: true`
+- v1.0: `capabilities.extendedAgentCard: true`
+
+Conforming clients read this to decide whether to call `agent/getAuthenticatedExtendedCard`. You don't set either flag by hand — registering the provider is the only signal you need. See [Authenticated Extended AgentCard](./extended-agent-card.md).
+
 ### 3. Multi-transport agents
 
 If you plan to expose JSON-RPC over HTTP **and** another transport (e.g. gRPC), only v1.0 expresses this cleanly. Legacy v0.3 consumers will only see the first/primary interface.

--- a/packages/a2x/docs/guides/advanced/authentication.md
+++ b/packages/a2x/docs/guides/advanced/authentication.md
@@ -173,6 +173,10 @@ const tokens = await flow.pollForTokens();
 
 Use the returned `access_token` as the bearer on subsequent `A2XClient` calls.
 
+## Exposing an authenticated extended AgentCard
+
+Declaring security also unlocks `agent/getAuthenticatedExtendedCard` — a way to return a richer card (extra skills, private documentation URLs, per-principal metadata) only to callers that pass the security check. See [Authenticated Extended AgentCard](./extended-agent-card.md).
+
 ## Inspecting what an agent requires
 
 Clients can introspect expected auth before calling:

--- a/packages/a2x/docs/guides/advanced/extended-agent-card.md
+++ b/packages/a2x/docs/guides/advanced/extended-agent-card.md
@@ -1,0 +1,104 @@
+# Authenticated Extended AgentCard
+
+An agent can expose a **richer** AgentCard to authenticated callers — extra skills, a longer description, private documentation URLs — without leaking any of it on the public `/.well-known/agent.json`. This is the A2A v0.3 `agent/getAuthenticatedExtendedCard` method, and A2X implements it as an extension on v1.0 too (the v1.0 spec doesn't bind a JSON-RPC name, so we reuse the v0.3 one).
+
+Use this when:
+
+- A skill is free to advertise publicly but only bookable by paying users.
+- Documentation or support URLs shouldn't be harvested by crawlers.
+- You want to tailor the card per-principal (enterprise tenant, user plan, role).
+
+## Wiring it up
+
+Register a provider callback that, given the resolved `AuthResult`, returns a partial agent state to merge on top of the base:
+
+```ts
+import {
+  A2XAgent,
+  ApiKeyAuthorization,
+  type AuthResult,
+  type A2XAgentState,
+} from '@a2x/sdk';
+
+const a2xAgent = new A2XAgent({ taskStore, executor })
+  .setDefaultUrl('https://agent.example.com/a2a')
+  .setName('acme-agent')
+  .setDescription('Public description of Acme Agent.')
+  // Auth is required — the handler returns AuthenticationRequiredError
+  // on unauthenticated calls to the extended-card method.
+  .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+    in: 'header',
+    name: 'x-api-key',
+    keys: [process.env.API_KEY!],
+  }))
+  .addSecurityRequirement({ apiKey: [] })
+  .setAuthenticatedExtendedCardProvider(async (auth: AuthResult): Promise<Partial<A2XAgentState>> => {
+    return {
+      description: 'Full Acme Agent description with private notes.',
+      skills: [
+        { id: 'public_chat', name: 'Chat', description: 'General Q&A.', tags: ['chat'] },
+        { id: 'premium_analysis', name: 'Deep Analysis', description: 'Subscribers only.', tags: ['premium'] },
+      ],
+      documentationUrl: 'https://internal.example.com/acme-agent/docs',
+    };
+  });
+```
+
+That's it. Calling the builder also flips the advertising capability on the base AgentCard:
+
+- v0.3: `supportsAuthenticatedExtendedCard: true`
+- v1.0: `capabilities.extendedAgentCard: true`
+
+Conforming clients see the flag, then call `agent/getAuthenticatedExtendedCard` with valid auth to fetch the enriched card.
+
+## Merge semantics
+
+The partial state returned by your provider is merged over the base state this way:
+
+| Field | Merge strategy |
+|---|---|
+| Top-level scalars (`name`, `description`, `defaultUrl`, `version`, …) | Overlay replaces. |
+| `skills`, `interfaces`, `securityRequirements`, `defaultInputModes`, `defaultOutputModes` | Overlay replaces the whole array when provided. |
+| `capabilities` | Deep-merged — missing keys keep base values. |
+| `securitySchemes` (Map) | Merged — overlay wins on key collision. |
+
+If you only want to *add* skills rather than replace them, build the merged array yourself from the base state:
+
+```ts
+.setAuthenticatedExtendedCardProvider(async (auth) => {
+  const base = a2xAgent.getAgentCard();   // current public card
+  return {
+    skills: [...base.skills, { id: 'premium', ... }],
+  };
+});
+```
+
+## Error semantics
+
+| Situation | JSON-RPC error | Code |
+|---|---|---|
+| Provider never registered | `AuthenticatedExtendedCardNotConfiguredError` | `-32007` |
+| Call arrives without auth (no `context`, failed auth, missing required scope) | `AuthenticationRequiredError` | `-32008` |
+| Resolved name / description missing after merge | Internal error (your provider stripped required fields) | `-32603` |
+
+The auth check runs at the `DefaultRequestHandler` level via the normal security-scheme flow — you don't need to re-implement it inside the provider. The provider only runs **after** `AuthResult.authenticated === true`.
+
+## When `AuthResult` has a principal
+
+Most schemes populate `AuthResult.principal` with whatever identity your validator returned (user ID, tenant ID, JWT sub, etc.). That's the hook for per-principal enrichment:
+
+```ts
+.setAuthenticatedExtendedCardProvider(async (auth) => {
+  const userId = (auth.principal as { sub: string }).sub;
+  const plan = await lookupUserPlan(userId);
+
+  return {
+    description: `Acme Agent — ${plan} tier.`,
+    skills: plan === 'enterprise'
+      ? [...publicSkills, ...enterpriseSkills]
+      : publicSkills,
+  };
+});
+```
+
+Keep the callback cheap. It runs on every extended-card request, and the SDK does **not** cache the per-principal result (unlike the base card, which is cached by version).

--- a/packages/a2x/docs/guides/advanced/manual-wiring.md
+++ b/packages/a2x/docs/guides/advanced/manual-wiring.md
@@ -77,6 +77,31 @@ const handler = new DefaultRequestHandler(a2xAgent);
 
 `InMemoryTaskStore` is the default. It loses state on restart, which is fine for stateless deployments but not for production long-running tasks. See [Custom Task Stores](./task-store.md).
 
+### Task event bus
+
+The bus fans `message/stream` events out to any `tasks/resubscribe` subscribers. `A2XAgent` creates a default `InMemoryTaskEventBus` when you don't pass one — sufficient for single-process deployments.
+
+Swap it when you need cross-process fan-out (e.g. multiple worker nodes behind a load balancer):
+
+```ts
+import { A2XAgent, type TaskEventBus } from '@a2x/sdk';
+
+class RedisTaskEventBus implements TaskEventBus {
+  publish(taskId, event) { /* PUBLISH a2x:task:<taskId> */ }
+  close(taskId) { /* PUBLISH a2x:task:<taskId>:close */ }
+  async *subscribe(taskId, signal) { /* SUBSCRIBE + yield until close */ }
+  hasSubscribers(taskId) { /* SUBSCRIBERS count */ }
+}
+
+const a2xAgent = new A2XAgent({
+  taskStore,
+  executor,
+  taskEventBus: new RedisTaskEventBus(),
+});
+```
+
+The default implementation's queue is unbounded — fine for most agents, but consider bounded backpressure if a single task can emit thousands of events faster than slow subscribers can drain.
+
 ### AgentCard skills and metadata
 
 ```ts

--- a/packages/a2x/docs/guides/agent/framework-integration.md
+++ b/packages/a2x/docs/guides/agent/framework-integration.md
@@ -74,6 +74,14 @@ app.post('/a2a', async (req, res) => {
     res.setHeader('Cache-Control', 'no-cache');
     const stream = createSSEStream(result);
     const reader = stream.getReader();
+
+    // Cancel the reader on client disconnect so the agent aborts in-flight
+    // LLM calls. Use `res.close` — `req.close` fires when the body is
+    // consumed, before streaming begins.
+    res.on('close', () => {
+      void reader.cancel().catch(() => {});
+    });
+
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -88,10 +96,11 @@ app.post('/a2a', async (req, res) => {
 app.listen(4000);
 ```
 
-Two things to notice:
+Three things to notice:
 
 1. `handler.handle()` returns either a plain object (regular response) or an async iterable (streaming response). Branch on `Symbol.asyncIterator`.
 2. `createSSEStream()` wraps the async iterable as an SSE-formatted `ReadableStream`.
+3. Wiring `res.on('close') → reader.cancel()` is what makes client disconnects propagate into the agent's `AbortSignal`. Without it, the LLM loop keeps running after the TCP connection dies. See [Streaming Responses](./streaming.md#client-disconnect-stops-the-work) for the why.
 
 ## Next.js App Router
 

--- a/packages/a2x/docs/guides/agent/streaming.md
+++ b/packages/a2x/docs/guides/agent/streaming.md
@@ -47,6 +47,35 @@ For a `message/stream` call, the client gets an SSE stream of typed events. Each
 
 See [Consuming Streams](../client/streaming.md) for the client-side iteration pattern.
 
+## Client disconnect stops the work
+
+When an SSE client disconnects mid-stream — tab closed, network drop, process killed — A2X propagates the cancellation all the way into the agent's `AbortSignal`. In-flight LLM calls are aborted, long-running tool calls see `context.signal.aborted === true`, and the task generator exits cleanly. No runaway loops, no wasted tokens.
+
+`toA2x()` wires this automatically. If you mount the handler into your own HTTP stack (Express, Next.js, Fastify, …), wire a `res.on('close')` → `reader.cancel()` on the SSE branch — `IncomingMessage.close` fires when the request body is consumed (too early) and misses the later TCP close, so use `res.close`:
+
+```ts
+const stream = createSSEStream(result);
+const reader = stream.getReader();
+
+res.on('close', () => {
+  void reader.cancel().catch(() => {});
+});
+```
+
+See [Framework Integration](./framework-integration.md) for the full per-framework recipe.
+
+## Resuming a dropped SSE stream
+
+If a client loses connection mid-task, it can re-attach via the A2A `tasks/resubscribe` method without restarting the agent. A2X keeps an in-memory **task event bus** that fans events from the original `message/stream` to every live subscriber; a resubscriber catches the tail of the same execution.
+
+Semantics:
+
+- **Forward-only.** Events that fired before the resubscribe call are not replayed.
+- **Terminal replay.** Resubscribing to a task that already completed yields a single status-update event with the final state, then ends.
+- **Unknown task.** Returns `TaskNotFoundError` (JSON-RPC error code `-32001`).
+
+The bus is on by default. For custom storage or multi-process deployments you can inject your own implementation — see [Manual Wiring](../advanced/manual-wiring.md#task-event-bus).
+
 ## Disabling streaming
 
 If you want a deliberately non-streaming agent (e.g. for backpressure reasons), drop `streamingMode`:

--- a/packages/a2x/docs/guides/client/streaming.md
+++ b/packages/a2x/docs/guides/client/streaming.md
@@ -60,6 +60,42 @@ for await (const event of stream) {
 
 If you want the agent itself to stop doing work (not just your client to stop listening), call `client.cancelTask(taskId)` using the `id` from the first `task` event.
 
+As of A2X **0.5.0**, breaking out of the loop is enough on its own: when the underlying HTTP connection closes the server aborts the in-flight agent execution. You don't need to call `cancelTask` just to save tokens on abandoned streams.
+
+## Resuming a dropped stream
+
+If the connection drops but you still want the results — flaky network, mobile tab restore, proxy idle timeout — re-attach to the same task with the A2A `tasks/resubscribe` method. The server keeps publishing events to any live subscriber, so a resubscriber catches the tail of the original execution.
+
+`A2XClient` doesn't yet expose a convenience helper, so issue the call at the JSON-RPC level. The response is an SSE stream with the same event shape as `message/stream`:
+
+```ts
+async function resubscribe(url: string, taskId: string) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tasks/resubscribe',
+      params: { id: taskId },
+    }),
+  });
+
+  // Parse the SSE body however you like — reuse your own SSE parser,
+  // or the one the A2X transport layer exports if you prefer.
+  return response.body!.getReader();
+}
+```
+
+Behavior to know:
+
+- **Forward-only.** Events that fired before the resubscribe call are not replayed — you see what the server publishes from that point on.
+- **Terminal replay.** If the task already completed, you receive a single `status-update` event with the final state, then the stream ends.
+- **Unknown task.** The server emits an SSE `error` event carrying `TaskNotFoundError` (JSON-RPC code `-32001`).
+
 ## Accumulating output
 
 A common pattern — render text as it arrives, keep a running buffer:

--- a/packages/a2x/docs/manifest.json
+++ b/packages/a2x/docs/manifest.json
@@ -40,6 +40,7 @@
       "pages": [
         { "slug": "advanced/manual-wiring", "title": "Manual Wiring" },
         { "slug": "advanced/authentication", "title": "Authentication" },
+        { "slug": "advanced/extended-agent-card", "title": "Authenticated Extended AgentCard" },
         { "slug": "advanced/task-store", "title": "Custom Task Stores" },
         { "slug": "advanced/agent-card-versioning", "title": "AgentCard v0.3 vs v1.0" },
         { "slug": "advanced/extensions", "title": "Protocol Extensions" }


### PR DESCRIPTION
## Summary

Closes #46. None of #42 / #43 / #44 touched the bundled guides, so the documentation silently omitted the new public surface for a full release cycle. This PR fills those gaps.

## What's changed

| File | Change |
|---|---|
| `guides/agent/streaming.md` | New "Client disconnect stops the work" and "Resuming a dropped SSE stream" sections; the former explains the new `AbortSignal` propagation contract (#42) and the `res.on('close')` wiring needed in custom handlers. |
| `guides/client/streaming.md` | New "Resuming a dropped stream" section with a raw-JSON-RPC `tasks/resubscribe` example (the client SDK doesn't have a convenience helper yet), plus a note that breaking a stream loop now actually stops the server-side work. |
| `guides/advanced/manual-wiring.md` | Documents `A2XAgentOptions.taskEventBus` and sketches a custom cross-process bus (Redis pub/sub). |
| `guides/advanced/extended-agent-card.md` (**new**) | Builder setup, overlay merge table, per-principal enrichment pattern, `-32007` / `-32008` error codes. |
| `guides/advanced/authentication.md` | Short cross-link to the new extended-card page. |
| `guides/advanced/agent-card-versioning.md` | Notes that `setAuthenticatedExtendedCardProvider()` auto-flips the v0.3 / v1.0 capability flag. |
| `guides/agent/framework-integration.md` | Express snippet now includes the `res.on('close')` disconnect wiring that the built-in `toA2x()` path already has. |
| `docs/manifest.json` | Registers the new `advanced/extended-agent-card` page between `authentication` and `task-store`. |

Next.js snippet left unchanged — the `Response(stream, …)` constructor propagates cancel to the underlying `ReadableStream` automatically on both Node and Edge runtimes, so no manual wiring is needed there.

## Verification

- `pnpm test` — 379 tests pass (no new tests; docs-only).
- `pnpm typecheck` — clean.
- `pnpm -r build` — succeeds for `@a2x/sdk`, `@a2x/cli`, and the Next.js skill sample.
- `python3 -m json.tool packages/a2x/docs/manifest.json` — valid JSON.

## Changeset

`@a2x/sdk` patch bump (`.changeset/docs-guides-for-issue-46.md`). If merged **before** the currently open release PR #48 (which targets `0.6.0`), this changeset folds into that release — no version change. If merged **after** #48 ships, the next release PR will bump to `0.6.1`.

## Test plan

- [x] `pnpm test`, `pnpm typecheck`, `pnpm -r build`
- [x] `manifest.json` JSON validity
- [ ] Manual: render the new page via the `a2x-web` docs site on a preview deploy (reviewer)