### PR TITLE
chore: cover README sync in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,25 @@ If a change genuinely has no user-visible surface (internal refactor, test-only 
 
 Reviewers: if a diff touches `packages/a2x/src/index.ts` or `request-handler.ts` or exports a new symbol without touching `packages/a2x/docs/`, block the merge and ask why.
 
+### README sync
+
+Guides under `packages/a2x/docs/` cover everything. The two READMEs are **quickstart + feature highlights** and are what every new reader sees first:
+
+- `README.md` (repo root) — published on the GitHub repo landing page.
+- `packages/a2x/README.md` — published on the npm package page.
+
+Update them when a PR adds (or removes) something that belongs in those surfaces:
+
+- A new top-level "Key Features" bullet (e.g. tasks/resubscribe, Claude Agent Skills runtime, authenticated extended card).
+- A new top-level export path (e.g. `@a2x/sdk/client`, `@a2x/sdk/google`) — it belongs in Installation or Usage.
+- A new supported LLM provider, transport, or framework integration worth advertising.
+- A change to the minimum Node / pnpm version, peer-dependency requirement, or environment variable listed in the quickstart.
+- Anything already listed in either README whose behavior this PR materially changes.
+
+Don't update the READMEs for every public method — that's what guides are for. The rule of thumb: **if you would mention it in a release tweet, it belongs in the README**.
+
+Sample READMEs under `samples/*/README.md` follow the same logic scoped to that sample.
+
 ## Changesets
 
 - Every source-affecting PR adds a file under `.changeset/` using the changesets CLI or by hand.


### PR DESCRIPTION
## Why

`AGENTS.md`'s documentation sync policy only named guides under `packages/a2x/docs/`. The repo-root `README.md` and `packages/a2x/README.md` are the surfaces GitHub-landing and npm-package-page visitors read first, and they drift quietly when a PR ships a new top-level feature bullet without touching them.

(This PR originally also added a root `CLAUDE.md`. That shipped separately via #52 as a one-line `@AGENTS.md` import, so it has been dropped from this PR during rebase.)

## Changes

### `AGENTS.md`

Adds a "README sync" subsection under the documentation sync policy. The rule is deliberately narrow — not "bump READMEs on every public-method change" but "bump them when it belongs in a release tweet":

- New top-level Key Features bullet
- New top-level export path
- New provider / transport / framework integration worth advertising
- Changes to minimum Node / pnpm version, peer deps, or quickstart env vars
- Any change to existing README-listed behavior

Sample `samples/*/README.md` follows the same rule scoped to that sample.

## Scope

One file, no source or test changes. No changeset — this is a repo-root policy file outside the `@a2x/sdk` package.

## Test plan

- [x] `AGENTS.md` renders with the new section in the correct spot.
- [ ] Reviewer: skim the README-sync trigger list and confirm the threshold (release-tweet-worthy) matches the team's expectation.