### PR TITLE
docs: fix README snippets and add root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -128,13 +128,12 @@ getAgentCard(version?)
 ## Client SDK
 
 ```typescript
-import { A2XClient, resolveAgentCard } from '@a2x/sdk/client';
+import { A2XClient } from '@a2x/sdk/client';
 
-// Discover an agent
-const card = await resolveAgentCard('https://agent.example.com');
+// The client discovers the agent card from /.well-known/agent.json
+const client = new A2XClient('https://agent.example.com');
 
-// Create a client and send messages
-const client = new A2XClient(card);
+// Send messages
 const task = await client.sendMessage({
   message: { role: 'user', parts: [{ text: 'Hello!' }] },
 });
@@ -183,19 +182,34 @@ export async function GET() {
 
 ## Device Flow Authentication
 
+Plug an `AuthProvider` into `A2XClient`. The SDK hands you the auth schemes
+declared on the agent card (including `OAuth2DeviceCodeAuthScheme`) and you
+populate them via `scheme.setCredential(...)`:
+
 ```typescript
-import { DeviceFlowClient } from '@a2x/sdk/auth';
+import { A2XClient, OAuth2DeviceCodeAuthScheme } from '@a2x/sdk/client';
+import type { AuthProvider } from '@a2x/sdk/client';
 
-const authClient = new DeviceFlowClient({
-  agentCardUrl: 'https://my-agent.example.com/.well-known/agent.json',
-});
+const authProvider: AuthProvider = {
+  async provide(requirements) {
+    // requirements: AuthScheme[][] — OR of ANDs. Pick any satisfiable group.
+    const group = requirements[0];
+    for (const scheme of group) {
+      if (scheme instanceof OAuth2DeviceCodeAuthScheme) {
+        // Run the RFC 8628 poll loop against scheme.params.deviceAuthorizationUrl
+        // and scheme.params.tokenUrl, then call setCredential with the token.
+        scheme.setCredential(await runDeviceCodeFlow(scheme));
+      }
+    }
+    return group;
+  },
+};
 
-const { userCode, verificationUri } = await authClient.requestDeviceCode({ scope: 'read write' });
-console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
-
-const token = await authClient.pollForToken(deviceCode);
-const a2aClient = authClient.createAuthenticatedClient(token);
+const client = new A2XClient('https://agent.example.com', { authProvider });
 ```
+
+For a working RFC 8628 flow (display user code, poll token endpoint, persist tokens),
+see `packages/cli/src/cli-auth-provider.ts` in the `@a2x/cli` package.
 
 ## CLI
 


### PR DESCRIPTION
## Summary

Two unrelated doc-surface fixes, both root-level, no SDK source changes — no version bump needed.

### 1. Root `README.md` — fix broken snippets

- **Client SDK snippet**: `resolveAgentCard(url)` returns a `ResolvedAgentCard` (`{ card, version, baseUrl }`), not a bare `AgentCard`. Passing that straight into `new A2XClient(card)` wouldn't work. Swapped the example for `new A2XClient(url)`, which `A2XClient` already resolves via the well-known path internally.
- **Device Flow Authentication snippet**: `DeviceFlowClient` (from `@a2x/sdk/auth`) is a Phase 3 stub — `requestDeviceCode`, `pollForToken`, and `createAuthenticatedClient` all throw `"DeviceFlowClient not yet implemented (Phase 3)"`. Replaced the snippet with the pattern that actually works today: an `AuthProvider` handing `OAuth2DeviceCodeAuthScheme` a token via `setCredential`. Added a pointer to `packages/cli/src/cli-auth-provider.ts` for a complete RFC 8628 reference.

Other recent features (skills runtime, `agent/getAuthenticatedExtendedCard`, `tasks/resubscribe`, `tasks/pushNotificationConfig/*`, SSE disconnect handling, device-code v0.3 extension) are not mentioned anywhere in the root README, so they are intentionally out of scope.

### 2. Root `CLAUDE.md` — make Claude Code auto-load `AGENTS.md`

Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`. The repo root had only `AGENTS.md`, so the contribution rules there were silently skipped when Claude Code ran from the repo root. Added a one-line root `CLAUDE.md` that imports `AGENTS.md` via the `@path` syntax — same pattern `samples/nextjs/CLAUDE.md` already uses. One source of truth (`AGENTS.md`) stays authoritative; Claude Code now picks it up automatically.

## Test plan

- [ ] Verify the new Client SDK snippet type-checks against the current `A2XClient` constructor signature (`string | AgentCardV03 | AgentCardV10`).
- [ ] Verify the new Device Flow snippet type-checks against `AuthProvider` and `OAuth2DeviceCodeAuthScheme` exports from `@a2x/sdk/client`.
- [ ] Render both `README.md` and `CLAUDE.md` on GitHub and confirm formatting.
- [ ] In a fresh Claude Code session opened in the repo root, confirm that `AGENTS.md` content is loaded via the `CLAUDE.md` → `@AGENTS.md` import.