### PR TITLE
chore(deps): ignore major bumps for github-actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,10 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+    ignore:
+      # Action major bumps are handled manually. A semver-valid major can
+      # still be freshly released and unstable (see pnpm/action-setup v6
+      # which ignored the packageManager field and corrupted the lockfile
+      # on install — pnpm/action-setup#227 and #228).
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Align the `github-actions` ecosystem in `.github/dependabot.yml` with the `npm` ecosystem: ignore `version-update:semver-major` so action major bumps require manual review.

## Motivation

The `npm` block already ignores majors. The `github-actions` block did not, so action major bumps were opening automatically. That is fine in theory but turned out to be risky in practice: **a semver-valid stable major is not the same as production-ready**, and Dependabot cannot tell the difference.

Concrete example from yesterday (#58, now closed):

- Dependabot opened `pnpm/action-setup@v4 -> @v6`.
- `v6.0.0` was only 12 days old (2026-04-10), with v6.0.1/0.2/0.3 shipping in that window.
- v5 -> v6 removed the bundled `dist/pnpm.cjs` (-220k lines) and replaced it with an npm-bootstrap installer. That rewrite has two currently-open bugs:
  - pnpm/action-setup#227 — action v6 does not install the pnpm version declared in `packageManager`.
  - pnpm/action-setup#228 — action v6 corrupts the lockfile on disk during install.
- Our CI failed with `ERR_PNPM_BROKEN_LOCKFILE: expected a single document in the stream, but found more`, matching #228.

We had to close #58 without merging. This PR prevents similar situations from filling the queue with auto-opened but un-mergeable action-major PRs.

## Changes

- `.github/dependabot.yml` — add `ignore: version-update:semver-major` to the `github-actions` ecosystem, with a comment pointing at the pnpm/action-setup incident as the rationale.

## Behavior after merge

- Weekly Dependabot runs still open PRs for action **minor/patch** bumps. That covers the common case (security fixes, small compat updates).
- Action **major** bumps will no longer be opened automatically. They need a maintainer to author the PR (or to temporarily remove the ignore) after reading upstream release notes and confirming stability.
- No change to the `npm` ecosystem behavior.

## Docs sync

- [x] No SDK public surface changed. Only repo-level CI config is modified.

## Changeset

- [x] Not needed. Does not affect any published package's runtime behavior.

## Local checks

- [x] YAML syntax preserved (indentation under the existing `github-actions` entry).
- [x] Mirrors the shape already in use for the `npm` block, which Dependabot has accepted since #54.