### PR TITLE
ci(cli): build macOS binaries on macOS runner so they ship ad-hoc signed

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -8,8 +8,12 @@ permissions:
   contents: write
 
 jobs:
-  release-cli:
+  check-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      changed: ${{ steps.version.outputs.changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,35 +32,95 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+  build-binaries:
+    needs: check-version
+    if: needs.check-version.outputs.changed == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # Ubuntu cross-compiles Linux + Windows targets (no signing required).
+          - os: ubuntu-latest
+            script: binaries:non-macos
+            artifact: binaries-non-macos
+          # macOS runner builds Mach-O binaries so @yao-pkg/pkg can apply an
+          # ad-hoc codesign (`codesign -s -`) as its post-build step. Apple
+          # Silicon rejects unsigned Mach-O at exec time (SIGKILL / EBADEXEC),
+          # so arm64 MUST be built here; x64 is built alongside for consistency.
+          - os: macos-14
+            script: binaries:macos
+            artifact: binaries-macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
       - uses: pnpm/action-setup@v4
-        if: steps.version.outputs.changed == 'true'
 
       - uses: actions/setup-node@v6
-        if: steps.version.outputs.changed == 'true'
         with:
           node-version: 20
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-        if: steps.version.outputs.changed == 'true'
 
       - run: pnpm -r build
-        if: steps.version.outputs.changed == 'true'
-
-      - name: Pack CLI tarball
-        if: steps.version.outputs.changed == 'true'
-        run: pnpm --filter @a2x/cli pack --pack-destination packages/cli
 
       - name: Build platform binaries
-        if: steps.version.outputs.changed == 'true'
-        run: pnpm --filter @a2x/cli binaries
+        run: pnpm --filter @a2x/cli ${{ matrix.script }}
+
+      - name: Verify macOS binaries are ad-hoc signed
+        if: matrix.os == 'macos-14'
+        run: |
+          for bin in packages/cli/binaries/a2x-macos-arm64 packages/cli/binaries/a2x-macos-x64; do
+            if ! codesign -dv "$bin" 2>&1 | grep -q 'Signature=adhoc'; then
+              echo "::error::$bin is not ad-hoc signed. Refusing to upload."
+              codesign -dv "$bin" || true
+              exit 1
+            fi
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: packages/cli/binaries/a2x-*
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    needs: [check-version, build-binaries]
+    if: needs.check-version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r build
+
+      - name: Pack CLI tarball
+        run: pnpm --filter @a2x/cli pack --pack-destination packages/cli
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages/cli/binaries
+          pattern: binaries-*
+          merge-multiple: true
 
       - name: Create GitHub Release
-        if: steps.version.outputs.changed == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: CLI ${{ steps.version.outputs.version }}
+          tag_name: ${{ needs.check-version.outputs.tag }}
+          name: CLI ${{ needs.check-version.outputs.version }}
           generate_release_notes: true
           files: |
             packages/cli/*.tgz

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,9 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "binaries": "pkg bin-bundle/a2x.cjs --targets node20-linux-x64,node20-linux-arm64,node20-macos-x64,node20-macos-arm64,node20-win-x64 --out-path binaries --compress Brotli --public"
+    "binaries": "pkg bin-bundle/a2x.cjs --targets node20-linux-x64,node20-linux-arm64,node20-macos-x64,node20-macos-arm64,node20-win-x64 --out-path binaries --compress Brotli --public",
+    "binaries:macos": "pkg bin-bundle/a2x.cjs --targets node20-macos-x64,node20-macos-arm64 --out-path binaries --compress Brotli --public",
+    "binaries:non-macos": "pkg bin-bundle/a2x.cjs --targets node20-linux-x64,node20-linux-arm64,node20-win-x64 --out-path binaries --compress Brotli --public"
   },
   "dependencies": {
     "@a2x/sdk": "workspace:*",


### PR DESCRIPTION
## Summary

- Split `release-cli.yml` into `check-version` → `build-binaries` (matrix) → `release`.
- `ubuntu-latest` cross-compiles the Linux + Windows targets (no signing requirement).
- `macos-14` builds `macos-arm64` + `macos-x64` so `@yao-pkg/pkg` applies its ad-hoc `codesign -s -` post-build step. A verification step greps `codesign -dv` for `Signature=adhoc` and fails the job if a macOS binary somehow ships unsigned, so this regression cannot recur silently.
- `release` downloads both artifacts, packs the npm tarball on Ubuntu (unchanged), and uploads all five binaries + the tarball to the GitHub Release.
- Add `binaries:macos` / `binaries:non-macos` scripts to `packages/cli/package.json` so the split is reusable locally; the existing all-in-one `binaries` script is kept for local dev convenience.

## Why

Every `cli-v*` release to date shipped an unsigned `a2x-macos-arm64`. On Apple Silicon the kernel rejects unsigned Mach-O at exec time (EBADEXEC → SIGKILL, exit 137), so consumers who followed the documented install path couldn't run the binary until they manually `codesign -s - --force`'d it. This is **not** a Gatekeeper/quarantine problem — `gh release download` doesn't set the quarantine xattr.

Root cause: `pkg` only invokes `codesign -s -` when running on macOS. The workflow built every target on `ubuntu-latest`, so the signature step was skipped.

Fix follows option 2 from the issue: split the runner so Mach-O binaries are produced on a macOS host. No consumer action required, no Apple Developer ID cert required, no ongoing cost beyond a single `macos-14` runner per release.

## Test plan

- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes (only a pre-existing warning unrelated to this change).
- [x] `pnpm -r build` passes.
- [x] `pnpm test` passes (403/403).
- [ ] After merge, the next `cli-v*` release produces `a2x-macos-arm64` and `a2x-macos-x64` that report `Signature=adhoc` under `codesign -dv`.
- [ ] `gh release download <next-tag> --pattern 'a2x-macos-arm64'` + `chmod +x` + run succeeds on Apple Silicon with no manual `codesign` step.
- [ ] `a2x-macos-x64`, `a2x-linux-x64`, `a2x-linux-arm64`, `a2x-win-x64.exe` continue to behave as today.

## Notes

- macOS-x64 was already functional unsigned (Intel macOS accepts unsigned exec outside Gatekeeper), but we sign it here too for consistency now that we're paying for the macOS runner anyway.
- Developer ID signing + notarization (option 3) is explicitly out of scope; that's a separate policy decision requiring an Apple Developer cert and secrets.

Closes #86