### PR TITLE
refactor(sdk): split A2XAgent.setCapabilities into focused builder methods

### DIFF
--- a/.changeset/refactor-agent-capabilities-api.md
+++ b/.changeset/refactor-agent-capabilities-api.md
@@ -1,0 +1,41 @@
+---
+"@a2x/sdk": minor
+---
+
+Refactor `A2XAgent` capabilities API into focused builder methods.
+
+`setCapabilities()` is now `@deprecated` and will be removed in the next major.
+In the meantime, `setCapabilities({ extensions: [...] })` appends instead of
+overwriting so multi-source callers no longer clobber one another.
+
+New methods:
+
+- `addExtension(ext)` / `addExtension(uri, opts?)` — append to
+  `capabilities.extensions`. Append-only, never drops earlier entries.
+- `setPushNotifications(enabled)` — override the auto-derived flag. The
+  default is `true` when the constructor receives a
+  `pushNotificationConfigStore` and `false` otherwise, so most callers no
+  longer need to touch it.
+- `setStateTransitionHistory(enabled)` — v0.3-only flag (silently dropped
+  from v1.0 cards).
+
+`capabilities.streaming` continues to be auto-extracted from
+`runConfig.streamingMode`, and `capabilities.extendedAgentCard` is still
+auto-set by `setAuthenticatedExtendedCardProvider()`.
+
+Migration:
+
+```ts
+// Before
+a2xAgent.setCapabilities({
+  pushNotifications: true,
+  extensions: [{ uri: X402_EXTENSION_URI, required: true }],
+  stateTransitionHistory: true,
+});
+
+// After
+a2xAgent
+  .addExtension({ uri: X402_EXTENSION_URI, required: true })
+  .setStateTransitionHistory(true);
+// pushNotifications: true is auto-derived from pushNotificationConfigStore.
+```

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -331,7 +331,7 @@ const executor = new X402PaymentExecutor(innerExecutor, {
 });
 
 const agent = new A2XAgent({ taskStore, executor })
-  .setCapabilities({ extensions: [{ uri: X402_EXTENSION_URI, required: true }] });
+  .addExtension({ uri: X402_EXTENSION_URI, required: true });
 ```
 
 Client:

--- a/packages/a2x/docs/guides/advanced/manual-wiring.md
+++ b/packages/a2x/docs/guides/advanced/manual-wiring.md
@@ -140,6 +140,35 @@ a2xAgent
 
 See [Authentication](./authentication.md) for all available schemes.
 
+### Capabilities
+
+Most capability flags on the AgentCard are derived automatically:
+
+- `capabilities.streaming` is taken from `runConfig.streamingMode`.
+- `capabilities.pushNotifications` is `true` when the constructor receives a
+  `pushNotificationConfigStore`, `false` otherwise.
+- `capabilities.extendedAgentCard` is set when
+  `setAuthenticatedExtendedCardProvider()` is called.
+
+Two capabilities need explicit builder calls — both are append-only / boolean:
+
+```ts
+import { X402_EXTENSION_URI } from '@a2x/sdk/x402';
+
+a2xAgent
+  .addExtension({ uri: X402_EXTENSION_URI, required: true })
+  // or: .addExtension('https://example.com/ext', { required: true })
+  .setStateTransitionHistory(true); // v0.3 only; dropped on v1.0 cards
+```
+
+`setPushNotifications(false)` exists for the rare case where the store is
+wired but you want to hide the capability.
+
+> `setCapabilities(...)` is deprecated in favor of the focused methods above
+> and will be removed in the next major. While it coexists, the `extensions`
+> field is treated as append-only so multi-source callers no longer clobber
+> each other.
+
 ## Serving the handler
 
 Once you have `handler`, mount it in any HTTP framework. The recipe is in [Framework Integration](../agent/framework-integration.md).

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -38,9 +38,7 @@ const executor = new X402PaymentExecutor(inner, {
 const agent = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor })
   .setName('Paid Agent')
   .setDescription('Charges per call')
-  .setCapabilities({
-    extensions: [{ uri: X402_EXTENSION_URI, required: true }],
-  });
+  .addExtension({ uri: X402_EXTENSION_URI, required: true });
 ```
 
 ### Multiple payment options

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { A2XAgent } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
+import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { LlmAgent } from '../agent/llm-agent.js';
 import { BaseLlmProvider } from '../provider/base.js';
@@ -398,6 +399,130 @@ describe('Layer 3: A2XAgent', () => {
       expect(() => a2x.getAgentCard()).toThrow(
         "references unregistered scheme 'nonexistent'",
       );
+    });
+  });
+
+  describe('Capabilities API', () => {
+    it('addExtension appends without clobbering earlier entries', () => {
+      const a2x = createA2XAgent();
+      a2x
+        .setDefaultUrl('https://example.com/a2a')
+        .addExtension({ uri: 'https://example.com/ext/a', required: true })
+        .addExtension('https://example.com/ext/b', { description: 'B' });
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.extensions).toEqual([
+        { uri: 'https://example.com/ext/a', required: true },
+        { uri: 'https://example.com/ext/b', description: 'B' },
+      ]);
+    });
+
+    it('deprecated setCapabilities({ extensions }) appends instead of overwriting', () => {
+      const a2x = createA2XAgent();
+      a2x
+        .setDefaultUrl('https://example.com/a2a')
+        .setCapabilities({ extensions: [{ uri: 'ext-a' }] })
+        .setCapabilities({ extensions: [{ uri: 'ext-b' }] });
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.extensions).toEqual([
+        { uri: 'ext-a' },
+        { uri: 'ext-b' },
+      ]);
+    });
+
+    it('preserves extensions across mixed old + new calls', () => {
+      const a2x = createA2XAgent();
+      a2x
+        .setDefaultUrl('https://example.com/a2a')
+        .addExtension({ uri: 'ext-a' })
+        .setCapabilities({ extensions: [{ uri: 'ext-b' }] })
+        .addExtension('ext-c');
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.extensions).toEqual([
+        { uri: 'ext-a' },
+        { uri: 'ext-b' },
+        { uri: 'ext-c' },
+      ]);
+    });
+
+    it('auto-derives pushNotifications=true when the store is provided', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const a2x = new A2XAgent({
+        taskStore: new InMemoryTaskStore(),
+        executor,
+        pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
+      }).setDefaultUrl('https://example.com/a2a');
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.pushNotifications).toBe(true);
+    });
+
+    it('auto-derives pushNotifications=false when no store is provided', () => {
+      const a2x = createA2XAgent();
+      a2x.setDefaultUrl('https://example.com/a2a');
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.pushNotifications).toBe(false);
+    });
+
+    it('setPushNotifications(false) overrides the auto-derived value', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const a2x = new A2XAgent({
+        taskStore: new InMemoryTaskStore(),
+        executor,
+        pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
+      })
+        .setDefaultUrl('https://example.com/a2a')
+        .setPushNotifications(false);
+
+      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      expect(card.capabilities.pushNotifications).toBe(false);
+    });
+
+    it('setStateTransitionHistory flips the v0.3 flag', () => {
+      const agent = new LlmAgent({
+        name: 'test',
+        provider: mockProvider,
+        description: 'test',
+        instruction: 'test',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.NONE },
+      });
+      const a2x = new A2XAgent({
+        taskStore: new InMemoryTaskStore(),
+        executor,
+        protocolVersion: '0.3',
+      })
+        .setDefaultUrl('https://example.com/a2a')
+        .setStateTransitionHistory(true);
+
+      const card = a2x.getAgentCard('0.3') as AgentCardV03;
+      expect(card.capabilities.stateTransitionHistory).toBe(true);
     });
   });
 

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -72,7 +72,6 @@ function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
     pushNotificationConfigStore: pushStore,
   });
   a2xAgent.setDefaultUrl('https://example.com/a2a');
-  a2xAgent.setCapabilities({ pushNotifications: true });
 
   return { handler: new DefaultRequestHandler(a2xAgent), pushStore };
 }

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -5,7 +5,7 @@
 
 import type { LlmAgent } from '../agent/llm-agent.js';
 import type { BaseSecurityScheme } from '../security/base.js';
-import type { AgentProvider } from '../types/common.js';
+import type { AgentExtension, AgentProvider } from '../types/common.js';
 import type {
   A2XAgentSkill,
   A2XAgentState,
@@ -186,8 +186,93 @@ export class A2XAgent {
     return this;
   }
 
+  /**
+   * @deprecated Use the focused builder methods instead:
+   *   - `addExtension(ext)` for `capabilities.extensions` (append-only, no clobber).
+   *   - `setPushNotifications(enabled)` to force-set the flag; by default it's
+   *     derived from whether `pushNotificationConfigStore` was provided to the
+   *     constructor.
+   *   - `setStateTransitionHistory(enabled)` for the v0.3-only flag.
+   *   - `streaming` is already auto-extracted from `runConfig.streamingMode`
+   *     and needs no manual setter.
+   *   - `extendedAgentCard` is already auto-set by
+   *     `setAuthenticatedExtendedCardProvider()`.
+   *
+   * This method will be removed in the next major. While it coexists with the
+   * replacements, `setCapabilities({ extensions: [...] })` appends (same
+   * semantics as `addExtension`) rather than overwriting, so calls from
+   * multiple sources no longer clobber one another.
+   */
   setCapabilities(capabilities: Partial<A2XAgentState['capabilities']>): this {
-    this._capabilities = { ...this._capabilities, ...capabilities };
+    const { extensions, ...rest } = capabilities;
+    this._capabilities = { ...this._capabilities, ...rest };
+    if (extensions && extensions.length > 0) {
+      const existing = this._capabilities.extensions ?? [];
+      this._capabilities.extensions = [...existing, ...extensions];
+    }
+    this._invalidateCache();
+    return this;
+  }
+
+  /**
+   * Append an extension to `capabilities.extensions`.
+   *
+   * Extensions are A2A-level capability declarations keyed by URI (e.g. the
+   * a2a-x402 payment extension). `addExtension` is append-only — calling it
+   * repeatedly never drops a previously added extension.
+   *
+   * Two call shapes:
+   * - `addExtension({ uri, description?, required?, params? })`
+   * - `addExtension(uri, { description?, required?, params? })`
+   */
+  addExtension(extension: AgentExtension): this;
+  addExtension(
+    uri: string,
+    options?: Omit<AgentExtension, 'uri'>,
+  ): this;
+  addExtension(
+    extensionOrUri: AgentExtension | string,
+    options?: Omit<AgentExtension, 'uri'>,
+  ): this {
+    const extension: AgentExtension =
+      typeof extensionOrUri === 'string'
+        ? { uri: extensionOrUri, ...(options ?? {}) }
+        : extensionOrUri;
+    const existing = this._capabilities.extensions ?? [];
+    this._capabilities = {
+      ...this._capabilities,
+      extensions: [...existing, extension],
+    };
+    this._invalidateCache();
+    return this;
+  }
+
+  /**
+   * Force the `capabilities.pushNotifications` flag. Rarely needed — the
+   * flag defaults to `true` when the constructor receives a
+   * `pushNotificationConfigStore` and `false` otherwise. Call this only to
+   * override the derived value (e.g. advertise the capability before wiring
+   * the store, or suppress it when the store is present but unused).
+   */
+  setPushNotifications(enabled: boolean): this {
+    this._capabilities = {
+      ...this._capabilities,
+      pushNotifications: enabled,
+    };
+    this._invalidateCache();
+    return this;
+  }
+
+  /**
+   * Advertise support for returning historical task state transitions on
+   * `tasks/get` / `tasks/resubscribe`. Only part of the v0.3 AgentCard —
+   * v1.0 does not expose the flag and it is silently dropped from v1.0 cards.
+   */
+  setStateTransitionHistory(enabled: boolean): this {
+    this._capabilities = {
+      ...this._capabilities,
+      stateTransitionHistory: enabled,
+    };
     this._invalidateCache();
     return this;
   }
@@ -399,6 +484,13 @@ export class A2XAgent {
       this._capabilities.streaming ??
       this._agentExecutor.runConfig.streamingMode === StreamingMode.SSE;
 
+    // Auto-derive push-notification capability from the presence of a
+    // configured store. An explicit value set via setPushNotifications() or
+    // the deprecated setCapabilities() still wins.
+    const pushNotifications =
+      this._capabilities.pushNotifications ??
+      this._pushNotificationConfigStore !== undefined;
+
     return {
       name,
       description,
@@ -409,6 +501,7 @@ export class A2XAgent {
       capabilities: {
         ...this._capabilities,
         streaming,
+        pushNotifications,
       },
       securitySchemes: new Map(this._securitySchemes),
       securityRequirements: [...this._securityRequirements],

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -23,9 +23,7 @@
  * const agent = new A2XAgent({ taskStore, executor })
  *   .setName('Paid Agent')
  *   .setDescription('Charges per call')
- *   .setCapabilities({
- *     extensions: [{ uri: X402_EXTENSION_URI, required: true }],
- *   });
+ *   .addExtension({ uri: X402_EXTENSION_URI, required: true });
  * ```
  *
  * Minimal client setup:

--- a/samples/nextjs-skill/src/lib/a2x-setup.ts
+++ b/samples/nextjs-skill/src/lib/a2x-setup.ts
@@ -76,7 +76,6 @@ export const a2xAgent = new A2XAgent({
     description:
       "Ask about the weather in a city, suggest a recipe from ingredients, or do a quick calculation to trigger a bundled skill.",
     tags: ["demo", "skills"],
-  })
-  .setCapabilities({ streaming: true });
+  });
 
 export const handler = new DefaultRequestHandler(a2xAgent);

--- a/samples/nextjs-x402/src/lib/a2x-setup.ts
+++ b/samples/nextjs-x402/src/lib/a2x-setup.ts
@@ -120,9 +120,6 @@ export const a2xAgent = new A2XAgent({
     description: 'Echoes your message back — paid per call via x402.',
     tags: ['echo', 'x402', 'demo'],
   })
-  .setCapabilities({
-    streaming: true,
-    extensions: [{ uri: X402_EXTENSION_URI, required: true }],
-  });
+  .addExtension({ uri: X402_EXTENSION_URI, required: true });
 
 export const handler = new DefaultRequestHandler(a2xAgent);

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -43,7 +43,6 @@ export const a2xAgent = new A2XAgent({
     description: "General conversation and Q&A",
     tags: ["chat", "general"],
   })
-  .setCapabilities({ streaming: true, pushNotifications: true })
   .addSecurityScheme(
     'deviceCode',
     new OAuth2DeviceCodeAuthorization({

--- a/skills/a2x-agent-integration/wiki/concepts.md
+++ b/skills/a2x-agent-integration/wiki/concepts.md
@@ -119,7 +119,7 @@ a2xAgent
   .setDescription('Agent desc')     // Override auto-extracted description
   .setVersion('1.0.0')              // Agent version
   .setDefaultUrl('http://localhost:3000/a2a')  // Required: endpoint URL
-  .setCapabilities({ streaming: true, pushNotifications: false })
+  .setPushNotifications(false)                 // Override the auto-derived flag
   .addSkill({
     id: 'skill-id',
     name: 'Skill Name',


### PR DESCRIPTION
Closes #69.

## Summary

- Deprecate `A2XAgent.setCapabilities()` via JSDoc (no runtime warning) in favor of focused builder methods.
- Add `addExtension(ext)` / `addExtension(uri, opts?)` — append-only, no array clobber.
- Add `setStateTransitionHistory(enabled)` — v0.3-only flag.
- Add `setPushNotifications(enabled)` — rare opt-out for the auto-derived flag.
- Auto-derive `capabilities.pushNotifications` from whether `pushNotificationConfigStore` is provided to the constructor (`true` when wired, `false` otherwise).
- `setCapabilities({ extensions: [...] })` now appends instead of overwriting — quietly fixes the array-clobber footgun for unmigrated callers.

`capabilities.streaming` continues to be auto-extracted from `runConfig.streamingMode`; `capabilities.extendedAgentCard` is still auto-set by `setAuthenticatedExtendedCardProvider()`.

## Example

```ts
// Before
new A2XAgent({ taskStore, executor, pushNotificationConfigStore })
  .setCapabilities({
    pushNotifications: true,            // redundant — store is already wired
    extensions: [{ uri: X402_EXTENSION_URI, required: true }],
    stateTransitionHistory: true,
  });

// After
new A2XAgent({ taskStore, executor, pushNotificationConfigStore })
  .addExtension({ uri: X402_EXTENSION_URI, required: true })
  .setStateTransitionHistory(true);
// pushNotifications: true comes from the store auto-derivation.
```

## Changes

- `packages/a2x/src/a2x/a2x-agent.ts` — deprecation + new methods + auto-derivation in `_buildState()`.
- `packages/a2x/src/__tests__/a2x-agent.test.ts` — 6 new tests covering append, auto-derivation, override, and `setStateTransitionHistory`.
- `packages/a2x/src/__tests__/request-handler.test.ts` — drop redundant `setCapabilities` now that the store is auto-advertised.
- `packages/a2x/README.md`, `packages/a2x/docs/guides/advanced/x402-payments.md`, `packages/a2x/docs/guides/advanced/manual-wiring.md`, `packages/a2x/src/x402/index.ts` (JSDoc), `skills/a2x-agent-integration/wiki/concepts.md`, root README unchanged (no setCapabilities there) — switched examples to the new API.
- `samples/nextjs`, `samples/nextjs-skill`, `samples/nextjs-x402` — migrated to the new API.
- `.changeset/refactor-agent-capabilities-api.md` — minor, with migration block.

Phase 2 (actually removing `setCapabilities`) is a separate PR for the next major, as described in the issue.

## Test plan

- [x] `pnpm test` — 410/410 passing (26 test files).
- [x] `pnpm typecheck` — clean across workspace + samples.
- [x] `pnpm -r build` — clean across workspace + samples.
- [x] `pnpm lint` — no new warnings (one pre-existing warning unrelated to this change).