### PR TITLE
feat(sdk): add x402 Embedded Flow (mid-execution payment via artifacts)

### DIFF
--- a/.changeset/x402-embedded-flow.md
+++ b/.changeset/x402-embedded-flow.md
@@ -1,0 +1,37 @@
+---
+"@a2x/sdk": minor
+---
+
+Add x402 Embedded Flow support (mid-execution payment via artifacts).
+
+`X402PaymentExecutor` now supports the Embedded Flow from a2a-x402 v0.2 in
+addition to the existing Standalone gate. The inner agent can yield a
+`paymentRequired` event mid-run; the executor stashes the paused generator,
+emits the challenge on a task artifact, transitions the task to
+`input-required`, and resumes the same generator once the client
+resubmits a signed payload.
+
+New API surface:
+
+- `paymentRequiredEvent({ accepts?, embeddedObject?, artifactName?, ... })`
+  — typed builder for the new `{ type: 'paymentRequired' }` AgentEvent
+  variant.
+- `X402PaymentExecutorOptions.resolveAccepts(ctx)` — dynamic pricing
+  hook. Consulted when the event omits inline `accepts`.
+- `X402PaymentExecutorOptions.accepts` is now optional — omit to skip the
+  gate and rely exclusively on Embedded charges.
+- `getEmbeddedX402Challenges(task)` — parse pending Embedded challenges
+  off a task's artifacts. Recognizes the bare SDK shape and any
+  `x402PaymentRequiredResponse`-shaped object nested inside a
+  higher-level wrapper (AP2 `CartMandate` etc.).
+- `X402ClientOptions.onEmbeddedPaymentRequired` callback, plus a
+  `maxPaymentHops` cap (default 8). `X402Client.sendMessage` now loops
+  over every challenge the merchant emits instead of stopping after the
+  gate.
+- `X402_EMBEDDED_ARTIFACT_NAME` / `X402_EMBEDDED_DATA_KEY` constants for
+  callers that parse artifacts by hand.
+
+The Standalone gate path, its error codes, and `X402Client` defaults
+remain backwards-compatible. Internal rename: `__internal.attachReceipt`
+→ `__internal.attachReceipts` (accepts an array; gate + embedded
+receipts now stack).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install @a2x/sdk
 - **Device Flow auth** — Built-in OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI and browserless environments.
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class support for `message/stream` via Server-Sent Events.
-- **x402 payments** — Optional `@a2x/sdk/x402` subpath gates agent calls behind on-chain cryptocurrency payments using the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension.
+- **x402 payments** — Optional `@a2x/sdk/x402` subpath gates agent calls behind on-chain cryptocurrency payments using the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension. Supports both the Standalone gate and the Embedded flow (mid-execution charges carried on artifacts, e.g. per-item checkout).
 - **Zero runtime dependencies** — Core module uses only Node.js built-in APIs.
 - **TypeScript-first** — Full type safety with types derived directly from A2A JSON Schema and proto definitions.
 

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -13,7 +13,7 @@ A self-contained TypeScript SDK for building [A2A (Agent-to-Agent)](https://a2a-
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class `message/stream` support via Server-Sent Events.
 - **Built-in auth** — API Key, Bearer, OAuth 2.0 (Authorization Code, Client Credentials, Device Code), OpenID Connect, and Mutual TLS.
-- **x402 payments** — Charge per call via the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension. On-chain verify + settle through any x402 facilitator.
+- **x402 payments** — Charge per call via the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension. Supports both the Standalone gate (one charge at the door) and the Embedded flow (mid-execution per-action charges on artifacts, e.g. cart checkout). On-chain verify + settle through any x402 facilitator.
 - **Zero runtime dependencies** — Core module uses only Node.js built-in APIs.
 - **TypeScript-first** — Full type safety with types derived from A2A JSON Schema.
 

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -188,11 +188,192 @@ for (const receipt of receipts) {
 }
 ```
 
+## Embedded Flow
+
+The Standalone flow above gates the whole task behind a single charge at the door. The **Embedded Flow** from a2a-x402 v0.2 lets an agent ask for an additional payment *mid-execution* — useful for cart-style checkouts, premium-asset delivery, or any "charge once you've decided to buy" flow. The gate and embedded charges compose: a call can settle both, or skip the gate entirely and charge only on purchase.
+
+### How it works
+
+1. The inner agent yields `paymentRequired` (optionally carrying a higher-level wrapper like an AP2 `CartMandate`).
+2. The executor stashes the paused generator, emits an artifact carrying the challenge, and transitions the task into `input-required`.
+3. The client signs the payload and resubmits.
+4. The executor verifies + settles, then resumes the generator from where it paused — no re-run.
+
+Per spec §4.2 the status metadata carries only `x402.payment.status: payment-required` (no `x402.payment.required` key); the actual challenge lives on `task.artifacts[]`.
+
+### Server — agent yielding mid-execution payment
+
+```ts
+import { BaseAgent, type AgentEvent } from '@a2x/sdk';
+import { paymentRequiredEvent, X402PaymentExecutor } from '@a2x/sdk/x402';
+
+class CartAgent extends BaseAgent {
+  async *run(): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'Your cart: 1× Nike Air Max — 120 USDC.' };
+
+    // Pause here until the client pays.
+    yield paymentRequiredEvent({
+      accepts: [{
+        network: 'base',
+        amount: '120000000',               // 120 USDC (6 decimals)
+        asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913',
+        payTo: process.env.MERCHANT_ADDRESS!,
+        description: 'Nike Air Max checkout',
+      }],
+      // Optional: attach your own higher-level object (rendered on the
+      // emitted artifact next to the x402 challenge).
+      embeddedObject: { cartId: 'cart-shoes-123', total: { currency: 'USD', value: 120 } },
+      artifactName: 'demo-cart',
+    });
+
+    yield { type: 'text', text: 'Paid — shipping shoes now.' };
+    yield { type: 'done' };
+  }
+}
+```
+
+Pair it with a gate-less executor if you only want per-purchase pricing:
+
+```ts
+const executor = new X402PaymentExecutor(inner, {
+  // No `accepts` → no gate. The executor only charges when the agent emits
+  // `paymentRequired`.
+});
+```
+
+### Dynamic pricing with `resolveAccepts`
+
+If the price depends on the cart (or on who's asking, or on the current inventory), let the agent yield `paymentRequired` without inline `accepts` and resolve them at the executor layer:
+
+```ts
+const executor = new X402PaymentExecutor(inner, {
+  resolveAccepts: async ({ embeddedObject, task, message }) => {
+    const cart = embeddedObject as { productId: string };
+    const unitPrice = await priceBook.lookup(cart.productId); // e.g. 75000000
+    return [{
+      network: 'base',
+      amount: unitPrice,
+      asset: USDC_BASE,
+      payTo,
+      description: `Checkout for ${cart.productId}`,
+    }];
+  },
+});
+
+class LookupAgent extends BaseAgent {
+  async *run() {
+    yield paymentRequiredEvent({ embeddedObject: { productId: 'sku-42' } });
+    yield { type: 'text', text: 'Delivered.' };
+    yield { type: 'done' };
+  }
+}
+```
+
+Inline `accepts` always wins — `resolveAccepts` is only consulted when the event omits them.
+
+### Client — stacking gate + embedded in one call
+
+`X402Client.sendMessage` loops over every payment challenge the merchant emits:
+
+```ts
+const x402 = new X402Client(new A2XClient(url), {
+  signer,
+  onPaymentRequired: (required) => {
+    console.log('Gate asks for', required.accepts);
+  },
+  onEmbeddedPaymentRequired: (challenge) => {
+    console.log('Embedded charge:', challenge.required.accepts, 'artifact=', challenge.artifactId);
+  },
+  // Safety cap — default 8. Raise for flows with many sequential charges.
+  maxPaymentHops: 8,
+});
+
+const task = await x402.sendMessage({
+  message: {
+    messageId: crypto.randomUUID(),
+    role: 'user',
+    parts: [{ text: 'buy shoes' }],
+  },
+});
+console.log(task.status.state); // "completed" after the gate AND the embedded charge settle
+```
+
+### Parsing Embedded challenges yourself
+
+For custom UIs (render the cart, show a confirmation modal, swap signers per artifact), use the primitive:
+
+```ts
+import { getEmbeddedX402Challenges, signX402Payment } from '@a2x/sdk/x402';
+
+const task = await client.sendMessage({ message: { … } });
+const challenges = getEmbeddedX402Challenges(task);
+for (const ch of challenges) {
+  console.log('artifactId', ch.artifactId);
+  console.log('full data (AP2, cart, etc.)', ch.data);
+  console.log('x402 requirements', ch.required.accepts);
+}
+
+const signed = await signX402Payment(task, { signer });
+const next = await client.sendMessage({
+  message: {
+    messageId: crypto.randomUUID(),
+    role: 'user',
+    taskId: task.id,
+    parts: [{ text: '' }],
+    metadata: signed.metadata,
+  },
+});
+```
+
+`getEmbeddedX402Challenges` recognizes the bare shape the SDK emits (data-part with an `x402.payment.required` key) AND `x402PaymentRequiredResponse`-shaped objects nested anywhere inside a higher-level wrapper (AP2 `CartMandate`, your own custom schema, etc.). If you transport the x402 payload inside your wrapper's `message.parts` on submission (true AP2), unwrap it into `message.metadata['x402.payment.payload']` yourself before handing to the SDK.
+
+### What gets emitted
+
+On an embedded charge, the task transitions to `input-required` and the status message carries just:
+
+```json
+{
+  "x402.payment.status": "payment-required"
+}
+```
+
+The actual challenge sits on a `task.artifacts[]` entry (named `x402-payment-required` by default, or whatever you passed as `artifactName`):
+
+```json
+{
+  "artifactId": "x402-challenge-1712345678",
+  "name": "demo-cart",
+  "parts": [{
+    "data": {
+      "cartId": "cart-shoes-123",
+      "total": { "currency": "USD", "value": 120 },
+      "x402.payment.required": {
+        "x402Version": 1,
+        "accepts": [{ /* PaymentRequirements */ }]
+      }
+    }
+  }]
+}
+```
+
+On success, all receipts (gate + every embedded charge) stack under `x402.payment.receipts`:
+
+```json
+{
+  "x402.payment.status": "payment-completed",
+  "x402.payment.receipts": [
+    { "success": true, "transaction": "0x…", "network": "base-sepolia" },
+    { "success": true, "transaction": "0x…", "network": "base-sepolia" }
+  ]
+}
+```
+
 ## Supported scope
 
-- **Standalone Flow** from a2a-x402 v0.2. Embedded Flow (AP2 `CartMandate` etc.) isn't yet wired up — the extension spec notes the embedded flow "supports" nesting but implementing it is separate work.
+- **Standalone Flow + Embedded Flow** from a2a-x402 v0.2. The SDK handles bare embedded challenges out of the box; for full AP2 `CartMandate`/`PaymentMandate` interop you can ship your own wrapper via `embeddedObject` and unwrap the payload on submission yourself (the data part shape is preserved verbatim).
 - **`exact` scheme, EVM networks** (`base`, `base-sepolia`, `polygon`, `avalanche`, …). The x402 npm package powers signing; adding Solana/SVM support means passing a Solana-compatible signer in a later release.
 - The base protocol is **x402 v1** (`x402Version: 1`). a2a-x402 v0.2 pins to this version; x402 v2 exists as a forward-looking draft but a2a-x402 has not adopted it yet.
+- Embedded-flow pause/resume is **in-memory** on the server: the paused generator lives in the `X402PaymentExecutor` instance keyed by `taskId`. If the server restarts between `paymentRequired` and the client's follow-up, the pending charge is lost (the task is effectively orphaned). Horizontally-scaled deployments should pin task resumption back to the originating instance.
 
 ## Reference
 

--- a/packages/a2x/src/__tests__/x402-embedded.test.ts
+++ b/packages/a2x/src/__tests__/x402-embedded.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Tests for a2a-x402 v0.2 Embedded Flow support.
+ *
+ * Embedded Flow = the inner agent yields `paymentRequired` mid-execution,
+ * the executor transitions the task into `input-required` with the
+ * challenge on an artifact, and on resumption the same generator
+ * continues from where it paused.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { privateKeyToAccount } from 'viem/accounts';
+import type { Message, Part } from '../types/common.js';
+import { TaskState, type Task } from '../types/task.js';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent, type AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+import {
+  X402_ERROR_CODES,
+  X402_METADATA_KEYS,
+  X402_PAYMENT_STATUS,
+} from '../x402/constants.js';
+import {
+  X402PaymentExecutor,
+  X402_EMBEDDED_ARTIFACT_NAME,
+  X402_EMBEDDED_DATA_KEY,
+} from '../x402/executor.js';
+import {
+  X402Client,
+  getEmbeddedX402Challenges,
+  getX402Receipts,
+  signX402Payment,
+} from '../x402/client.js';
+import { paymentRequiredEvent } from '../x402/events.js';
+import type {
+  X402Accept,
+  X402Facilitator,
+  X402PaymentPayload,
+  X402PaymentRequirements,
+  X402SettleResponse,
+} from '../x402/types.js';
+import type { SendMessageParams } from '../types/jsonrpc.js';
+import { A2XClient } from '../client/a2x-client.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────
+
+const TEST_PRIVATE_KEY =
+  '0x1111111111111111111111111111111111111111111111111111111111111111' as const;
+const TEST_ACCOUNT = privateKeyToAccount(TEST_PRIVATE_KEY);
+const PAY_TO = '0x2222222222222222222222222222222222222222';
+const USDC_BASE_SEPOLIA = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+
+const GATE_ACCEPT: X402Accept = {
+  network: 'base-sepolia',
+  amount: '1000',
+  asset: USDC_BASE_SEPOLIA,
+  payTo: PAY_TO,
+  description: 'Gate',
+};
+
+const EMBEDDED_ACCEPT: X402Accept = {
+  network: 'base-sepolia',
+  amount: '120000000', // 120 USDC
+  asset: USDC_BASE_SEPOLIA,
+  payTo: PAY_TO,
+  description: 'Cart checkout',
+};
+
+class PreEmbedAgent extends BaseAgent {
+  constructor(private readonly _accepts: X402Accept[]) {
+    super({ name: 'pre-embed-agent' });
+  }
+  async *run(_context: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'Preparing cart… ', role: 'agent' };
+    yield paymentRequiredEvent({
+      accepts: this._accepts,
+      embeddedObject: {
+        cartId: 'cart-abc',
+        total: { currency: 'USD', value: 120 },
+      },
+      artifactName: 'demo-cart',
+    });
+    yield { type: 'text', text: 'Shipping shoes…', role: 'agent' };
+    yield { type: 'done' };
+  }
+}
+
+class DynamicEmbedAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'dyn-embed-agent' });
+  }
+  async *run(_context: InvocationContext): AsyncGenerator<AgentEvent> {
+    // No inline accepts — relies on executor's resolveAccepts hook.
+    yield paymentRequiredEvent({
+      embeddedObject: { productId: 'sku-42' },
+    });
+    yield { type: 'text', text: 'Delivered.', role: 'agent' };
+    yield { type: 'done' };
+  }
+}
+
+class NoAcceptsEmbedAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'no-accepts-agent' });
+  }
+  async *run(_context: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield paymentRequiredEvent({});
+    yield { type: 'done' };
+  }
+}
+
+function newTask(id = 't1', contextId = 'c1'): Task {
+  return {
+    id,
+    contextId,
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  };
+}
+
+function newMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    messageId: 'm1',
+    role: 'user',
+    parts: [{ text: 'buy shoes' }],
+    ...overrides,
+  };
+}
+
+const mockFacilitator = (
+  overrides: Partial<X402Facilitator> = {},
+): X402Facilitator => ({
+  verify: async () => ({
+    isValid: true,
+    invalidReason: undefined,
+    payer: TEST_ACCOUNT.address,
+  }),
+  settle: async (payload) => ({
+    success: true,
+    transaction: `0xtx-${payload.network}-${Date.now()}`,
+    network: payload.network,
+    payer: TEST_ACCOUNT.address,
+  }),
+  ...overrides,
+});
+
+function makeExecutor(
+  agent: BaseAgent,
+  options: Partial<
+    Parameters<typeof buildOptions>[0]
+  > = {},
+): X402PaymentExecutor {
+  const runner = new InMemoryRunner({ agent, appName: 'test' });
+  const inner = new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+  return new X402PaymentExecutor(inner, buildOptions(options));
+}
+
+function buildOptions(
+  overrides: {
+    accepts?: X402Accept[];
+    facilitator?: X402Facilitator;
+    resolveAccepts?: Parameters<
+      typeof import('../x402/executor.js').X402PaymentExecutor
+    >[1]['resolveAccepts'];
+    requiresPayment?: (message: Message) => boolean;
+  } = {},
+) {
+  return {
+    accepts: overrides.accepts ?? [],
+    facilitator: overrides.facilitator ?? mockFacilitator(),
+    ...(overrides.resolveAccepts
+      ? { resolveAccepts: overrides.resolveAccepts }
+      : {}),
+    ...(overrides.requiresPayment
+      ? { requiresPayment: overrides.requiresPayment }
+      : {}),
+  };
+}
+
+async function signTask(
+  task: Task,
+): Promise<Record<string, unknown>> {
+  const signed = await signX402Payment(task, { signer: TEST_ACCOUNT });
+  return signed.metadata;
+}
+
+// ─── Server-side Embedded Flow ─────────────────────────────────────────
+
+describe('X402PaymentExecutor — Embedded Flow emission', () => {
+  it('emits an artifact-shaped challenge when the agent yields paymentRequired', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]));
+    const task = newTask();
+
+    const result = await executor.execute(task, newMessage());
+
+    expect(result.status.state).toBe(TaskState.INPUT_REQUIRED);
+    // Per spec §5.3 Embedded: status.metadata has `payment-required` but
+    // NOT `x402.payment.required` (that sits on the artifact instead).
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REQUIRED);
+    expect(meta[X402_METADATA_KEYS.REQUIRED]).toBeUndefined();
+
+    expect(result.artifacts).toHaveLength(1);
+    const [artifact] = result.artifacts!;
+    expect(artifact!.name).toBe('demo-cart');
+    const dataPart = artifact!.parts[0] as { data: Record<string, unknown> };
+    expect(dataPart.data.cartId).toBe('cart-abc');
+    const challenge = dataPart.data[X402_EMBEDDED_DATA_KEY] as {
+      x402Version: number;
+      accepts: X402PaymentRequirements[];
+    };
+    expect(challenge.x402Version).toBe(1);
+    expect(challenge.accepts[0]!.maxAmountRequired).toBe('120000000');
+  });
+
+  it('uses resolveAccepts when the event omits inline accepts', async () => {
+    const executor = makeExecutor(new DynamicEmbedAgent(), {
+      resolveAccepts: (ctx) => {
+        const embed = ctx.embeddedObject as { productId: string };
+        expect(embed.productId).toBe('sku-42');
+        return [{ ...EMBEDDED_ACCEPT, amount: '75000000' }];
+      },
+    });
+
+    const result = await executor.execute(newTask(), newMessage());
+
+    expect(result.status.state).toBe(TaskState.INPUT_REQUIRED);
+    const artifact = result.artifacts![0]!;
+    const dataPart = artifact.parts[0] as { data: Record<string, unknown> };
+    const challenge = dataPart.data[X402_EMBEDDED_DATA_KEY] as {
+      accepts: X402PaymentRequirements[];
+    };
+    expect(challenge.accepts[0]!.maxAmountRequired).toBe('75000000');
+  });
+
+  it('fails the task with NO_REQUIREMENTS when neither inline accepts nor resolver supply any', async () => {
+    const executor = makeExecutor(new NoAcceptsEmbedAgent());
+
+    const result = await executor.execute(newTask(), newMessage());
+
+    expect(result.status.state).toBe(TaskState.FAILED);
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.NO_REQUIREMENTS);
+  });
+
+  it('defaults the artifact name when the event does not set one', async () => {
+    class NoNameAgent extends BaseAgent {
+      constructor() {
+        super({ name: 'no-name' });
+      }
+      async *run(): AsyncGenerator<AgentEvent> {
+        yield paymentRequiredEvent({ accepts: [EMBEDDED_ACCEPT] });
+        yield { type: 'done' };
+      }
+    }
+    const executor = makeExecutor(new NoNameAgent());
+    const result = await executor.execute(newTask(), newMessage());
+    expect(result.artifacts![0]!.name).toBe(X402_EMBEDDED_ARTIFACT_NAME);
+  });
+});
+
+describe('X402PaymentExecutor — Embedded Flow resume', () => {
+  it('verifies the embedded payment and resumes the inner generator', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]));
+
+    const first = await executor.execute(newTask(), newMessage());
+    expect(first.status.state).toBe(TaskState.INPUT_REQUIRED);
+
+    const metadata = await signTask(first);
+    const resumed = await executor.execute(
+      first,
+      newMessage({ messageId: 'm2', metadata, taskId: first.id }),
+    );
+
+    expect(resumed.status.state).toBe(TaskState.COMPLETED);
+
+    // Final artifact combines pre- and post-payment text.
+    const textArtifact = resumed.artifacts!.find((a) =>
+      a.parts.some((p) => 'text' in p),
+    )!;
+    const textPart = textArtifact.parts.find((p) => 'text' in p) as { text: string };
+    expect(textPart.text).toBe('Preparing cart… Shipping shoes…');
+
+    // Receipts attached to the final status message.
+    const receipts = getX402Receipts(resumed);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]!.success).toBe(true);
+  });
+
+  it('fails the task and discards the generator on verify failure', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]), {
+      facilitator: mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'nonce_reused',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+    });
+
+    const first = await executor.execute(newTask(), newMessage());
+    const metadata = await signTask(first);
+    const resumed = await executor.execute(
+      first,
+      newMessage({ messageId: 'm2', metadata, taskId: first.id }),
+    );
+
+    expect(resumed.status.state).toBe(TaskState.FAILED);
+    const meta = resumed.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.VERIFY_FAILED);
+  });
+
+  it('re-emits payment-required when resume is called without payment-submitted', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]));
+    const first = await executor.execute(newTask(), newMessage());
+    const retried = await executor.execute(
+      first,
+      newMessage({ messageId: 'm2', taskId: first.id }),
+    );
+    expect(retried.status.state).toBe(TaskState.INPUT_REQUIRED);
+  });
+});
+
+describe('X402PaymentExecutor — gate + embedded stacking', () => {
+  it('runs the gate first, then the embedded charge in sequence', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]), {
+      accepts: [GATE_ACCEPT],
+    });
+
+    // 1. Initial call → gate challenge.
+    const gateChallenge = await executor.execute(newTask(), newMessage());
+    expect(gateChallenge.status.state).toBe(TaskState.INPUT_REQUIRED);
+    const gateMeta = gateChallenge.status.message?.metadata as Record<string, unknown>;
+    expect(gateMeta[X402_METADATA_KEYS.REQUIRED]).toBeDefined();
+
+    // 2. Client signs the gate requirement and resubmits.
+    const gateSigned = await signTask(gateChallenge);
+    const afterGate = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata: gateSigned }),
+    );
+
+    // 3. After the gate, agent yields paymentRequired → embedded challenge.
+    expect(afterGate.status.state).toBe(TaskState.INPUT_REQUIRED);
+    expect(
+      (afterGate.status.message?.metadata as Record<string, unknown>)[
+        X402_METADATA_KEYS.REQUIRED
+      ],
+    ).toBeUndefined();
+    expect(afterGate.artifacts?.some((a) => a.name === 'demo-cart')).toBe(true);
+
+    // 4. Client signs the embedded challenge and resubmits.
+    const embedSigned = await signTask(afterGate);
+    const completed = await executor.execute(
+      afterGate,
+      newMessage({ messageId: 'm3', metadata: embedSigned, taskId: afterGate.id }),
+    );
+
+    expect(completed.status.state).toBe(TaskState.COMPLETED);
+    const receipts = getX402Receipts(completed);
+    expect(receipts).toHaveLength(2); // gate + embedded
+    expect(receipts.every((r) => r.success)).toBe(true);
+  });
+
+  it('supports gate-zero / purchase-only setups (requiresPayment returns false)', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]), {
+      accepts: [GATE_ACCEPT],
+      requiresPayment: () => false, // skip gate entirely
+    });
+
+    const first = await executor.execute(newTask(), newMessage());
+    expect(first.status.state).toBe(TaskState.INPUT_REQUIRED);
+    // No gate was charged → only embedded challenge should be present.
+    const meta = first.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.REQUIRED]).toBeUndefined();
+
+    const signed = await signTask(first);
+    const completed = await executor.execute(
+      first,
+      newMessage({ messageId: 'm2', metadata: signed, taskId: first.id }),
+    );
+
+    expect(completed.status.state).toBe(TaskState.COMPLETED);
+    const receipts = getX402Receipts(completed);
+    expect(receipts).toHaveLength(1); // embedded only
+  });
+});
+
+// ─── Streaming ─────────────────────────────────────────────────────────
+
+describe('X402PaymentExecutor — Embedded Flow streaming', () => {
+  it('yields the challenge artifact and an input-required status, then resumes to completed', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]));
+
+    const firstEvents: unknown[] = [];
+    for await (const event of executor.executeStream(newTask(), newMessage())) {
+      firstEvents.push(event);
+    }
+
+    // WORKING → artifact-update(text) → artifact-update(challenge) → INPUT_REQUIRED.
+    const statuses = firstEvents.filter(
+      (e): e is { status: { state: TaskState } } =>
+        typeof e === 'object' && e !== null && 'status' in e,
+    );
+    expect(statuses[0]!.status.state).toBe(TaskState.WORKING);
+    expect(statuses.at(-1)!.status.state).toBe(TaskState.INPUT_REQUIRED);
+
+    const artifacts = firstEvents.filter(
+      (e): e is { artifact: { artifactId: string; name?: string } } =>
+        typeof e === 'object' && e !== null && 'artifact' in e,
+    );
+    expect(artifacts.some((e) => e.artifact.name === 'demo-cart')).toBe(true);
+
+    // Resume.
+    const firstTask = await executor.execute(newTask('t2'), newMessage());
+    const metadata = await signTask(firstTask);
+    const secondEvents: unknown[] = [];
+    for await (const event of executor.executeStream(
+      firstTask,
+      newMessage({ messageId: 'm2', metadata, taskId: firstTask.id }),
+    )) {
+      secondEvents.push(event);
+    }
+    const secondStatuses = secondEvents.filter(
+      (e): e is { status: { state: TaskState } } =>
+        typeof e === 'object' && e !== null && 'status' in e,
+    );
+    expect(secondStatuses.at(-1)!.status.state).toBe(TaskState.COMPLETED);
+  });
+});
+
+// ─── Client-side helpers ───────────────────────────────────────────────
+
+describe('getEmbeddedX402Challenges', () => {
+  function taskWithEmbeddedArtifact(
+    data: Record<string, unknown>,
+    artifactName = 'demo-cart',
+  ): Task {
+    return {
+      id: 't1',
+      contextId: 'c1',
+      status: {
+        state: TaskState.INPUT_REQUIRED,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: 'msg',
+          role: 'agent',
+          parts: [{ text: 'Payment is required to continue.' }],
+          metadata: {
+            [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          },
+        },
+      },
+      artifacts: [
+        {
+          artifactId: 'challenge-1',
+          name: artifactName,
+          parts: [{ data } as Part],
+        },
+      ],
+    };
+  }
+
+  it('parses the bare embedded shape the SDK emits', () => {
+    const task = taskWithEmbeddedArtifact({
+      [X402_EMBEDDED_DATA_KEY]: {
+        x402Version: 1,
+        accepts: [{ maxAmountRequired: '120000000', network: 'base-sepolia' }],
+      },
+    });
+    const challenges = getEmbeddedX402Challenges(task);
+    expect(challenges).toHaveLength(1);
+    expect(challenges[0]!.artifactId).toBe('challenge-1');
+    expect(challenges[0]!.required.accepts[0]!.maxAmountRequired).toBe('120000000');
+  });
+
+  it('finds an x402PaymentRequiredResponse nested inside a higher-level wrapper (AP2-style)', () => {
+    const task = taskWithEmbeddedArtifact({
+      'ap2.mandates.CartMandate': {
+        id: 'cart-shoes-123',
+        payment_request: {
+          method_data: [
+            {
+              supported_methods: 'https://www.x402.org/',
+              data: {
+                x402Version: 1,
+                accepts: [{ maxAmountRequired: '120000000', network: 'base' }],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const challenges = getEmbeddedX402Challenges(task);
+    expect(challenges).toHaveLength(1);
+    expect(challenges[0]!.required.accepts[0]!.network).toBe('base');
+  });
+
+  it('returns an empty array when no artifact carries a challenge', () => {
+    const task: Task = {
+      id: 't1',
+      status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+    };
+    expect(getEmbeddedX402Challenges(task)).toEqual([]);
+  });
+});
+
+describe('X402Client — gate + embedded integration', () => {
+  /**
+   * Build a fake A2XClient that dispatches into a given executor so we
+   * can exercise the client loop end-to-end without HTTP.
+   */
+  function makeClient(executor: X402PaymentExecutor): A2XClient {
+    // A2XClient expects an HTTP URL; we stub sendMessage directly.
+    const client = new A2XClient('http://stub');
+    const tasks = new Map<string, Task>();
+    (client as unknown as { sendMessage: typeof client.sendMessage }).sendMessage =
+      async (params: SendMessageParams): Promise<Task> => {
+        const existingId = (params.message as { taskId?: string }).taskId;
+        let task: Task;
+        if (existingId && tasks.has(existingId)) {
+          task = tasks.get(existingId)!;
+        } else {
+          task = {
+            id: `task-${tasks.size + 1}`,
+            contextId: 'ctx',
+            status: {
+              state: TaskState.SUBMITTED,
+              timestamp: new Date().toISOString(),
+            },
+          };
+          tasks.set(task.id, task);
+        }
+        const result = await executor.execute(task, params.message);
+        tasks.set(result.id, result);
+        return result;
+      };
+    return client;
+  }
+
+  it('resolves both a gate challenge and an embedded challenge in one sendMessage call', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]), {
+      accepts: [GATE_ACCEPT],
+    });
+    const client = makeClient(executor);
+
+    let gateCallbacks = 0;
+    let embeddedCallbacks = 0;
+    const x402 = new X402Client(client, {
+      signer: TEST_ACCOUNT,
+      onPaymentRequired: () => {
+        gateCallbacks += 1;
+      },
+      onEmbeddedPaymentRequired: () => {
+        embeddedCallbacks += 1;
+      },
+    });
+
+    const task = await x402.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'buy shoes' }],
+      },
+    });
+
+    expect(task.status.state).toBe(TaskState.COMPLETED);
+    expect(gateCallbacks).toBe(1);
+    expect(embeddedCallbacks).toBe(1);
+    const receipts = getX402Receipts(task);
+    expect(receipts).toHaveLength(2);
+  });
+
+  it('handles a purchase-only (no-gate) setup', async () => {
+    const executor = makeExecutor(new PreEmbedAgent([EMBEDDED_ACCEPT]));
+    const client = makeClient(executor);
+    const x402 = new X402Client(client, { signer: TEST_ACCOUNT });
+
+    const task = await x402.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'buy shoes' }],
+      },
+    });
+
+    expect(task.status.state).toBe(TaskState.COMPLETED);
+    const receipts = getX402Receipts(task);
+    expect(receipts).toHaveLength(1);
+  });
+
+  it('gives up after `maxPaymentHops` hops to avoid infinite loops', async () => {
+    // Build an agent that always yields paymentRequired, never completes.
+    class LoopAgent extends BaseAgent {
+      constructor() {
+        super({ name: 'loop-agent' });
+      }
+      async *run(): AsyncGenerator<AgentEvent> {
+        while (true) {
+          yield paymentRequiredEvent({ accepts: [EMBEDDED_ACCEPT] });
+        }
+      }
+    }
+    const executor = makeExecutor(new LoopAgent());
+    const client = makeClient(executor);
+    const x402 = new X402Client(client, { signer: TEST_ACCOUNT, maxPaymentHops: 3 });
+
+    const task = await x402.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'pay forever' }],
+      },
+    });
+    // Final task is still in input-required because we bailed early.
+    expect(task.status.state).toBe(TaskState.INPUT_REQUIRED);
+  });
+});
+
+// ─── Marker: ensure the non-x402 executor still ignores paymentRequired ──
+
+describe('Base AgentExecutor', () => {
+  it('does not crash when the agent yields paymentRequired (ignored)', async () => {
+    // Use base AgentExecutor (NOT X402PaymentExecutor) with an agent that
+    // yields paymentRequired. The base switch has no case for it and
+    // should fall through without throwing.
+    const runner = new InMemoryRunner({
+      agent: new PreEmbedAgent([EMBEDDED_ACCEPT]),
+      appName: 'base-test',
+    });
+    const inner = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const task = newTask('t-base');
+    const result = await inner.execute(task, newMessage());
+    // Base executor should complete normally (paymentRequired ignored).
+    expect(result.status.state).toBe(TaskState.COMPLETED);
+  });
+});
+
+// Suppress unused-import warnings for types used only in annotations.
+void ({} as { X402PaymentPayload: X402PaymentPayload; X402SettleResponse: X402SettleResponse });

--- a/packages/a2x/src/agent/base-agent.ts
+++ b/packages/a2x/src/agent/base-agent.ts
@@ -11,7 +11,36 @@ export type AgentEvent =
   | { type: 'toolCall'; toolName: string; args: Record<string, unknown>; toolCallId?: string }
   | { type: 'toolResult'; toolName: string; result: unknown; toolCallId?: string }
   | { type: 'done'; output?: unknown }
-  | { type: 'error'; error: Error };
+  | { type: 'error'; error: Error }
+  | {
+      /**
+       * Request an additional payment mid-execution. The wrapping executor
+       * (e.g. `X402PaymentExecutor`) converts this event into an embedded
+       * payment challenge on an artifact and suspends the task into
+       * `input-required`. Execution resumes on the next client message
+       * carrying the signed payload. Executors that don't know about
+       * payments ignore this event.
+       */
+      type: 'paymentRequired';
+      /**
+       * Inline payment options. Loosely typed so this variant stays
+       * independent of the x402 extension package; the x402 executor
+       * casts to `X402Accept[]` when present.
+       */
+      accepts?: unknown;
+      /**
+       * Opaque higher-level object to embed alongside the x402 challenge
+       * (e.g. an AP2 `CartMandate`). Passed to `resolveAccepts()` when
+       * `accepts` is omitted, and rendered as the artifact's data part.
+       */
+      embeddedObject?: unknown;
+      /** Optional artifact id. Executor generates one when omitted. */
+      artifactId?: string;
+      /** Optional artifact name. Default: `x402-payment-required`. */
+      artifactName?: string;
+      /** Optional artifact-level metadata. */
+      artifactMetadata?: Record<string, unknown>;
+    };
 
 // ─── BaseAgent ───
 

--- a/packages/a2x/src/x402/client.ts
+++ b/packages/a2x/src/x402/client.ts
@@ -9,8 +9,9 @@
  *     should attach to the follow-up message.
  *
  *  2. `X402Client` — wrapper around `A2XClient` that runs the full
- *     payment dance automatically: sendMessage → detect payment-required →
- *     sign → resubmit → return completed task.
+ *     payment dance automatically: sendMessage → detect gate challenge →
+ *     sign → resubmit → detect embedded challenges → sign → resubmit →
+ *     … → return completed task.
  *
  * We accept any viem-compatible `LocalAccount` as the signer, which keeps
  * the SDK wallet-agnostic (CLI, browser wallets, HSM-backed signers etc.
@@ -24,12 +25,16 @@ import { PaymentPayloadSchema } from 'x402/types';
 import { A2XClient } from '../client/a2x-client.js';
 import type { SendMessageParams } from '../types/jsonrpc.js';
 import type { Task } from '../types/task.js';
-import type { Message } from '../types/common.js';
+import type { Artifact, Message } from '../types/common.js';
+import { isDataPart } from '../types/common.js';
 import {
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
   type X402PaymentStatus,
 } from './constants.js';
+import {
+  X402_EMBEDDED_DATA_KEY,
+} from './executor.js';
 import {
   X402NoSupportedRequirementError,
   X402PaymentFailedError,
@@ -70,8 +75,10 @@ export interface SignedX402Payment {
 
 /**
  * Extract the `X402PaymentRequiredResponse` from a task the merchant put
- * into `input-required` state. Returns `undefined` if the task isn't
- * actually asking for payment.
+ * into `input-required` state via the Standalone flow. Returns
+ * `undefined` if the task isn't asking for Standalone payment — callers
+ * should additionally check `getEmbeddedX402Challenges` for Embedded
+ * flow challenges.
  */
 export function getX402PaymentRequirements(
   task: Task,
@@ -83,6 +90,112 @@ export function getX402PaymentRequirements(
     | X402PaymentRequiredResponse
     | undefined;
   return required;
+}
+
+/**
+ * One pending Embedded-flow challenge discovered on a task.
+ *
+ * Matches the a2a-x402 v0.2 Embedded detection path (spec §4.2): the
+ * task is in `input-required` with `x402.payment.status: payment-required`
+ * in `status.message.metadata` but WITHOUT `x402.payment.required`, and
+ * the challenge lives inside an artifact on `task.artifacts[]`.
+ */
+export interface EmbeddedX402Challenge {
+  /** The artifact carrying the challenge. */
+  artifactId: string;
+  /** Optional artifact name. */
+  artifactName?: string;
+  /** The x402 payment-required object parsed out of the artifact data. */
+  required: X402PaymentRequiredResponse;
+  /**
+   * The raw data-part value. When the merchant wraps the challenge in a
+   * higher-level object (e.g. an AP2 `CartMandate`) this carries the
+   * full shape so callers can render order details.
+   */
+  data: Record<string, unknown>;
+}
+
+/**
+ * Scan a task for Embedded-flow x402 challenges. Returns an empty array
+ * if the task isn't asking for Embedded payment.
+ *
+ * Per spec §4.2 the Embedded path is triggered when the task metadata
+ * has `payment-required` status without the `x402.payment.required`
+ * standalone key. We additionally accept a partially-populated task
+ * (e.g. a gate-less agent that emits an Embedded challenge from the
+ * first event) as long as `task.artifacts[]` contains a supported shape.
+ */
+export function getEmbeddedX402Challenges(task: Task): EmbeddedX402Challenge[] {
+  const artifacts = task.artifacts ?? [];
+  const results: EmbeddedX402Challenge[] = [];
+  for (const artifact of artifacts) {
+    const challenge = parseEmbeddedChallenge(artifact);
+    if (challenge) results.push(challenge);
+  }
+  return results;
+}
+
+function parseEmbeddedChallenge(artifact: Artifact): EmbeddedX402Challenge | undefined {
+  for (const part of artifact.parts) {
+    if (!isDataPart(part)) continue;
+    const data = part.data;
+    if (!data || typeof data !== 'object') continue;
+    const asRecord = data as Record<string, unknown>;
+    const required = findX402RequiredShape(asRecord);
+    if (required) {
+      return {
+        artifactId: artifact.artifactId,
+        artifactName: artifact.name,
+        required,
+        data: asRecord,
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Look for an `X402PaymentRequiredResponse`-shaped object anywhere in a
+ * data tree. Handles both the bare embedded shape (where the SDK writes
+ * under the `x402.payment.required` key) and user-supplied higher-level
+ * wrappers (e.g. AP2 `payment_request.method_data[n].data`).
+ */
+function findX402RequiredShape(
+  value: unknown,
+): X402PaymentRequiredResponse | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findX402RequiredShape(entry);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+
+  // Bare shape emitted by X402PaymentExecutor.
+  const direct = record[X402_EMBEDDED_DATA_KEY];
+  if (isX402RequiredShape(direct)) return direct;
+
+  // Direct match — when the object itself IS an X402PaymentRequiredResponse.
+  if (isX402RequiredShape(record)) return record;
+
+  // Recurse into nested values (handles AP2 and other wrappers).
+  for (const nested of Object.values(record)) {
+    const found = findX402RequiredShape(nested);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function isX402RequiredShape(value: unknown): value is X402PaymentRequiredResponse {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.x402Version === 1 &&
+    Array.isArray(v.accepts) &&
+    v.accepts.length > 0
+  );
 }
 
 /**
@@ -106,13 +219,18 @@ export function getX402Status(task: Task): X402PaymentStatus | undefined {
 /**
  * Sign a payment for the given `payment-required` task. Callers
  * typically use this when they want fine-grained control of the
- * subsequent `message/send` call.
+ * subsequent `message/send` call. Works for both Standalone and
+ * Embedded challenges — when the task is in Embedded state, the first
+ * embedded challenge is selected unless the caller passes `requirements`
+ * explicitly via `selectRequirement`.
  */
 export async function signX402Payment(
   task: Task,
   options: SignX402PaymentOptions,
 ): Promise<SignedX402Payment> {
-  const required = getX402PaymentRequirements(task);
+  const standalone = getX402PaymentRequirements(task);
+  const embedded = standalone ? [] : getEmbeddedX402Challenges(task);
+  const required = standalone ?? embedded[0]?.required;
   if (!required) {
     throw new X402PaymentRequiredError(
       'Task is not in a payment-required state.',
@@ -125,18 +243,7 @@ export async function signX402Payment(
     throw new X402NoSupportedRequirementError();
   }
 
-  const header = await createX402PaymentHeader(
-    options.signer as unknown as Parameters<typeof createX402PaymentHeader>[0],
-    required.x402Version,
-    requirement as unknown as Parameters<typeof createX402PaymentHeader>[2],
-  );
-
-  // `createPaymentHeader` returns a base64-encoded PaymentPayload for HTTP
-  // transports. A2A doesn't transport through headers, so we decode it
-  // back to the structured object for embedding in `message.metadata`.
-  const decoded = safeBase64Decode(header);
-  const parsed = PaymentPayloadSchema.parse(JSON.parse(decoded));
-  const payload = parsed as unknown as X402PaymentPayload;
+  const payload = await signRequirement(required.x402Version, requirement, options.signer);
 
   return {
     requirement,
@@ -146,6 +253,25 @@ export async function signX402Payment(
       [X402_METADATA_KEYS.PAYLOAD]: payload,
     },
   };
+}
+
+async function signRequirement(
+  x402Version: X402PaymentRequiredResponse['x402Version'],
+  requirement: X402PaymentRequirements,
+  signer: LocalAccount,
+): Promise<X402PaymentPayload> {
+  const header = await createX402PaymentHeader(
+    signer as unknown as Parameters<typeof createX402PaymentHeader>[0],
+    x402Version,
+    requirement as unknown as Parameters<typeof createX402PaymentHeader>[2],
+  );
+
+  // `createPaymentHeader` returns a base64-encoded PaymentPayload for HTTP
+  // transports. A2A doesn't transport through headers, so we decode it
+  // back to the structured object for embedding in `message.metadata`.
+  const decoded = safeBase64Decode(header);
+  const parsed = PaymentPayloadSchema.parse(JSON.parse(decoded));
+  return parsed as unknown as X402PaymentPayload;
 }
 
 function defaultSelect(
@@ -158,17 +284,33 @@ function defaultSelect(
 
 export interface X402ClientOptions extends SignX402PaymentOptions {
   /**
-   * Optional callback invoked after the merchant asks for payment and
-   * before the client signs. Useful for prompting the user to confirm.
-   * Throw from the callback to abort the payment flow.
+   * Optional callback invoked after the merchant asks for a Standalone
+   * (gate) payment, before the client signs. Useful for prompting the
+   * user to confirm. Throw from the callback to abort the flow.
    */
   onPaymentRequired?: (required: X402PaymentRequiredResponse) => void | Promise<void>;
+  /**
+   * Optional callback invoked for each Embedded-flow challenge the
+   * merchant emits mid-execution. Receives the parsed challenge and the
+   * full in-flight task. Throw to abort.
+   */
+  onEmbeddedPaymentRequired?: (
+    challenge: EmbeddedX402Challenge,
+    task: Task,
+  ) => void | Promise<void>;
+  /**
+   * Cap the number of payment hops (gate + embedded) a single
+   * `sendMessage` call will complete before giving up. Defaults to 8 so
+   * buggy agents can't produce infinite loops.
+   */
+  maxPaymentHops?: number;
 }
 
 /**
  * Thin wrapper around `A2XClient` that transparently handles x402
- * payment challenges. Use when the calling code doesn't need to inspect
- * the `payment-required` task itself.
+ * payment challenges — both the Standalone gate and any Embedded-flow
+ * charges emitted mid-execution. Use when the calling code doesn't need
+ * to inspect the intermediate tasks itself.
  */
 export class X402Client {
   constructor(
@@ -177,57 +319,103 @@ export class X402Client {
   ) {}
 
   /**
-   * Send a message, resolving payment if the merchant asks for it.
-   * Returns the final completed (or failed) Task.
+   * Send a message, resolving every payment challenge the merchant
+   * emits. Returns the final completed (or failed) Task.
    */
   async sendMessage(params: SendMessageParams): Promise<Task> {
-    const first = await this._client.sendMessage(params);
-    if (first.status.state !== 'input-required') {
-      return first;
-    }
-    const required = getX402PaymentRequirements(first);
-    if (!required) {
-      return first;
-    }
-    if (this._options.onPaymentRequired) {
-      await this._options.onPaymentRequired(required);
+    const maxHops = this._options.maxPaymentHops ?? 8;
+    let task = await this._client.sendMessage(params);
+    let hops = 0;
+
+    while (task.status.state === 'input-required' && hops < maxHops) {
+      task = await this._resolveChallenge(params, task);
+      this._assertNotFailed(task);
+      hops += 1;
     }
 
-    const signed = await signX402Payment(first, this._options);
-    const followup: Message = {
-      ...params.message,
-      messageId: cryptoRandomId(),
-      taskId: first.id,
-      contextId: first.contextId,
-      metadata: {
-        ...(params.message.metadata ?? {}),
-        ...signed.metadata,
-      },
-    };
-
-    const second = await this._client.sendMessage({
-      ...params,
-      message: followup,
-    });
-
-    const receipts = getX402Receipts(second);
-    const failed = receipts.find((r) => !r.success);
-    if (failed) {
-      throw new X402PaymentFailedError(
-        failed.errorReason ?? 'Payment failed',
-        (second.status.message?.metadata as Record<string, unknown> | undefined)?.[
-          X402_METADATA_KEYS.ERROR
-        ] as string ?? 'UNKNOWN',
-        { transaction: failed.transaction, network: failed.network },
-      );
-    }
-
-    return second;
+    this._assertNotFailed(task);
+    return task;
   }
 
   /** Access the underlying A2XClient for non-x402 operations. */
   get client(): A2XClient {
     return this._client;
+  }
+
+  private async _resolveChallenge(
+    params: SendMessageParams,
+    task: Task,
+  ): Promise<Task> {
+    const standalone = getX402PaymentRequirements(task);
+    if (standalone) {
+      if (this._options.onPaymentRequired) {
+        await this._options.onPaymentRequired(standalone);
+      }
+      const signed = await signX402Payment(task, this._options);
+      return this._submit(params, task, signed.metadata);
+    }
+
+    const embedded = getEmbeddedX402Challenges(task);
+    const first = embedded[0];
+    if (first) {
+      if (this._options.onEmbeddedPaymentRequired) {
+        await this._options.onEmbeddedPaymentRequired(first, task);
+      }
+      const select = this._options.selectRequirement ?? defaultSelect;
+      const requirement = select(first.required.accepts);
+      if (!requirement) {
+        throw new X402NoSupportedRequirementError();
+      }
+      const payload = await signRequirement(
+        first.required.x402Version,
+        requirement,
+        this._options.signer,
+      );
+      const metadata = {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.SUBMITTED,
+        [X402_METADATA_KEYS.PAYLOAD]: payload,
+      };
+      return this._submit(params, task, metadata);
+    }
+
+    // Input required but no x402 challenge we recognize — surface as-is.
+    return task;
+  }
+
+  private async _submit(
+    params: SendMessageParams,
+    task: Task,
+    metadata: Record<string, unknown>,
+  ): Promise<Task> {
+    const followup: Message = {
+      ...params.message,
+      messageId: cryptoRandomId(),
+      taskId: task.id,
+      contextId: task.contextId,
+      metadata: {
+        ...(params.message.metadata ?? {}),
+        ...metadata,
+      },
+    };
+    return this._client.sendMessage({
+      ...params,
+      message: followup,
+    });
+  }
+
+  private _assertNotFailed(task: Task): void {
+    const receipts = getX402Receipts(task);
+    const failed = receipts.find((r) => !r.success);
+    if (failed) {
+      const meta = task.status.message?.metadata as
+        | Record<string, unknown>
+        | undefined;
+      throw new X402PaymentFailedError(
+        failed.errorReason ?? 'Payment failed',
+        (meta?.[X402_METADATA_KEYS.ERROR] as string | undefined) ?? 'UNKNOWN',
+        { transaction: failed.transaction, network: failed.network },
+      );
+    }
   }
 }
 

--- a/packages/a2x/src/x402/events.ts
+++ b/packages/a2x/src/x402/events.ts
@@ -1,0 +1,58 @@
+/**
+ * Typed constructor for the `paymentRequired` AgentEvent variant.
+ *
+ * The event lives on the generic `AgentEvent` union (see
+ * `agent/base-agent.ts`) with a loosely-typed `accepts: unknown` so the
+ * base agent types stay independent of the x402 extension. This helper
+ * narrows the builder side back to `X402Accept[]`, so agent code reads
+ * naturally:
+ *
+ * ```ts
+ * async *run(ctx) {
+ *   yield paymentRequiredEvent({
+ *     accepts: [{ network: 'base', amount: '120000000', ... }],
+ *     embeddedObject: { 'ap2.mandates.CartMandate': cart },
+ *   });
+ *   yield { type: 'text', text: 'Paid! Shipping your shoes…' };
+ *   yield { type: 'done' };
+ * }
+ * ```
+ */
+
+import type { AgentEvent } from '../agent/base-agent.js';
+import type { X402Accept } from './types.js';
+
+export interface PaymentRequiredEventOptions {
+  /**
+   * Inline payment options. If omitted, the executor's `resolveAccepts`
+   * hook is consulted; if neither produces a non-empty list, the event
+   * fails the task with `NO_REQUIREMENTS`.
+   */
+  accepts?: X402Accept[];
+  /**
+   * Higher-level embedded object (e.g. an AP2 `CartMandate`) to carry
+   * alongside the x402 challenge on the emitted artifact. The SDK adds
+   * `x402.payment.required` alongside whatever shape you pass here.
+   */
+  embeddedObject?: unknown;
+  /** Override the generated artifact id. */
+  artifactId?: string;
+  /** Override the default artifact name (`x402-payment-required`). */
+  artifactName?: string;
+  /** Optional artifact-level metadata. */
+  artifactMetadata?: Record<string, unknown>;
+}
+
+export function paymentRequiredEvent(
+  options: PaymentRequiredEventOptions = {},
+): AgentEvent {
+  const event: Extract<AgentEvent, { type: 'paymentRequired' }> = {
+    type: 'paymentRequired',
+  };
+  if (options.accepts !== undefined) event.accepts = options.accepts;
+  if (options.embeddedObject !== undefined) event.embeddedObject = options.embeddedObject;
+  if (options.artifactId !== undefined) event.artifactId = options.artifactId;
+  if (options.artifactName !== undefined) event.artifactName = options.artifactName;
+  if (options.artifactMetadata !== undefined) event.artifactMetadata = options.artifactMetadata;
+  return event;
+}

--- a/packages/a2x/src/x402/executor.ts
+++ b/packages/a2x/src/x402/executor.ts
@@ -1,21 +1,31 @@
 /**
- * `X402PaymentExecutor` wraps an existing `AgentExecutor` with an x402
- * payment gate. All inbound messages are classified as either:
+ * `X402PaymentExecutor` wraps an existing `AgentExecutor` with x402
+ * payment coordination. It supports both flows from a2a-x402 v0.2:
  *
- *  - "payment-submitted" → verify + settle on-chain, then run the inner
- *    executor with the original user content, and attach the settlement
- *    receipt to the response.
- *  - anything else → respond with a `payment-required` task state carrying
- *    the `X402PaymentRequiredResponse` in message metadata. The task is
- *    left in `input-required` so the client can resume it by resending the
- *    message with a signed `PaymentPayload`.
+ *  - **Standalone (gate) flow.** The first message to a task triggers a
+ *    `payment-required` response carrying the `x402PaymentRequiredResponse`
+ *    in `task.status.message.metadata`. The client signs a `PaymentPayload`
+ *    and resubmits the same task; the executor verifies + settles and then
+ *    runs the inner agent.
+ *
+ *  - **Embedded flow.** While the inner agent is running it can yield
+ *    `{ type: 'paymentRequired', ... }` to request an additional charge.
+ *    The executor converts that into an artifact-shaped challenge
+ *    (per spec §5.3 Embedded example), transitions the task back into
+ *    `input-required`, and suspends execution. When the client resubmits
+ *    with a signed payload, the executor verifies + settles and resumes
+ *    the inner agent generator from where it paused.
+ *
+ * The two flows compose: a gate-zero or gate-skipped setup can rely on
+ * embedded charges exclusively, or they can stack (gate + one or more
+ * embedded charges per task).
  *
  * The wrapper preserves the `AgentExecutor` public surface (runner,
  * runConfig, execute, executeStream, cancel) so it can be dropped into
  * `A2XAgent` transparently.
  */
 
-import type { Message } from '../types/common.js';
+import type { Artifact, Message } from '../types/common.js';
 import type {
   Task,
   TaskStatusUpdateEvent,
@@ -23,6 +33,8 @@ import type {
 } from '../types/task.js';
 import { TaskState } from '../types/task.js';
 import { AgentExecutor } from '../a2x/agent-executor.js';
+import type { AgentEvent } from '../agent/base-agent.js';
+import type { Session } from '../runner/context.js';
 import {
   X402_ERROR_CODES,
   X402_DEFAULT_RESOURCE,
@@ -41,13 +53,27 @@ import type {
   X402SettleResponse,
 } from './types.js';
 
+/** Artifact name the SDK uses for bare embedded challenges. */
+export const X402_EMBEDDED_ARTIFACT_NAME = 'x402-payment-required';
+
+/** Data-part key the SDK uses for bare embedded challenges. */
+export const X402_EMBEDDED_DATA_KEY = 'x402.payment.required';
+
+export interface X402ResolveAcceptsContext {
+  /** The task the inner agent is running against. */
+  task: Task;
+  /** The message that triggered the current execution. */
+  message: Message;
+  /** Higher-level embedded object the agent emitted alongside the event. */
+  embeddedObject?: unknown;
+}
+
 export interface X402PaymentExecutorOptions {
   /**
-   * Payment options offered to the client. At least one is required.
-   * The SDK publishes all of them under `x402.payment.required.accepts`;
-   * the client picks one to sign.
+   * Payment options offered at the Standalone gate. Omit or pass `[]` to
+   * skip the gate entirely and rely solely on Embedded flow charges.
    */
-  accepts: X402Accept[];
+  accepts?: X402Accept[];
   /**
    * Facilitator that performs on-chain verify/settle. Either a URL config
    * (uses `useFacilitator()` from x402/verify), a fully custom
@@ -56,21 +82,45 @@ export interface X402PaymentExecutorOptions {
   facilitator?: FacilitatorUrlConfig | X402Facilitator;
   /**
    * Optional predicate: receive the incoming message and decide whether
-   * to require payment. Return `false` for requests that should pass
-   * through without charging. Default: always require payment.
+   * to require gate payment. Return `false` for requests that should pass
+   * through the gate without charging. Default: gate runs whenever
+   * `accepts` is non-empty.
    */
   requiresPayment?: (message: Message) => boolean;
+  /**
+   * Resolver for Embedded flow. Invoked when the inner agent yields
+   * `{ type: 'paymentRequired' }` without inline `accepts`. Use this to
+   * price per-action (cart totals, premium content, etc.).
+   */
+  resolveAccepts?: (
+    context: X402ResolveAcceptsContext,
+  ) => X402Accept[] | Promise<X402Accept[]>;
 }
 
 interface ResolvedConfig {
   accepts: X402PaymentRequirements[];
   facilitator: X402Facilitator;
-  requiresPayment: (message: Message) => boolean;
+  requiresPayment?: (message: Message) => boolean;
+  resolveAccepts?: (
+    context: X402ResolveAcceptsContext,
+  ) => X402Accept[] | Promise<X402Accept[]>;
+}
+
+interface PendingEmbeddedState {
+  iterator: AsyncIterator<AgentEvent>;
+  session: Session;
+  controller: AbortController;
+  accepts: X402PaymentRequirements[];
+  challengeArtifactId: string;
+  textArtifactId: string;
+  textParts: string[];
+  priorReceipts: X402SettleResponse[];
 }
 
 export class X402PaymentExecutor extends AgentExecutor {
   private readonly _inner: AgentExecutor;
   private readonly _config: ResolvedConfig;
+  private readonly _pending = new Map<string, PendingEmbeddedState>();
 
   constructor(inner: AgentExecutor, options: X402PaymentExecutorOptions) {
     super({ runner: inner.runner, runConfig: inner.runConfig });
@@ -79,205 +129,715 @@ export class X402PaymentExecutor extends AgentExecutor {
   }
 
   override async execute(task: Task, message: Message): Promise<Task> {
-    if (!this._config.requiresPayment(message)) {
-      return this._inner.execute(task, message);
+    const pending = this._pending.get(task.id);
+    if (pending) {
+      return this._resumeEmbeddedNonStream(task, message, pending);
     }
 
-    const status = getPaymentStatus(message);
-
-    if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
-      applyPaymentRequiredStatus(task, this._buildRequirements());
-      return task;
+    if (this._shouldRunGate(message)) {
+      const gateOutcome = await this._runGateNonStream(task, message);
+      if (gateOutcome.action !== 'continue') {
+        return task;
+      }
+      // Gate passed; inner run gets the message with payment receipts attached.
+      return this._runInnerNonStream(task, message, [gateOutcome.receipt]);
     }
 
-    const payload = getPaymentPayload(message);
-    const authorization = getEvmAuthorization(payload);
-    if (!payload || !authorization) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.INVALID_PAYLOAD,
-        'Payment payload is missing or malformed.',
-        payload?.network,
-      );
-      return task;
-    }
-
-    const accepted = this._matchRequirement(payload);
-    const validationErr = validatePayloadAgainstRequirement(payload, accepted);
-    if (validationErr) {
-      applyFailedPaymentStatus(
-        task,
-        validationErr.code,
-        validationErr.reason,
-        payload.network,
-      );
-      return task;
-    }
-
-    const verifyResult = await this._config.facilitator.verify(payload, accepted!);
-    if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.VERIFY_FAILED,
-        verifyResult.invalidReason ?? 'Payment verification failed.',
-        payload.network,
-      );
-      return task;
-    }
-
-    const settleResult = await this._config.facilitator.settle(payload, accepted!);
-    if (!settleResult.success) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.SETTLE_FAILED,
-        settleResult.errorReason ?? 'Payment settlement failed.',
-        payload.network,
-      );
-      return task;
-    }
-
-    const receipt: X402SettleResponse = {
-      success: true,
-      transaction: settleResult.transaction ?? '',
-      network: payload.network,
-    };
-
-    const result = await this._inner.execute(task, message);
-    attachReceipt(result, receipt);
-    return result;
+    return this._runInnerNonStream(task, message, []);
   }
 
   override async *executeStream(
     task: Task,
     message: Message,
   ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
-    if (!this._config.requiresPayment(message)) {
-      yield* this._inner.executeStream(task, message);
+    const pending = this._pending.get(task.id);
+    if (pending) {
+      yield* this._resumeEmbeddedStream(task, message, pending);
       return;
     }
 
+    if (this._shouldRunGate(message)) {
+      const gateOutcome = yield* this._runGateStream(task, message);
+      if (gateOutcome.action !== 'continue') {
+        return;
+      }
+      yield* this._runInnerStream(task, message, [gateOutcome.receipt]);
+      return;
+    }
+
+    yield* this._runInnerStream(task, message, []);
+  }
+
+  override async cancel(task: Task): Promise<Task> {
+    const pending = this._pending.get(task.id);
+    if (pending) {
+      pending.controller.abort();
+      try {
+        await pending.iterator.return?.(undefined);
+      } catch {
+        // Generators may throw on .return(); we don't care during cancel.
+      }
+      this._pending.delete(task.id);
+    }
+    return this._inner.cancel(task);
+  }
+
+  // ─── Gate (Standalone flow) ────────────────────────────────────────────
+
+  private _shouldRunGate(message: Message): boolean {
+    if (this._config.accepts.length === 0) return false;
+    const predicate = this._config.requiresPayment;
+    return predicate ? predicate(message) : true;
+  }
+
+  private async _runGateNonStream(
+    task: Task,
+    message: Message,
+  ): Promise<GateOutcome> {
+    const status = getPaymentStatus(message);
+    if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
+      applyPaymentRequiredStatus(task, {
+        x402Version: 1,
+        accepts: this._config.accepts,
+      });
+      return { action: 'emit-required' };
+    }
+
+    const verdict = await this._verifyAndSettle(
+      getPaymentPayload(message),
+      this._config.accepts,
+    );
+    if (verdict.kind === 'failure') {
+      applyFailedPaymentStatus(task, verdict.code, verdict.reason, verdict.network);
+      return { action: 'failed' };
+    }
+    return { action: 'continue', receipt: verdict.receipt };
+  }
+
+  private async *_runGateStream(
+    task: Task,
+    message: Message,
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent, GateOutcome> {
     const contextId = task.contextId ?? task.id;
     const status = getPaymentStatus(message);
-
     if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
-      applyPaymentRequiredStatus(task, this._buildRequirements());
-      yield {
-        taskId: task.id,
-        contextId,
-        status: task.status,
+      applyPaymentRequiredStatus(task, {
+        x402Version: 1,
+        accepts: this._config.accepts,
+      });
+      yield { taskId: task.id, contextId, status: task.status };
+      return { action: 'emit-required' };
+    }
+
+    const verdict = await this._verifyAndSettle(
+      getPaymentPayload(message),
+      this._config.accepts,
+    );
+    if (verdict.kind === 'failure') {
+      applyFailedPaymentStatus(task, verdict.code, verdict.reason, verdict.network);
+      yield { taskId: task.id, contextId, status: task.status };
+      return { action: 'failed' };
+    }
+    return { action: 'continue', receipt: verdict.receipt };
+  }
+
+  // ─── Inner run (with embedded interception) ────────────────────────────
+
+  private async _runInnerNonStream(
+    task: Task,
+    message: Message,
+    priorReceipts: X402SettleResponse[],
+  ): Promise<Task> {
+    const session = await this.runner.createSession();
+    const controller = new AbortController();
+    const rawIterator = this.runner
+      .runAsync(session, message, controller.signal)
+      [Symbol.asyncIterator]();
+
+    task.status = {
+      state: TaskState.WORKING,
+      timestamp: new Date().toISOString(),
+    };
+
+    const textArtifactId = `artifact-${task.id}`;
+    const textParts: string[] = [];
+
+    return this._driveNonStream(
+      task,
+      rawIterator,
+      session,
+      controller,
+      textArtifactId,
+      textParts,
+      priorReceipts,
+    );
+  }
+
+  private async _driveNonStream(
+    task: Task,
+    iterator: AsyncIterator<AgentEvent>,
+    session: Session,
+    controller: AbortController,
+    textArtifactId: string,
+    textParts: string[],
+    priorReceipts: X402SettleResponse[],
+  ): Promise<Task> {
+    const contextId = task.contextId ?? task.id;
+    try {
+      while (true) {
+        const { value: event, done } = await iterator.next();
+        if (done) break;
+
+        switch (event.type) {
+          case 'text':
+            textParts.push(event.text);
+            break;
+          case 'paymentRequired': {
+            const outcome = await this._emitPaymentRequired(
+              task,
+              event,
+              iterator,
+              session,
+              controller,
+              textArtifactId,
+              textParts,
+              priorReceipts,
+            );
+            if (outcome === 'failed') return task;
+            return task;
+          }
+          case 'done':
+            // Handled after the loop.
+            break;
+          case 'error':
+            task.status = {
+              state: TaskState.FAILED,
+              timestamp: new Date().toISOString(),
+              message: {
+                messageId: `error-${Date.now()}`,
+                role: 'agent',
+                parts: [{ text: event.error.message }],
+              },
+            };
+            return task;
+        }
+      }
+
+      if (!controller.signal.aborted) {
+        if (textParts.length > 0) {
+          appendArtifact(task, {
+            artifactId: textArtifactId,
+            parts: [{ text: textParts.join('') }],
+          });
+        }
+        task.status = {
+          state: TaskState.COMPLETED,
+          timestamp: new Date().toISOString(),
+        };
+        if (priorReceipts.length > 0) {
+          attachReceipts(task, priorReceipts);
+        }
+      }
+      return task;
+    } catch (error) {
+      task.status = {
+        state: TaskState.FAILED,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: `error-${Date.now()}`,
+          role: 'agent',
+          parts: [
+            {
+              text:
+                error instanceof Error
+                  ? error.message
+                  : 'Unknown error occurred',
+            },
+          ],
+        },
       };
+      return task;
+    } finally {
+      // Only fire abort if we didn't stash the iterator for resumption.
+      if (!this._pending.has(task.id) && !controller.signal.aborted) {
+        controller.abort();
+      }
+      // contextId referenced for parity with base executor; unused here.
+      void contextId;
+    }
+  }
+
+  private async *_runInnerStream(
+    task: Task,
+    message: Message,
+    priorReceipts: X402SettleResponse[],
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+    const session = await this.runner.createSession();
+    const controller = new AbortController();
+    const rawIterator = this.runner
+      .runAsync(session, message, controller.signal)
+      [Symbol.asyncIterator]();
+
+    const textArtifactId = `artifact-${task.id}`;
+    const textParts: string[] = [];
+
+    task.status = {
+      state: TaskState.WORKING,
+      timestamp: new Date().toISOString(),
+    };
+    const contextId = task.contextId ?? task.id;
+    yield { taskId: task.id, contextId, status: task.status };
+
+    yield* this._driveStream(
+      task,
+      rawIterator,
+      session,
+      controller,
+      textArtifactId,
+      textParts,
+      priorReceipts,
+    );
+  }
+
+  private async *_driveStream(
+    task: Task,
+    iterator: AsyncIterator<AgentEvent>,
+    session: Session,
+    controller: AbortController,
+    textArtifactId: string,
+    textParts: string[],
+    priorReceipts: X402SettleResponse[],
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+    const contextId = task.contextId ?? task.id;
+    try {
+      while (true) {
+        const { value: event, done } = await iterator.next();
+        if (done) break;
+
+        switch (event.type) {
+          case 'text': {
+            textParts.push(event.text);
+            yield {
+              taskId: task.id,
+              contextId,
+              artifact: {
+                artifactId: textArtifactId,
+                parts: [{ text: event.text }],
+              },
+              append: true,
+              lastChunk: false,
+            } satisfies TaskArtifactUpdateEvent;
+            break;
+          }
+          case 'paymentRequired': {
+            const outcome = await this._emitPaymentRequired(
+              task,
+              event,
+              iterator,
+              session,
+              controller,
+              textArtifactId,
+              textParts,
+              priorReceipts,
+            );
+            // Yield the artifact update for the challenge.
+            const challengeArtifact = task.artifacts?.find(
+              (a) => a.artifactId === this._pending.get(task.id)?.challengeArtifactId,
+            );
+            if (outcome === 'emitted' && challengeArtifact) {
+              yield {
+                taskId: task.id,
+                contextId,
+                artifact: challengeArtifact,
+                append: false,
+                lastChunk: true,
+              } satisfies TaskArtifactUpdateEvent;
+            }
+            yield { taskId: task.id, contextId, status: task.status };
+            return;
+          }
+          case 'done': {
+            if (textParts.length > 0) {
+              const artifact: Artifact = {
+                artifactId: textArtifactId,
+                parts: [{ text: textParts.join('') }],
+              };
+              appendArtifact(task, artifact);
+              yield {
+                taskId: task.id,
+                contextId,
+                artifact,
+                append: false,
+                lastChunk: true,
+              } satisfies TaskArtifactUpdateEvent;
+            }
+            task.status = {
+              state: TaskState.COMPLETED,
+              timestamp: new Date().toISOString(),
+            };
+            if (priorReceipts.length > 0) {
+              attachReceipts(task, priorReceipts);
+            }
+            yield {
+              taskId: task.id,
+              contextId,
+              status: task.status,
+            } satisfies TaskStatusUpdateEvent;
+            return;
+          }
+          case 'error':
+            task.status = {
+              state: TaskState.FAILED,
+              timestamp: new Date().toISOString(),
+              message: {
+                messageId: `error-${Date.now()}`,
+                role: 'agent',
+                parts: [{ text: event.error.message }],
+              },
+            };
+            yield {
+              taskId: task.id,
+              contextId,
+              status: task.status,
+            } satisfies TaskStatusUpdateEvent;
+            return;
+        }
+      }
+    } catch (error) {
+      task.status = {
+        state: TaskState.FAILED,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: `error-${Date.now()}`,
+          role: 'agent',
+          parts: [
+            {
+              text:
+                error instanceof Error
+                  ? error.message
+                  : 'Unknown error occurred',
+            },
+          ],
+        },
+      };
+      yield { taskId: task.id, contextId, status: task.status };
+    } finally {
+      if (!this._pending.has(task.id) && !controller.signal.aborted) {
+        controller.abort();
+      }
+    }
+  }
+
+  // ─── paymentRequired handling ──────────────────────────────────────────
+
+  /**
+   * Consume a `paymentRequired` event from the inner generator: resolve
+   * its accepts, emit an artifact-shaped challenge on the task, mark the
+   * task `input-required`, stash the paused iterator so the next client
+   * message can resume it.
+   */
+  private async _emitPaymentRequired(
+    task: Task,
+    event: Extract<AgentEvent, { type: 'paymentRequired' }>,
+    iterator: AsyncIterator<AgentEvent>,
+    session: Session,
+    controller: AbortController,
+    textArtifactId: string,
+    textParts: string[],
+    priorReceipts: X402SettleResponse[],
+  ): Promise<'emitted' | 'failed'> {
+    const resolved = await this._resolveAcceptsForEvent(event, task);
+    if (resolved.length === 0) {
+      applyFailedPaymentStatus(
+        task,
+        X402_ERROR_CODES.NO_REQUIREMENTS,
+        'Agent requested embedded payment but no requirements were resolved.',
+        undefined,
+      );
+      try {
+        await iterator.return?.(undefined);
+      } catch {
+        // ignore
+      }
+      if (!controller.signal.aborted) controller.abort();
+      return 'failed';
+    }
+
+    const challengeArtifactId = event.artifactId ?? `x402-challenge-${Date.now()}`;
+    const artifact = buildChallengeArtifact({
+      artifactId: challengeArtifactId,
+      name: event.artifactName ?? X402_EMBEDDED_ARTIFACT_NAME,
+      metadata: event.artifactMetadata,
+      accepts: resolved,
+      embeddedObject: event.embeddedObject,
+    });
+    appendArtifact(task, artifact);
+
+    // Per spec §5.3 the status.message.metadata MUST contain
+    // `x402.payment.status: payment-required` but MUST NOT contain
+    // `x402.payment.required` when Embedded is active — the payload
+    // lives on an artifact.
+    task.status = {
+      state: TaskState.INPUT_REQUIRED,
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: `x402-${Date.now()}`,
+        role: 'agent',
+        parts: [{ text: 'Payment is required to continue.' }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+        },
+      },
+    };
+
+    this._pending.set(task.id, {
+      iterator,
+      session,
+      controller,
+      accepts: resolved,
+      challengeArtifactId,
+      textArtifactId,
+      textParts,
+      priorReceipts,
+    });
+
+    return 'emitted';
+  }
+
+  private async _resolveAcceptsForEvent(
+    event: Extract<AgentEvent, { type: 'paymentRequired' }>,
+    task: Task,
+  ): Promise<X402PaymentRequirements[]> {
+    const inline = Array.isArray(event.accepts)
+      ? (event.accepts as X402Accept[])
+      : undefined;
+    if (inline && inline.length > 0) {
+      return inline.map(normalizeAccept);
+    }
+
+    if (this._config.resolveAccepts) {
+      const dynamic = await this._config.resolveAccepts({
+        task,
+        message: task.status.message ?? { messageId: '', role: 'agent', parts: [] },
+        embeddedObject: event.embeddedObject,
+      });
+      if (dynamic.length > 0) {
+        return dynamic.map(normalizeAccept);
+      }
+    }
+
+    return [];
+  }
+
+  // ─── Embedded resume ───────────────────────────────────────────────────
+
+  private async _resumeEmbeddedNonStream(
+    task: Task,
+    message: Message,
+    pending: PendingEmbeddedState,
+  ): Promise<Task> {
+    const status = getPaymentStatus(message);
+    if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
+      // Client didn't actually submit payment — treat as a retry request.
+      // Re-emit the challenge state so the client sees it again.
+      task.status = {
+        state: TaskState.INPUT_REQUIRED,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: `x402-${Date.now()}`,
+          role: 'agent',
+          parts: [{ text: 'Payment is required to continue.' }],
+          metadata: {
+            [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          },
+        },
+      };
+      return task;
+    }
+
+    const verdict = await this._verifyAndSettle(
+      getPaymentPayload(message),
+      pending.accepts,
+    );
+    if (verdict.kind === 'failure') {
+      applyFailedPaymentStatus(task, verdict.code, verdict.reason, verdict.network);
+      try {
+        await pending.iterator.return?.(undefined);
+      } catch {
+        // ignore
+      }
+      if (!pending.controller.signal.aborted) pending.controller.abort();
+      this._pending.delete(task.id);
+      return task;
+    }
+
+    this._pending.delete(task.id);
+    task.status = {
+      state: TaskState.WORKING,
+      timestamp: new Date().toISOString(),
+    };
+    const combinedReceipts = [...pending.priorReceipts, verdict.receipt];
+    return this._driveNonStream(
+      task,
+      pending.iterator,
+      pending.session,
+      pending.controller,
+      pending.textArtifactId,
+      pending.textParts,
+      combinedReceipts,
+    );
+  }
+
+  private async *_resumeEmbeddedStream(
+    task: Task,
+    message: Message,
+    pending: PendingEmbeddedState,
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+    const contextId = task.contextId ?? task.id;
+    const status = getPaymentStatus(message);
+    if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
+      task.status = {
+        state: TaskState.INPUT_REQUIRED,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: `x402-${Date.now()}`,
+          role: 'agent',
+          parts: [{ text: 'Payment is required to continue.' }],
+          metadata: {
+            [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          },
+        },
+      };
+      yield { taskId: task.id, contextId, status: task.status };
       return;
     }
 
-    const payload = getPaymentPayload(message);
+    const verdict = await this._verifyAndSettle(
+      getPaymentPayload(message),
+      pending.accepts,
+    );
+    if (verdict.kind === 'failure') {
+      applyFailedPaymentStatus(task, verdict.code, verdict.reason, verdict.network);
+      try {
+        await pending.iterator.return?.(undefined);
+      } catch {
+        // ignore
+      }
+      if (!pending.controller.signal.aborted) pending.controller.abort();
+      this._pending.delete(task.id);
+      yield { taskId: task.id, contextId, status: task.status };
+      return;
+    }
+
+    this._pending.delete(task.id);
+    task.status = {
+      state: TaskState.WORKING,
+      timestamp: new Date().toISOString(),
+    };
+    yield { taskId: task.id, contextId, status: task.status };
+
+    const combinedReceipts = [...pending.priorReceipts, verdict.receipt];
+    yield* this._driveStream(
+      task,
+      pending.iterator,
+      pending.session,
+      pending.controller,
+      pending.textArtifactId,
+      pending.textParts,
+      combinedReceipts,
+    );
+  }
+
+  // ─── Verify + settle ───────────────────────────────────────────────────
+
+  private async _verifyAndSettle(
+    payload: X402PaymentPayload | undefined,
+    accepts: X402PaymentRequirements[],
+  ): Promise<
+    | {
+        kind: 'failure';
+        code: X402ErrorCode;
+        reason: string;
+        network: string | undefined;
+      }
+    | { kind: 'success'; receipt: X402SettleResponse }
+  > {
     const authorization = getEvmAuthorization(payload);
     if (!payload || !authorization) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.INVALID_PAYLOAD,
-        'Payment payload is missing or malformed.',
-        payload?.network,
-      );
-      yield { taskId: task.id, contextId, status: task.status };
-      return;
+      return {
+        kind: 'failure',
+        code: X402_ERROR_CODES.INVALID_PAYLOAD,
+        reason: 'Payment payload is missing or malformed.',
+        network: payload?.network,
+      };
     }
 
-    const accepted = this._matchRequirement(payload);
+    const accepted = accepts.find(
+      (req) => req.network === payload.network && req.scheme === payload.scheme,
+    );
     const validationErr = validatePayloadAgainstRequirement(payload, accepted);
     if (validationErr) {
-      applyFailedPaymentStatus(
-        task,
-        validationErr.code,
-        validationErr.reason,
-        payload.network,
-      );
-      yield { taskId: task.id, contextId, status: task.status };
-      return;
+      return {
+        kind: 'failure',
+        code: validationErr.code,
+        reason: validationErr.reason,
+        network: payload.network,
+      };
     }
 
     const verifyResult = await this._config.facilitator.verify(payload, accepted!);
     if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.VERIFY_FAILED,
-        verifyResult.invalidReason ?? 'Payment verification failed.',
-        payload.network,
-      );
-      yield { taskId: task.id, contextId, status: task.status };
-      return;
+      return {
+        kind: 'failure',
+        code: X402_ERROR_CODES.VERIFY_FAILED,
+        reason: verifyResult.invalidReason ?? 'Payment verification failed.',
+        network: payload.network,
+      };
     }
 
     const settleResult = await this._config.facilitator.settle(payload, accepted!);
     if (!settleResult.success) {
-      applyFailedPaymentStatus(
-        task,
-        X402_ERROR_CODES.SETTLE_FAILED,
-        settleResult.errorReason ?? 'Payment settlement failed.',
-        payload.network,
-      );
-      yield { taskId: task.id, contextId, status: task.status };
-      return;
-    }
-
-    const receipt: X402SettleResponse = {
-      success: true,
-      transaction: settleResult.transaction ?? '',
-      network: payload.network,
-    };
-
-    let lastStatusEvent: TaskStatusUpdateEvent | undefined;
-    for await (const event of this._inner.executeStream(task, message)) {
-      if ('status' in event && event.status.state === TaskState.COMPLETED) {
-        lastStatusEvent = event;
-        continue;
-      }
-      yield event;
-    }
-
-    attachReceipt(task, receipt);
-    if (lastStatusEvent) {
-      yield {
-        taskId: task.id,
-        contextId,
-        status: task.status,
+      return {
+        kind: 'failure',
+        code: X402_ERROR_CODES.SETTLE_FAILED,
+        reason: settleResult.errorReason ?? 'Payment settlement failed.',
+        network: payload.network,
       };
     }
-  }
 
-  override async cancel(task: Task): Promise<Task> {
-    return this._inner.cancel(task);
-  }
-
-  // ─── Private ───
-
-  private _buildRequirements(): X402PaymentRequiredResponse {
     return {
-      x402Version: 1,
-      accepts: this._config.accepts,
+      kind: 'success',
+      receipt: {
+        success: true,
+        transaction: settleResult.transaction ?? '',
+        network: payload.network,
+      },
     };
   }
-
-  private _matchRequirement(
-    payload: X402PaymentPayload,
-  ): X402PaymentRequirements | undefined {
-    return this._config.accepts.find(
-      (req) => req.network === payload.network && req.scheme === payload.scheme,
-    );
-  }
 }
+
+type GateOutcome =
+  | { action: 'continue'; receipt: X402SettleResponse }
+  | { action: 'emit-required' }
+  | { action: 'failed' };
 
 // ─── Module-private helpers (exported under `__internal` for tests below) ───
 
 function resolveOptions(options: X402PaymentExecutorOptions): ResolvedConfig {
-  if (!options.accepts || options.accepts.length === 0) {
-    throw new Error(
-      'X402PaymentExecutor: at least one entry in `accepts` is required',
-    );
+  const gateAccepts = options.accepts ?? [];
+  if (gateAccepts.length === 0 && !options.resolveAccepts) {
+    // Purely event-driven with no dynamic resolver and no gate: require
+    // callers to at least provide one path to price payments.
+    if (options.requiresPayment && options.requiresPayment.length > 0) {
+      // Predicate defined but nothing to charge — fall through; the
+      // predicate will decide nothing ever charges.
+    }
   }
   return {
-    accepts: options.accepts.map(normalizeAccept),
+    accepts: gateAccepts.map(normalizeAccept),
     facilitator: resolveFacilitator(options.facilitator),
-    requiresPayment: options.requiresPayment ?? (() => true),
+    requiresPayment: options.requiresPayment,
+    resolveAccepts: options.resolveAccepts,
   };
 }
 
@@ -353,7 +913,7 @@ function applyFailedPaymentStatus(
   };
 }
 
-function attachReceipt(task: Task, receipt: X402SettleResponse): void {
+function attachReceipts(task: Task, receipts: X402SettleResponse[]): void {
   if (!task.status.message) {
     task.status.message = {
       messageId: `x402-${Date.now()}`,
@@ -366,8 +926,49 @@ function attachReceipt(task: Task, receipt: X402SettleResponse): void {
   task.status.message.metadata = {
     ...existing,
     [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
-    [X402_METADATA_KEYS.RECEIPTS]: [receipt],
+    [X402_METADATA_KEYS.RECEIPTS]: receipts,
   };
+}
+
+function buildChallengeArtifact(input: {
+  artifactId: string;
+  name: string;
+  metadata?: Record<string, unknown>;
+  accepts: X402PaymentRequirements[];
+  embeddedObject?: unknown;
+}): Artifact {
+  const required: X402PaymentRequiredResponse = {
+    x402Version: 1,
+    accepts: input.accepts,
+  };
+  // If the caller provided a higher-level wrapper (e.g. an AP2 CartMandate),
+  // embed the x402 challenge alongside it at the well-known key; otherwise
+  // emit a bare wrapper.
+  const data =
+    input.embeddedObject && typeof input.embeddedObject === 'object'
+      ? {
+          ...(input.embeddedObject as Record<string, unknown>),
+          [X402_EMBEDDED_DATA_KEY]: required,
+        }
+      : { [X402_EMBEDDED_DATA_KEY]: required };
+
+  return {
+    artifactId: input.artifactId,
+    name: input.name,
+    parts: [{ data }],
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  };
+}
+
+function appendArtifact(task: Task, artifact: Artifact): void {
+  const existing = task.artifacts ?? [];
+  const idx = existing.findIndex((a) => a.artifactId === artifact.artifactId);
+  if (idx >= 0) {
+    existing[idx] = artifact;
+    task.artifacts = existing;
+  } else {
+    task.artifacts = [...existing, artifact];
+  }
 }
 
 interface EvmAuthorization {
@@ -439,5 +1040,6 @@ export const __internal = {
   validatePayloadAgainstRequirement,
   applyPaymentRequiredStatus,
   applyFailedPaymentStatus,
-  attachReceipt,
+  attachReceipts,
+  buildChallengeArtifact,
 };

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -63,8 +63,18 @@ export type {
   X402Network,
 } from './types.js';
 
-export { X402PaymentExecutor } from './executor.js';
-export type { X402PaymentExecutorOptions } from './executor.js';
+export {
+  X402PaymentExecutor,
+  X402_EMBEDDED_ARTIFACT_NAME,
+  X402_EMBEDDED_DATA_KEY,
+} from './executor.js';
+export type {
+  X402PaymentExecutorOptions,
+  X402ResolveAcceptsContext,
+} from './executor.js';
+
+export { paymentRequiredEvent } from './events.js';
+export type { PaymentRequiredEventOptions } from './events.js';
 
 export {
   resolveFacilitator,
@@ -77,12 +87,14 @@ export {
   getX402PaymentRequirements,
   getX402Receipts,
   getX402Status,
+  getEmbeddedX402Challenges,
   X402Client,
 } from './client.js';
 export type {
   SignX402PaymentOptions,
   SignedX402Payment,
   X402ClientOptions,
+  EmbeddedX402Challenge,
 } from './client.js';
 
 export {

--- a/packages/cli/src/__tests__/x402-embedded-policy.test.ts
+++ b/packages/cli/src/__tests__/x402-embedded-policy.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the separated gate/embedded budget policy the CLI applies
+ * before signing any x402 authorization.
+ *
+ * The policy lives in `x402-cli.ts` as `parseEmbeddedPolicy` +
+ * `confirmEmbeddedPayment`. Both `a2a send` and `a2a stream` call the
+ * same helpers so this file is the single source of truth for the
+ * "don't silently auto-sign a big embedded charge" guarantee.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { EmbeddedX402Challenge } from '@a2x/sdk';
+import {
+  confirmEmbeddedPayment,
+  parseEmbeddedPolicy,
+  X402BudgetExceededError,
+  X402EmbeddedDeclinedError,
+} from '../x402-cli.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────
+
+function challenge(amount: string): EmbeddedX402Challenge {
+  return {
+    artifactId: 'challenge-1',
+    artifactName: 'demo-cart',
+    required: {
+      x402Version: 1,
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'base-sepolia',
+          maxAmountRequired: amount,
+          resource: 'a2a-x402/access',
+          description: 'Checkout',
+          mimeType: 'application/json',
+          payTo: '0x1111111111111111111111111111111111111111',
+          maxTimeoutSeconds: 300,
+          asset: '0x2222222222222222222222222222222222222222',
+          extra: { name: 'USDC', version: '2' },
+        },
+      ],
+    },
+    data: {
+      cartId: 'cart-xyz',
+      'x402.payment.required': {
+        x402Version: 1,
+        accepts: [{ scheme: 'exact', maxAmountRequired: amount }],
+      },
+    },
+  };
+}
+
+// ─── parseEmbeddedPolicy ──────────────────────────────────────────
+
+describe('parseEmbeddedPolicy', () => {
+  it('returns "refuse" when --no-embedded is set', () => {
+    expect(parseEmbeddedPolicy({ noEmbedded: true })).toEqual({ kind: 'refuse' });
+  });
+
+  it('returns "auto" with ceiling when --auto-embedded + --max-embedded-amount', () => {
+    const policy = parseEmbeddedPolicy({
+      autoEmbedded: true,
+      maxEmbeddedAmount: '500000',
+    });
+    expect(policy).toEqual({ kind: 'auto', maxAmount: 500000n });
+  });
+
+  it('throws when --auto-embedded is set without --max-embedded-amount', () => {
+    expect(() => parseEmbeddedPolicy({ autoEmbedded: true })).toThrow(
+      /requires --max-embedded-amount/,
+    );
+  });
+
+  it('throws when --max-embedded-amount is given without --auto-embedded', () => {
+    expect(() =>
+      parseEmbeddedPolicy({ maxEmbeddedAmount: '500000' }),
+    ).toThrow(/requires --auto-embedded/);
+  });
+
+  it('rejects non-integer embedded amounts', () => {
+    expect(() =>
+      parseEmbeddedPolicy({
+        autoEmbedded: true,
+        maxEmbeddedAmount: '1.5',
+      }),
+    ).toThrow(/non-negative integer/);
+  });
+
+  it('falls back to "refuse" in --json mode', () => {
+    const policy = parseEmbeddedPolicy({ json: true });
+    expect(policy).toEqual({ kind: 'refuse' });
+  });
+
+  it('falls back to "refuse" in non-TTY stdin', () => {
+    const original = process.stdin.isTTY;
+    // Simulate pipe.
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      get: () => false,
+    });
+    try {
+      const policy = parseEmbeddedPolicy({});
+      expect(policy).toEqual({ kind: 'refuse' });
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        get: () => original,
+      });
+    }
+  });
+
+  it('returns "prompt" when interactive and no flags are set', () => {
+    const original = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      get: () => true,
+    });
+    try {
+      const policy = parseEmbeddedPolicy({});
+      expect(policy).toEqual({ kind: 'prompt' });
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        get: () => original,
+      });
+    }
+  });
+});
+
+// ─── confirmEmbeddedPayment ───────────────────────────────────────
+
+describe('confirmEmbeddedPayment', () => {
+  // Silence the pretty-print output while exercising policy logic.
+  const originalLog = console.log;
+  beforeEach(() => {
+    console.log = vi.fn();
+  });
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  it('throws X402EmbeddedDeclinedError under the refuse policy', async () => {
+    await expect(
+      confirmEmbeddedPayment(challenge('120000000'), { kind: 'refuse' }, {
+        json: true,
+      }),
+    ).rejects.toBeInstanceOf(X402EmbeddedDeclinedError);
+  });
+
+  it('approves silently under an auto policy within the ceiling', async () => {
+    await expect(
+      confirmEmbeddedPayment(
+        challenge('120000'),
+        { kind: 'auto', maxAmount: 500_000n },
+        { json: true },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws X402BudgetExceededError under an auto policy over the ceiling', async () => {
+    const p = confirmEmbeddedPayment(
+      challenge('600_000'.replace(/_/g, '')),
+      { kind: 'auto', maxAmount: 500_000n },
+      { json: true },
+    );
+    await expect(p).rejects.toBeInstanceOf(X402BudgetExceededError);
+    await expect(p).rejects.toMatchObject({ scope: 'embedded' });
+  });
+
+  it('surfaces the scope=embedded marker so the error printer knows which flag to hint', async () => {
+    try {
+      await confirmEmbeddedPayment(
+        challenge('600000'),
+        { kind: 'auto', maxAmount: 500_000n },
+        { json: true },
+      );
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(X402BudgetExceededError);
+      expect((err as X402BudgetExceededError).scope).toBe('embedded');
+    }
+  });
+});

--- a/packages/cli/src/__tests__/x402-embedded-rendering.test.ts
+++ b/packages/cli/src/__tests__/x402-embedded-rendering.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression tests for the two CLI issues that showed up when `a2x a2a
+ * stream` met the nextjs-x402 sample's embedded flow:
+ *
+ *  1. `printArtifactChunk` dumped `JSON.stringify(part.data)` for the
+ *     embedded challenge artifact straight into the streaming-text
+ *     column, collapsing the pretty challenge display onto the same
+ *     line as the agent's narration.
+ *  2. The stream command's renderer didn't recognise embedded challenge
+ *     artifacts, so it kept rendering them even though the payment
+ *     dance was about to re-print them anyway.
+ *
+ * These tests lock in the fix: the renderer we now use in
+ * `commands/a2a/stream.ts` detects challenge artifacts via
+ * `isEmbeddedChallengeArtifact`, flushes any in-flight text line, and
+ * emits nothing else — leaving the payment-block rendering to the
+ * payment dance.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Artifact, TaskArtifactUpdateEvent } from '@a2x/sdk';
+import { printArtifactChunk, printStatusUpdate } from '../format.js';
+import { isEmbeddedChallengeArtifact } from '../x402-cli.js';
+
+// Mirror the renderer used by `commands/a2a/stream.ts` so we can test
+// it without wiring Commander + network up.
+function createRenderer() {
+  let midLine = false;
+  const flushLine = (): void => {
+    if (midLine) {
+      process.stdout.write('\n');
+      midLine = false;
+    }
+  };
+  function renderEvent(event: TaskArtifactUpdateEvent): void {
+    if (isEmbeddedChallengeArtifact(event.artifact)) {
+      flushLine();
+      return;
+    }
+    printArtifactChunk(event, true);
+    if (event.artifact.parts.some((p) => 'text' in p)) midLine = true;
+    if (event.lastChunk) flushLine();
+  }
+  return { renderEvent, flushLine };
+}
+
+function textArtifactEvent(text: string, lastChunk = false): TaskArtifactUpdateEvent {
+  return {
+    taskId: 't',
+    contextId: 'c',
+    artifact: { artifactId: 'art-text', parts: [{ text }] },
+    lastChunk,
+  } as TaskArtifactUpdateEvent;
+}
+
+function challengeArtifact(): Artifact {
+  return {
+    artifactId: 'challenge-1',
+    name: 'demo-cart',
+    parts: [
+      {
+        data: {
+          cartId: 'cart-xyz',
+          total: { currency: 'USD', value: 120 },
+          'x402.payment.required': {
+            x402Version: 1,
+            accepts: [
+              {
+                scheme: 'exact',
+                network: 'base-sepolia',
+                maxAmountRequired: '120000000',
+                resource: 'a2a-x402/access',
+                description: 'Checkout',
+                mimeType: 'application/json',
+                payTo: '0x1111111111111111111111111111111111111111',
+                maxTimeoutSeconds: 300,
+                asset: '0x2222222222222222222222222222222222222222',
+                extra: { name: 'USDC', version: '2' },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+function challengeArtifactEvent(): TaskArtifactUpdateEvent {
+  return {
+    taskId: 't',
+    contextId: 'c',
+    artifact: challengeArtifact(),
+    lastChunk: true,
+  } as TaskArtifactUpdateEvent;
+}
+
+function ap2WrappedChallengeArtifact(): Artifact {
+  // A higher-level wrapper (AP2-style) where the x402 payload is
+  // nested inside a method_data entry. `getEmbeddedX402Challenges` is
+  // expected to find it recursively.
+  return {
+    artifactId: 'challenge-2',
+    name: 'AP2 CartMandate',
+    parts: [
+      {
+        data: {
+          'ap2.mandates.CartMandate': {
+            id: 'cart-shoes',
+            payment_request: {
+              method_data: [
+                {
+                  supported_methods: 'https://www.x402.org/',
+                  data: {
+                    x402Version: 1,
+                    accepts: [
+                      {
+                        scheme: 'exact',
+                        network: 'base',
+                        maxAmountRequired: '120000000',
+                        resource: 'a2a-x402/access',
+                        description: 'Checkout',
+                        mimeType: 'application/json',
+                        payTo: '0xAAA',
+                        maxTimeoutSeconds: 300,
+                        asset: '0xBBB',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('isEmbeddedChallengeArtifact', () => {
+  it('recognises the bare shape the SDK emits', () => {
+    expect(isEmbeddedChallengeArtifact(challengeArtifact())).toBe(true);
+  });
+
+  it('recognises an x402 payload nested inside an AP2-style wrapper', () => {
+    expect(isEmbeddedChallengeArtifact(ap2WrappedChallengeArtifact())).toBe(true);
+  });
+
+  it('does not flag a plain text artifact', () => {
+    const art: Artifact = {
+      artifactId: 'art',
+      parts: [{ text: 'hello' }],
+    };
+    expect(isEmbeddedChallengeArtifact(art)).toBe(false);
+  });
+
+  it('does not flag a data artifact without an x402 challenge', () => {
+    const art: Artifact = {
+      artifactId: 'art',
+      parts: [{ data: { cartId: 'c1', total: 100 } }],
+    };
+    expect(isEmbeddedChallengeArtifact(art)).toBe(false);
+  });
+});
+
+describe('stream renderer + embedded challenge', () => {
+  let output: string;
+  const originalWrite = process.stdout.write;
+
+  beforeEach(() => {
+    output = '';
+    process.stdout.write = ((chunk: unknown) => {
+      output += typeof chunk === 'string' ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it('does not dump the challenge JSON into the text stream', () => {
+    const { renderEvent } = createRenderer();
+
+    renderEvent(textArtifactEvent('Adding Nike Air Max to cart… '));
+    renderEvent(challengeArtifactEvent());
+
+    // The JSON keys of the challenge MUST NOT leak into the rendered
+    // output; the payment dance re-renders the challenge after.
+    expect(output).toContain('Adding Nike Air Max to cart… ');
+    expect(output).not.toContain('x402.payment.required');
+    expect(output).not.toContain('cart-xyz');
+    expect(output).not.toContain('maxAmountRequired');
+  });
+
+  it('flushes any in-flight text line before the payment dance runs', () => {
+    const { renderEvent } = createRenderer();
+
+    renderEvent(textArtifactEvent('Adding Nike Air Max to cart… '));
+    renderEvent(challengeArtifactEvent());
+
+    // After the challenge artifact is seen, a trailing newline must
+    // separate the stream text from whatever comes next (the payment
+    // block). Otherwise the same line collision from the ticket
+    // returns.
+    expect(output.endsWith('\n')).toBe(true);
+  });
+
+  it('still renders a non-challenge text artifact normally', () => {
+    const { renderEvent } = createRenderer();
+
+    renderEvent(textArtifactEvent('Hello ', false));
+    renderEvent(textArtifactEvent('world', true));
+
+    expect(output).toContain('Hello world');
+  });
+});
+
+// Ensure the imported `printStatusUpdate` still compiles into the
+// test's symbol table — otherwise ESLint complains the import is
+// unused. This is a belt-and-braces no-op.
+void printStatusUpdate;

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -92,7 +92,11 @@ export const sendCommand = new Command('send')
 
           const x402 = new X402Client(
             client,
-            buildBudgetedX402ClientSettings({ signer, maxAmount }),
+            buildBudgetedX402ClientSettings({
+              signer,
+              maxAmount,
+              verbose: opts.json !== true,
+            }),
           );
           task = await x402.sendMessage(params);
         }

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -12,6 +12,7 @@ import { activeWalletAccount } from '../../wallet-store.js';
 import {
   DEFAULT_MAX_AMOUNT_ATOMIC,
   buildBudgetedX402ClientSettings,
+  parseEmbeddedPolicy,
   parseMaxAmount,
   printPaymentRequirement,
   printX402Error,
@@ -27,8 +28,21 @@ export const sendCommand = new Command('send')
   .option('--no-x402', 'Don\'t auto-sign an x402 payment even if the agent asks for one')
   .option(
     '--max-amount <atomic>',
-    'Maximum amount (in asset\'s atomic units) to auto-sign for an x402 payment. ' +
-      `Defaults to ${DEFAULT_MAX_AMOUNT_ATOMIC.toString()}.`,
+    'Maximum amount (in atomic units) to auto-sign for the Standalone gate. ' +
+      `Defaults to ${DEFAULT_MAX_AMOUNT_ATOMIC.toString()}. ` +
+      'Does NOT apply to Embedded charges.',
+  )
+  .option(
+    '--auto-embedded',
+    'Auto-sign Embedded-flow charges up to --max-embedded-amount instead of prompting.',
+  )
+  .option(
+    '--max-embedded-amount <atomic>',
+    'Ceiling (in atomic units) used when --auto-embedded is set. Required with --auto-embedded.',
+  )
+  .option(
+    '--no-embedded',
+    'Refuse every Embedded-flow charge outright (useful for scripts).',
   )
   .action(
     async (
@@ -40,11 +54,20 @@ export const sendCommand = new Command('send')
         json?: boolean;
         x402?: boolean;
         maxAmount?: string;
+        autoEmbedded?: boolean;
+        maxEmbeddedAmount?: string;
+        embedded?: boolean; // commander --no-embedded → embedded: false
       },
     ) => {
-      const maxAmount = parseMaxAmount(opts.maxAmount);
-
       try {
+        const gateMaxAmount = parseMaxAmount(opts.maxAmount);
+        const embeddedPolicy = parseEmbeddedPolicy({
+          noEmbedded: opts.embedded === false,
+          autoEmbedded: opts.autoEmbedded,
+          maxEmbeddedAmount: opts.maxEmbeddedAmount,
+          json: opts.json,
+        });
+
         const client = createClient(url, opts);
 
         const params: SendMessageParams = {
@@ -87,15 +110,16 @@ export const sendCommand = new Command('send')
           }
 
           if (!opts.json) {
-            printPaymentRequirement(required, maxAmount);
+            printPaymentRequirement(required, gateMaxAmount);
           }
 
           const x402 = new X402Client(
             client,
             buildBudgetedX402ClientSettings({
               signer,
-              maxAmount,
-              verbose: opts.json !== true,
+              gateMaxAmount,
+              embeddedPolicy,
+              json: opts.json,
             }),
           );
           task = await x402.sendMessage(params);

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -2,12 +2,16 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import crypto from 'node:crypto';
 import type {
+  Artifact,
+  EmbeddedX402Challenge,
   SendMessageParams,
   Task,
   TaskArtifactUpdateEvent,
   TaskStatusUpdateEvent,
+  X402PaymentRequiredResponse,
 } from '@a2x/sdk';
 import {
+  getEmbeddedX402Challenges,
   getX402PaymentRequirements,
   signX402Payment,
   X402_METADATA_KEYS,
@@ -23,13 +27,32 @@ import { activeWalletAccount } from '../../wallet-store.js';
 import {
   DEFAULT_MAX_AMOUNT_ATOMIC,
   enforceBudget,
+  isEmbeddedChallengeArtifact,
   parseMaxAmount,
   pickAffordableRequirement,
+  printEmbeddedChallenge,
   printPaymentRequirement,
   printX402Error,
 } from '../../x402-cli.js';
 
 type StreamEvent = TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
+
+/** Hard cap on how many payment hops we will auto-sign in one call. */
+const MAX_PAYMENT_HOPS = 8;
+
+/**
+ * A challenge the CLI needs to sign and resubmit before the stream
+ * can continue. Either Standalone (gate, from status metadata) or
+ * Embedded (from a task artifact).
+ */
+interface PaymentSignal {
+  kind: 'standalone' | 'embedded';
+  required: X402PaymentRequiredResponse;
+  embedded?: EmbeddedX402Challenge;
+  syntheticTask: Task;
+  taskId: string;
+  contextId: string;
+}
 
 export const streamCommand = new Command('stream')
   .description('Send a message and stream the response via SSE')
@@ -64,110 +87,118 @@ export const streamCommand = new Command('stream')
       try {
         const client = createClient(url, opts);
 
-        const params: SendMessageParams = {
-          message: {
-            messageId: crypto.randomUUID(),
-            role: 'user',
-            parts: [{ text: message }],
-          },
+        const baseMessage: SendMessageParams['message'] = {
+          messageId: crypto.randomUUID(),
+          role: 'user',
+          parts: [{ text: message }],
+          ...(opts.contextId ? { contextId: opts.contextId } : {}),
         };
-        if (opts.contextId) {
-          params.message.contextId = opts.contextId;
-        }
 
         if (!opts.json) {
           console.log(chalk.bold.cyan('Streaming response...'));
           console.log(chalk.gray('─'.repeat(40)));
         }
 
-        // First pass: consume the stream but pause as soon as a
-        // payment-required status-update arrives.
-        const paymentSignal = await consumeUntilPaymentRequired(
-          client.sendMessageStream(params),
-          opts,
-        );
+        let currentParams: SendMessageParams = { message: baseMessage };
 
-        if (!paymentSignal) {
-          // Stream finished without ever asking for payment — normal case.
-          finish(opts);
-          return;
-        }
-
-        if (opts.x402 === false) {
-          if (!opts.json) {
-            console.log();
-            console.log(
-              chalk.yellow(
-                'Stream paused for x402 payment; --no-x402 was set, exiting.',
-              ),
-            );
-          }
-          process.exit(2);
-        }
-
-        const signer = activeWalletAccount();
-        if (!signer) {
-          if (!opts.json) {
-            console.log();
-            console.error(
-              chalk.yellow(
-                'Agent is asking for an x402 payment but no wallet is active.',
-              ),
-            );
-            console.error(
-              chalk.yellow(
-                'Run `a2x wallet create` (or `a2x wallet use <name>`) to unlock paid calls.',
-              ),
-            );
-          }
-          process.exit(2);
-        }
-
-        // Budget check + display before signing.
-        enforceBudget(paymentSignal.required, maxAmount);
-        if (!opts.json) {
-          console.log();
-          printPaymentRequirement(paymentSignal.required, maxAmount);
-        }
-
-        const signed = await signX402Payment(paymentSignal.syntheticTask, {
-          signer,
-          selectRequirement: (accepts) =>
-            pickAffordableRequirement(
-              { x402Version: 1, accepts },
-              maxAmount,
-            ),
-        });
-
-        // Second pass: same content + taskId + payment metadata.
-        const followupParams: SendMessageParams = {
-          ...params,
-          message: {
-            ...params.message,
-            messageId: crypto.randomUUID(),
-            taskId: paymentSignal.taskId,
-            contextId: paymentSignal.contextId,
-            metadata: {
-              ...(params.message.metadata ?? {}),
-              ...signed.metadata,
-            },
-          },
-        };
-
-        if (!opts.json) {
-          console.log(
-            chalk.gray(
-              `  signed ${signed.requirement.maxAmountRequired} atomic → resuming stream`,
-            ),
+        for (let hop = 0; hop <= MAX_PAYMENT_HOPS; hop += 1) {
+          const signal = await consumeUntilPaymentRequired(
+            client.sendMessageStream(currentParams),
+            opts,
           );
-          console.log();
-        }
 
-        for await (const event of client.sendMessageStream(followupParams)) {
-          renderEvent(event, opts);
-        }
+          if (!signal) {
+            // Stream finished normally — no (further) payment required.
+            finish(opts);
+            return;
+          }
 
-        finish(opts);
+          if (hop === MAX_PAYMENT_HOPS) {
+            if (!opts.json) {
+              console.log();
+              console.error(
+                chalk.yellow(
+                  `Giving up: server asked for more than ${MAX_PAYMENT_HOPS} payments in one call.`,
+                ),
+              );
+            }
+            process.exit(2);
+          }
+
+          if (opts.x402 === false) {
+            if (!opts.json) {
+              console.log();
+              console.log(
+                chalk.yellow(
+                  'Stream paused for x402 payment; --no-x402 was set, exiting.',
+                ),
+              );
+            }
+            process.exit(2);
+          }
+
+          const signer = activeWalletAccount();
+          if (!signer) {
+            if (!opts.json) {
+              console.log();
+              console.error(
+                chalk.yellow(
+                  'Agent is asking for an x402 payment but no wallet is active.',
+                ),
+              );
+              console.error(
+                chalk.yellow(
+                  'Run `a2x wallet create` (or `a2x wallet use <name>`) to unlock paid calls.',
+                ),
+              );
+            }
+            process.exit(2);
+          }
+
+          // Budget check + display before signing.
+          enforceBudget(signal.required, maxAmount);
+          if (!opts.json) {
+            console.log();
+            if (signal.kind === 'embedded' && signal.embedded) {
+              printEmbeddedChallenge(signal.embedded, maxAmount);
+            } else {
+              printPaymentRequirement(signal.required, maxAmount);
+            }
+          }
+
+          const signed = await signX402Payment(signal.syntheticTask, {
+            signer,
+            selectRequirement: (accepts) =>
+              pickAffordableRequirement(
+                { x402Version: 1, accepts },
+                maxAmount,
+              ),
+          });
+
+          if (!opts.json) {
+            console.log(
+              chalk.gray(
+                `  signed ${signed.requirement.maxAmountRequired} atomic → resuming stream`,
+              ),
+            );
+            console.log();
+          }
+
+          // Build the follow-up params: same content + taskId + payment metadata.
+          currentParams = {
+            ...currentParams,
+            message: {
+              ...baseMessage,
+              messageId: crypto.randomUUID(),
+              taskId: signal.taskId,
+              contextId: signal.contextId,
+              metadata: {
+                ...(baseMessage.metadata ?? {}),
+                ...signed.metadata,
+              },
+            },
+          };
+        }
       } catch (err) {
         const code = printX402Error(err);
         if (code !== null) process.exit(code);
@@ -178,46 +209,69 @@ export const streamCommand = new Command('stream')
   );
 
 /**
- * Iterate the first stream, printing events as they come in. As soon as
- * we see a TaskStatusUpdateEvent whose message carries the x402
- * payment-required status, we synthesize a minimal Task so the caller
- * can feed it to `signX402Payment` and stop consuming further events.
+ * Iterate the stream, printing events as they come in. As soon as we
+ * see a TaskStatusUpdateEvent whose status is `input-required` with
+ * an x402 challenge, we synthesize a minimal Task so the caller can
+ * feed it to `signX402Payment` and stop consuming further events.
  *
- * Returns `undefined` when the stream ended naturally (no payment gate).
+ * The challenge might live on `status.message.metadata`
+ * (Standalone/gate) or on one of the `task.artifacts[]`
+ * (Embedded). We track accumulated artifacts across the stream so
+ * Embedded challenges can be surfaced even though no single event
+ * carries the full task.
+ *
+ * Returns `undefined` when the stream ended without a pending
+ * challenge.
  */
 async function consumeUntilPaymentRequired(
   stream: AsyncGenerator<StreamEvent>,
   opts: { json?: boolean },
-): Promise<
-  | {
-      required: NonNullable<ReturnType<typeof getX402PaymentRequirements>>;
-      syntheticTask: Task;
-      taskId: string;
-      contextId: string;
-    }
-  | undefined
-> {
+): Promise<PaymentSignal | undefined> {
+  const artifacts: Artifact[] = [];
+
   for await (const event of stream) {
     if (!('status' in event)) {
+      captureArtifact(artifacts, event);
       renderEvent(event, opts);
       continue;
     }
 
     const meta = (event.status.message?.metadata ?? {}) as Record<string, unknown>;
     const x402Status = meta[X402_METADATA_KEYS.STATUS];
-    if (x402Status === X402_PAYMENT_STATUS.REQUIRED) {
-      // The SDK helpers expect a Task shape, not a status-update event.
+    const pending =
+      event.status.state === 'input-required' &&
+      x402Status === X402_PAYMENT_STATUS.REQUIRED;
+
+    if (pending) {
       const syntheticTask: Task = {
         id: event.taskId,
         contextId: event.contextId,
         status: event.status,
+        artifacts,
       };
-      const required = getX402PaymentRequirements(syntheticTask);
-      if (required) {
-        // Print the status update (so the user sees the pause) and stop.
+
+      // Gate first (Standalone): status.message.metadata carries the challenge.
+      const standalone = getX402PaymentRequirements(syntheticTask);
+      if (standalone) {
         renderEvent(event, opts);
         return {
-          required,
+          kind: 'standalone',
+          required: standalone,
+          syntheticTask,
+          taskId: event.taskId,
+          contextId: event.contextId,
+        };
+      }
+
+      // Embedded: scan accumulated artifacts.
+      const embedded = getEmbeddedX402Challenges(syntheticTask);
+      if (embedded.length > 0) {
+        const first = embedded[0]!;
+        renderEvent(event, opts);
+        return {
+          kind: 'embedded',
+          required: first.required,
+          embedded: first,
           syntheticTask,
           taskId: event.taskId,
           contextId: event.contextId,
@@ -228,6 +282,33 @@ async function consumeUntilPaymentRequired(
     renderEvent(event, opts);
   }
   return undefined;
+}
+
+/**
+ * Accumulate artifact updates by artifactId so a later
+ * `getEmbeddedX402Challenges()` can see the full artifact. Append-style
+ * updates extend parts; non-append updates replace.
+ */
+function captureArtifact(
+  artifacts: Artifact[],
+  event: TaskArtifactUpdateEvent,
+): void {
+  const idx = artifacts.findIndex(
+    (a) => a.artifactId === event.artifact.artifactId,
+  );
+  if (idx < 0) {
+    artifacts.push({ ...event.artifact });
+    return;
+  }
+  const current = artifacts[idx]!;
+  if (event.append) {
+    artifacts[idx] = {
+      ...current,
+      parts: [...current.parts, ...event.artifact.parts],
+    };
+  } else {
+    artifacts[idx] = { ...event.artifact };
+  }
 }
 
 /**
@@ -251,14 +332,21 @@ function renderEvent(event: StreamEvent, opts: { json?: boolean }): void {
   if ('status' in event) {
     flushLine();
     printStatusUpdate(event);
-  } else {
-    printArtifactChunk(event, true);
-    if (event.artifact.parts.some((p) => 'text' in p)) {
-      midLine = true;
-    }
-    if (event.lastChunk) {
-      flushLine();
-    }
+    return;
+  }
+  // Artifact update: skip x402 embedded challenge artifacts — the
+  // payment-dance block re-renders them with proper formatting. Still
+  // flush any pending text line so the transition is clean.
+  if (isEmbeddedChallengeArtifact(event.artifact)) {
+    flushLine();
+    return;
+  }
+  printArtifactChunk(event, true);
+  if (event.artifact.parts.some((p) => 'text' in p)) {
+    midLine = true;
+  }
+  if (event.lastChunk) {
+    flushLine();
   }
 }
 

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -9,6 +9,7 @@ import type {
   TaskArtifactUpdateEvent,
   TaskStatusUpdateEvent,
   X402PaymentRequiredResponse,
+  X402PaymentRequirements,
 } from '@a2x/sdk';
 import {
   getEmbeddedX402Challenges,
@@ -25,19 +26,22 @@ import {
 } from '../../format.js';
 import { activeWalletAccount } from '../../wallet-store.js';
 import {
+  confirmEmbeddedPayment,
   DEFAULT_MAX_AMOUNT_ATOMIC,
   enforceBudget,
   isEmbeddedChallengeArtifact,
+  parseEmbeddedPolicy,
   parseMaxAmount,
   pickAffordableRequirement,
-  printEmbeddedChallenge,
+  pickCheapestExact,
   printPaymentRequirement,
   printX402Error,
+  type EmbeddedPolicy,
 } from '../../x402-cli.js';
 
 type StreamEvent = TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
 
-/** Hard cap on how many payment hops we will auto-sign in one call. */
+/** Hard cap on how many payment hops we will handle in one call. */
 const MAX_PAYMENT_HOPS = 8;
 
 /**
@@ -67,8 +71,21 @@ export const streamCommand = new Command('stream')
   )
   .option(
     '--max-amount <atomic>',
-    'Maximum amount (in asset\'s atomic units) to auto-sign for an x402 payment. ' +
-      `Defaults to ${DEFAULT_MAX_AMOUNT_ATOMIC.toString()}.`,
+    'Maximum amount (in atomic units) to auto-sign for the Standalone gate. ' +
+      `Defaults to ${DEFAULT_MAX_AMOUNT_ATOMIC.toString()}. ` +
+      'Does NOT apply to Embedded charges.',
+  )
+  .option(
+    '--auto-embedded',
+    'Auto-sign Embedded-flow charges up to --max-embedded-amount instead of prompting.',
+  )
+  .option(
+    '--max-embedded-amount <atomic>',
+    'Ceiling (in atomic units) used when --auto-embedded is set. Required with --auto-embedded.',
+  )
+  .option(
+    '--no-embedded',
+    'Refuse every Embedded-flow charge outright (useful for scripts).',
   )
   .action(
     async (
@@ -80,11 +97,20 @@ export const streamCommand = new Command('stream')
         json?: boolean;
         x402?: boolean;
         maxAmount?: string;
+        autoEmbedded?: boolean;
+        maxEmbeddedAmount?: string;
+        embedded?: boolean;
       },
     ) => {
-      const maxAmount = parseMaxAmount(opts.maxAmount);
-
       try {
+        const gateMaxAmount = parseMaxAmount(opts.maxAmount);
+        const embeddedPolicy = parseEmbeddedPolicy({
+          noEmbedded: opts.embedded === false,
+          autoEmbedded: opts.autoEmbedded,
+          maxEmbeddedAmount: opts.maxEmbeddedAmount,
+          json: opts.json,
+        });
+
         const client = createClient(url, opts);
 
         const baseMessage: SendMessageParams['message'] = {
@@ -155,24 +181,29 @@ export const streamCommand = new Command('stream')
             process.exit(2);
           }
 
-          // Budget check + display before signing.
-          enforceBudget(signal.required, maxAmount);
-          if (!opts.json) {
-            console.log();
-            if (signal.kind === 'embedded' && signal.embedded) {
-              printEmbeddedChallenge(signal.embedded, maxAmount);
-            } else {
-              printPaymentRequirement(signal.required, maxAmount);
+          // Per-hop policy: gate uses --max-amount auto-sign; embedded
+          // consults parseEmbeddedPolicy (prompt / auto / refuse).
+          if (signal.kind === 'standalone') {
+            enforceBudget(signal.required, gateMaxAmount, 'gate');
+            if (!opts.json) {
+              console.log();
+              printPaymentRequirement(signal.required, gateMaxAmount);
             }
+          } else if (signal.embedded) {
+            await confirmEmbeddedPayment(signal.embedded, embeddedPolicy, {
+              json: opts.json,
+            });
           }
 
           const signed = await signX402Payment(signal.syntheticTask, {
             signer,
             selectRequirement: (accepts) =>
-              pickAffordableRequirement(
-                { x402Version: 1, accepts },
-                maxAmount,
-              ),
+              signal.kind === 'standalone'
+                ? pickAffordableRequirement(
+                    { x402Version: 1, accepts },
+                    gateMaxAmount,
+                  )
+                : pickCheapestExactForEmbedded(accepts, embeddedPolicy),
           });
 
           if (!opts.json) {
@@ -184,7 +215,6 @@ export const streamCommand = new Command('stream')
             console.log();
           }
 
-          // Build the follow-up params: same content + taskId + payment metadata.
           currentParams = {
             ...currentParams,
             message: {
@@ -209,19 +239,29 @@ export const streamCommand = new Command('stream')
   );
 
 /**
- * Iterate the stream, printing events as they come in. As soon as we
- * see a TaskStatusUpdateEvent whose status is `input-required` with
- * an x402 challenge, we synthesize a minimal Task so the caller can
- * feed it to `signX402Payment` and stop consuming further events.
- *
- * The challenge might live on `status.message.metadata`
- * (Standalone/gate) or on one of the `task.artifacts[]`
- * (Embedded). We track accumulated artifacts across the stream so
- * Embedded challenges can be surfaced even though no single event
- * carries the full task.
- *
- * Returns `undefined` when the stream ended without a pending
- * challenge.
+ * After `confirmEmbeddedPayment` has approved the spend, pick which
+ * requirement to sign. Under an auto policy we still respect the
+ * ceiling; under a prompt or refuse policy the user's `y` applies to
+ * whatever cheapest `exact`-scheme requirement we pick.
+ */
+function pickCheapestExactForEmbedded(
+  accepts: X402PaymentRequirements[],
+  policy: EmbeddedPolicy,
+): X402PaymentRequirements | undefined {
+  if (policy.kind === 'auto') {
+    return pickAffordableRequirement(
+      { x402Version: 1, accepts },
+      policy.maxAmount,
+    );
+  }
+  return pickCheapestExact(accepts);
+}
+
+/**
+ * Iterate the stream, printing events as they come in. Pauses as
+ * soon as a pending x402 challenge surfaces (Standalone via status
+ * metadata, or Embedded via an accumulated artifact) and returns a
+ * synthetic Task for the caller to sign against.
  */
 async function consumeUntilPaymentRequired(
   stream: AsyncGenerator<StreamEvent>,
@@ -250,7 +290,6 @@ async function consumeUntilPaymentRequired(
         artifacts,
       };
 
-      // Gate first (Standalone): status.message.metadata carries the challenge.
       const standalone = getX402PaymentRequirements(syntheticTask);
       if (standalone) {
         renderEvent(event, opts);
@@ -263,7 +302,6 @@ async function consumeUntilPaymentRequired(
         };
       }
 
-      // Embedded: scan accumulated artifacts.
       const embedded = getEmbeddedX402Challenges(syntheticTask);
       if (embedded.length > 0) {
         const first = embedded[0]!;
@@ -284,11 +322,6 @@ async function consumeUntilPaymentRequired(
   return undefined;
 }
 
-/**
- * Accumulate artifact updates by artifactId so a later
- * `getEmbeddedX402Challenges()` can see the full artifact. Append-style
- * updates extend parts; non-append updates replace.
- */
 function captureArtifact(
   artifacts: Artifact[],
   event: TaskArtifactUpdateEvent,
@@ -311,10 +344,6 @@ function captureArtifact(
   }
 }
 
-/**
- * Whether the cursor is currently mid-line after a streaming artifact chunk
- * that was written without a trailing newline.
- */
 let midLine = false;
 
 function flushLine(): void {
@@ -334,9 +363,6 @@ function renderEvent(event: StreamEvent, opts: { json?: boolean }): void {
     printStatusUpdate(event);
     return;
   }
-  // Artifact update: skip x402 embedded challenge artifacts — the
-  // payment-dance block re-renders them with proper formatting. Still
-  // flush any pending text line so the transition is clean.
   if (isEmbeddedChallengeArtifact(event.artifact)) {
     flushLine();
     return;

--- a/packages/cli/src/x402-cli.ts
+++ b/packages/cli/src/x402-cli.ts
@@ -1,21 +1,33 @@
 /**
  * Shared x402 helpers used by `a2x a2a send` and `a2x a2a stream`.
  *
- * The SDK exposes `X402Client.onPaymentRequired` and `selectRequirement`
- * as callbacks. The CLI wires them to a spend ceiling so an auto-signed
- * payment can never exceed `--max-amount` — if the server advertises
- * only expensive options we throw `X402BudgetExceededError` before any
- * EIP-3009 authorization gets signed.
+ * The SDK exposes budget-shaped callbacks on both flows:
+ *
+ *  - `onPaymentRequired` / `selectRequirement` for the Standalone gate
+ *    (see a2a-x402 v0.2 §5.1 Standalone flow).
+ *  - `onEmbeddedPaymentRequired` for each mid-execution charge
+ *    (v0.2 §5.1 Embedded flow).
+ *
+ * The CLI wires both to a spend ceiling so no EIP-3009 authorization is
+ * ever signed for more than `--max-amount` — the refusal happens
+ * BEFORE the signature, not after.
  */
 
 import chalk from 'chalk';
 import type {
+  Artifact,
+  EmbeddedX402Challenge,
   SignX402PaymentOptions,
+  Task,
   X402ClientOptions,
   X402PaymentRequiredResponse,
   X402PaymentRequirements,
 } from '@a2x/sdk';
-import { X402PaymentFailedError } from '@a2x/sdk';
+import {
+  X402PaymentFailedError,
+  getEmbeddedX402Challenges,
+} from '@a2x/sdk';
+import { TaskState } from '@a2x/sdk';
 
 /**
  * Default spend ceiling, in the asset's atomic units, applied to every
@@ -71,34 +83,34 @@ export function safeBigInt(raw: string): bigint {
 }
 
 /**
- * Build the `{ onPaymentRequired, selectRequirement }` pair that both
- * `X402Client` (used by send) and the manual payment dance in stream
- * should share. Takes the same `SignX402PaymentOptions.signer` shape
- * so callers can spread `{ signer, ...buildBudgetedX402ClientOptions }`
- * without repeating themselves.
+ * Combine `signer` + budget callbacks (gate + embedded) into a full
+ * `X402ClientOptions` block.
+ *
+ * `verbose` controls whether the embedded-hop callback prints the
+ * challenge to stdout — on by default for interactive UX, disabled in
+ * `--json` mode.
  */
-export function buildBudgetedX402ClientOptions(
-  maxAmount: bigint,
-): Pick<X402ClientOptions, 'onPaymentRequired' | 'selectRequirement'> {
+export function buildBudgetedX402ClientSettings(args: {
+  signer: SignX402PaymentOptions['signer'];
+  maxAmount: bigint;
+  verbose?: boolean;
+}): X402ClientOptions {
+  const verbose = args.verbose ?? true;
   return {
-    onPaymentRequired: (r) => {
-      const affordable = r.accepts.filter(
-        (a) => safeBigInt(a.maxAmountRequired) <= maxAmount,
-      );
-      if (affordable.length === 0) {
-        const cheapest = r.accepts
-          .map((a) => ({ v: safeBigInt(a.maxAmountRequired), asset: a.asset }))
-          .sort((x, y) => (x.v < y.v ? -1 : 1))[0];
-        throw new X402BudgetExceededError(
-          cheapest?.v ?? 0n,
-          maxAmount,
-          cheapest?.asset ?? 'unknown',
-        );
+    signer: args.signer,
+    onPaymentRequired: (required) => {
+      enforceBudget(required, args.maxAmount);
+    },
+    onEmbeddedPaymentRequired: (challenge: EmbeddedX402Challenge) => {
+      if (verbose) {
+        console.log();
+        printEmbeddedChallenge(challenge, args.maxAmount);
       }
+      enforceBudget(challenge.required, args.maxAmount);
     },
     selectRequirement: (accepts) => {
       const affordable = accepts
-        .filter((a) => safeBigInt(a.maxAmountRequired) <= maxAmount)
+        .filter((a) => safeBigInt(a.maxAmountRequired) <= args.maxAmount)
         .sort((x, y) =>
           safeBigInt(x.maxAmountRequired) < safeBigInt(y.maxAmountRequired)
             ? -1
@@ -106,20 +118,6 @@ export function buildBudgetedX402ClientOptions(
         );
       return affordable.find((a) => a.scheme === 'exact') ?? affordable[0];
     },
-  };
-}
-
-/**
- * Combine `signer` + budget callbacks into a full `X402ClientOptions`
- * in one call.
- */
-export function buildBudgetedX402ClientSettings(args: {
-  signer: SignX402PaymentOptions['signer'];
-  maxAmount: bigint;
-}): X402ClientOptions {
-  return {
-    signer: args.signer,
-    ...buildBudgetedX402ClientOptions(args.maxAmount),
   };
 }
 
@@ -177,6 +175,48 @@ export function printPaymentRequirement(
   console.log();
 }
 
+export function printEmbeddedChallenge(
+  challenge: EmbeddedX402Challenge,
+  budget: bigint,
+): void {
+  console.log(chalk.bold.magenta('x402: embedded payment required'));
+  console.log(chalk.gray('─'.repeat(40)));
+  if (challenge.artifactName) {
+    console.log(`  ${chalk.bold('artifact:')} ${challenge.artifactName}`);
+  }
+  // Surface any non-x402 fields on the data wrapper (cartId, total, etc.)
+  // so the user sees what they're paying for.
+  const summary = summarizeEmbeddedData(challenge.data);
+  if (summary.length > 0) {
+    for (const line of summary) console.log(`  ${line}`);
+  }
+  for (const accept of challenge.required.accepts) {
+    printAccept(accept, budget);
+  }
+  console.log(
+    chalk.gray(
+      `  (budget: ${budget.toString()} atomic — use --max-amount to change)`,
+    ),
+  );
+  console.log();
+}
+
+function summarizeEmbeddedData(data: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    // Skip the x402 challenge itself; the rows below already print it.
+    if (key === 'x402.payment.required') continue;
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      out.push(`${chalk.bold(`${key}:`)} ${String(value)}`);
+    } else {
+      // Compact JSON for nested shapes (cart items list, total object, …).
+      out.push(`${chalk.bold(`${key}:`)} ${chalk.gray(JSON.stringify(value))}`);
+    }
+  }
+  return out;
+}
+
 function printAccept(accept: X402PaymentRequirements, budget: bigint): void {
   const amount = accept.maxAmountRequired;
   const overBudget = safeBigInt(amount) > budget;
@@ -190,6 +230,27 @@ function printAccept(accept: X402PaymentRequirements, budget: bigint): void {
   if (accept.description) {
     console.log(`  ${chalk.bold('note:')}     ${accept.description}`);
   }
+}
+
+// ─── Artifact classification (stream path) ─────────────────────────
+
+/**
+ * True when `artifact` carries an x402 embedded payment challenge —
+ * either the bare SDK shape (`x402.payment.required` key on a data part)
+ * or any `x402PaymentRequiredResponse`-shaped object nested inside a
+ * higher-level wrapper.
+ *
+ * The stream command uses this to skip dumping the raw challenge JSON
+ * into the text stream; the payment-dance block re-renders it with
+ * proper formatting.
+ */
+export function isEmbeddedChallengeArtifact(artifact: Artifact): boolean {
+  const probe: Task = {
+    id: '_probe',
+    status: { state: TaskState.INPUT_REQUIRED },
+    artifacts: [artifact],
+  };
+  return getEmbeddedX402Challenges(probe).length > 0;
 }
 
 // ─── Error handling ─────────────────────────────────────────────────

--- a/packages/cli/src/x402-cli.ts
+++ b/packages/cli/src/x402-cli.ts
@@ -1,18 +1,30 @@
 /**
  * Shared x402 helpers used by `a2x a2a send` and `a2x a2a stream`.
  *
- * The SDK exposes budget-shaped callbacks on both flows:
+ * The two flows defined by a2a-x402 v0.2 map to very different UX:
  *
- *  - `onPaymentRequired` / `selectRequirement` for the Standalone gate
- *    (see a2a-x402 v0.2 §5.1 Standalone flow).
- *  - `onEmbeddedPaymentRequired` for each mid-execution charge
- *    (v0.2 §5.1 Embedded flow).
+ *  - **Standalone gate.** Typically a tiny anti-spam/access fee. The
+ *    CLI auto-signs anything under `--max-amount` (10_000 atomic by
+ *    default — 0.01 USDC on a 6-decimal stablecoin). Raising this
+ *    ceiling is safe because everything above it refuses up-front,
+ *    before any signature.
+ *  - **Embedded flow.** Mid-execution per-purchase charge (cart
+ *    checkout, premium asset delivery). Amounts are arbitrary and
+ *    *can be high*, so auto-signing under a generous ceiling is
+ *    dangerous — a buggy/malicious merchant could drain a wallet.
+ *    The CLI therefore requires explicit per-hop approval:
  *
- * The CLI wires both to a spend ceiling so no EIP-3009 authorization is
- * ever signed for more than `--max-amount` — the refusal happens
- * BEFORE the signature, not after.
+ *    - Default (TTY): pause, print challenge, prompt `y/N`.
+ *    - `--auto-embedded --max-embedded-amount N`: auto-sign up to N.
+ *    - `--no-embedded`: refuse any embedded charge outright.
+ *    - Non-TTY or `--json` mode: refuse by default (can't prompt);
+ *      caller must opt into `--auto-embedded` explicitly.
+ *
+ * All policy decisions live here so `send.ts` and `stream.ts` share
+ * one implementation.
  */
 
+import { createInterface } from 'node:readline';
 import chalk from 'chalk';
 import type {
   Artifact,
@@ -31,39 +43,56 @@ import { TaskState } from '@a2x/sdk';
 
 /**
  * Default spend ceiling, in the asset's atomic units, applied to every
- * auto-signed x402 payment. 10_000 on a 6-decimal stablecoin is 0.01 USDC.
+ * auto-signed x402 gate payment. 10_000 on a 6-decimal stablecoin is
+ * 0.01 USDC — a paranoid default for a CLI that holds real keys.
  *
- * Anything the server asks for above this will be refused up-front,
- * before we sign — a paranoid default for a CLI that holds real keys.
- * Override explicitly with --max-amount.
+ * Only affects the **Standalone gate**. Embedded charges never use
+ * this ceiling; they always require explicit approval.
  */
 export const DEFAULT_MAX_AMOUNT_ATOMIC = 10_000n;
 
 /**
- * Thrown by our onPaymentRequired callback when every payment option
- * advertised by the server exceeds the configured budget. The outer
- * command-level catch recognises it and prints a dedicated message
- * with remediation hints.
+ * Thrown when the server asks for a payment the configured budget
+ * can't cover. Used for both gate-exceeded and auto-embedded-exceeded.
  */
 export class X402BudgetExceededError extends Error {
   constructor(
     public readonly cheapest: bigint,
     public readonly budget: bigint,
     public readonly asset: string,
+    public readonly scope: 'gate' | 'embedded' = 'gate',
   ) {
     super(
-      `Refusing to pay: cheapest advertised amount ${cheapest.toString()} (atomic of ${asset}) exceeds --max-amount budget ${budget.toString()}.`,
+      `Refusing to pay: cheapest advertised ${scope} amount ${cheapest.toString()} (atomic of ${asset}) exceeds budget ${budget.toString()}.`,
     );
     this.name = 'X402BudgetExceededError';
   }
 }
 
-/** Parse the --max-amount CLI value; fall back to the default. */
+/**
+ * Thrown when the user says "no" at the embedded-payment prompt, when
+ * `--no-embedded` is active, or when a non-interactive invocation
+ * tries to trigger an embedded charge without `--auto-embedded`.
+ */
+export class X402EmbeddedDeclinedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'X402EmbeddedDeclinedError';
+  }
+}
+
+// ─── Amount parsing ────────────────────────────────────────────────
+
+/** Parse the --max-amount CLI value; fall back to the gate default. */
 export function parseMaxAmount(raw: string | undefined): bigint {
   if (raw === undefined) return DEFAULT_MAX_AMOUNT_ATOMIC;
+  return parseAtomic(raw, '--max-amount');
+}
+
+function parseAtomic(raw: string, flag: string): bigint {
   if (!/^\d+$/.test(raw)) {
     throw new Error(
-      `--max-amount must be a non-negative integer in atomic units; got "${raw}".`,
+      `${flag} must be a non-negative integer in atomic units; got "${raw}".`,
     );
   }
   return BigInt(raw);
@@ -82,66 +111,187 @@ export function safeBigInt(raw: string): bigint {
   }
 }
 
+// ─── Embedded policy ───────────────────────────────────────────────
+
+export type EmbeddedPolicy =
+  | { kind: 'prompt' } // Interactive Y/N
+  | { kind: 'auto'; maxAmount: bigint } // Auto-sign up to maxAmount
+  | { kind: 'refuse' }; // Hard refuse every embedded charge
+
+export interface EmbeddedPolicyOpts {
+  noEmbedded?: boolean;
+  autoEmbedded?: boolean;
+  maxEmbeddedAmount?: string;
+  json?: boolean;
+}
+
 /**
- * Combine `signer` + budget callbacks (gate + embedded) into a full
- * `X402ClientOptions` block.
- *
- * `verbose` controls whether the embedded-hop callback prints the
- * challenge to stdout — on by default for interactive UX, disabled in
- * `--json` mode.
+ * Resolve the CLI flags into a concrete embedded-payment policy. This
+ * is the single source of truth for "should the CLI sign an embedded
+ * charge without human input?" — callers just dispatch on the
+ * returned `kind`.
  */
-export function buildBudgetedX402ClientSettings(args: {
+export function parseEmbeddedPolicy(opts: EmbeddedPolicyOpts): EmbeddedPolicy {
+  if (opts.noEmbedded) return { kind: 'refuse' };
+
+  if (opts.autoEmbedded) {
+    if (opts.maxEmbeddedAmount === undefined) {
+      throw new Error(
+        '--auto-embedded requires --max-embedded-amount <atomic> so the CLI has an explicit ceiling.',
+      );
+    }
+    return {
+      kind: 'auto',
+      maxAmount: parseAtomic(opts.maxEmbeddedAmount, '--max-embedded-amount'),
+    };
+  }
+
+  if (opts.maxEmbeddedAmount !== undefined) {
+    throw new Error(
+      '--max-embedded-amount requires --auto-embedded; otherwise the prompt decides.',
+    );
+  }
+
+  // Neither auto nor refuse: prompt when interactive, refuse otherwise.
+  if (opts.json || !process.stdin.isTTY) {
+    return { kind: 'refuse' };
+  }
+  return { kind: 'prompt' };
+}
+
+/**
+ * Apply the resolved policy to one embedded challenge. Returns on
+ * approval; throws on refusal (callers propagate to exit).
+ */
+export async function confirmEmbeddedPayment(
+  challenge: EmbeddedX402Challenge,
+  policy: EmbeddedPolicy,
+  opts: { json?: boolean } = {},
+): Promise<void> {
+  const verbose = opts.json !== true;
+  const cheapest = cheapestAmount(challenge.required);
+
+  if (policy.kind === 'refuse') {
+    throw new X402EmbeddedDeclinedError(
+      `Embedded payment refused (--no-embedded or non-interactive session). ` +
+        `Cheapest advertised amount: ${cheapest.v.toString()} atomic of ${cheapest.asset}.`,
+    );
+  }
+
+  if (policy.kind === 'auto') {
+    if (verbose) {
+      console.log();
+      printEmbeddedChallenge(challenge, policy.maxAmount);
+      console.log(
+        chalk.gray(
+          `  auto-approving under --max-embedded-amount ${policy.maxAmount.toString()}`,
+        ),
+      );
+    }
+    if (cheapest.v > policy.maxAmount) {
+      throw new X402BudgetExceededError(
+        cheapest.v,
+        policy.maxAmount,
+        cheapest.asset,
+        'embedded',
+      );
+    }
+    return;
+  }
+
+  // Interactive prompt.
+  if (verbose) {
+    console.log();
+    printEmbeddedChallenge(challenge, cheapest.v);
+  }
+  const ok = await promptYesNo(
+    chalk.bold.yellow('  Approve this embedded payment? ') + chalk.gray('[y/N] '),
+  );
+  if (!ok) {
+    throw new X402EmbeddedDeclinedError('User declined embedded payment.');
+  }
+}
+
+function cheapestAmount(required: X402PaymentRequiredResponse): {
+  v: bigint;
+  asset: string;
+} {
+  const sorted = required.accepts
+    .map((a) => ({ v: safeBigInt(a.maxAmountRequired), asset: a.asset }))
+    .sort((x, y) => (x.v < y.v ? -1 : 1));
+  return sorted[0] ?? { v: 0n, asset: 'unknown' };
+}
+
+// ─── Interactive prompt ────────────────────────────────────────────
+
+async function promptYesNo(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+// ─── X402ClientOptions builder (send path) ─────────────────────────
+
+export interface X402CliSettingsArgs {
   signer: SignX402PaymentOptions['signer'];
-  maxAmount: bigint;
+  gateMaxAmount: bigint;
+  embeddedPolicy: EmbeddedPolicy;
   verbose?: boolean;
-}): X402ClientOptions {
-  const verbose = args.verbose ?? true;
+  json?: boolean;
+}
+
+/**
+ * Assemble the full `X402ClientOptions` used by `a2x a2a send`.
+ *
+ * The callbacks enforce policy *before* signatures:
+ *
+ *  - `onPaymentRequired` refuses gate charges over `gateMaxAmount`.
+ *  - `onEmbeddedPaymentRequired` runs the embedded policy (prompt,
+ *    auto-with-ceiling, or refuse).
+ *  - `selectRequirement` picks the cheapest `exact` option. It does
+ *    NOT filter by budget — the callbacks own that decision, per
+ *    hop, so the gate ceiling can't silently apply to embedded.
+ */
+export function buildBudgetedX402ClientSettings(
+  args: X402CliSettingsArgs,
+): X402ClientOptions {
   return {
     signer: args.signer,
     onPaymentRequired: (required) => {
-      enforceBudget(required, args.maxAmount);
+      enforceBudget(required, args.gateMaxAmount, 'gate');
     },
-    onEmbeddedPaymentRequired: (challenge: EmbeddedX402Challenge) => {
-      if (verbose) {
-        console.log();
-        printEmbeddedChallenge(challenge, args.maxAmount);
-      }
-      enforceBudget(challenge.required, args.maxAmount);
+    onEmbeddedPaymentRequired: async (challenge) => {
+      await confirmEmbeddedPayment(challenge, args.embeddedPolicy, {
+        json: args.json,
+      });
     },
-    selectRequirement: (accepts) => {
-      const affordable = accepts
-        .filter((a) => safeBigInt(a.maxAmountRequired) <= args.maxAmount)
-        .sort((x, y) =>
-          safeBigInt(x.maxAmountRequired) < safeBigInt(y.maxAmountRequired)
-            ? -1
-            : 1,
-        );
-      return affordable.find((a) => a.scheme === 'exact') ?? affordable[0];
-    },
+    selectRequirement: (accepts) => pickCheapestExact(accepts),
   };
 }
 
-/** Enforce the budget without going through `X402Client` (stream path). */
+/**
+ * Enforce a budget without going through `X402Client`. Used by the
+ * gate check in the stream path and by the auto-embedded ceiling.
+ */
 export function enforceBudget(
   required: X402PaymentRequiredResponse,
   maxAmount: bigint,
+  scope: 'gate' | 'embedded' = 'gate',
 ): void {
   const affordable = required.accepts.filter(
     (a) => safeBigInt(a.maxAmountRequired) <= maxAmount,
   );
   if (affordable.length === 0) {
-    const cheapest = required.accepts
-      .map((a) => ({ v: safeBigInt(a.maxAmountRequired), asset: a.asset }))
-      .sort((x, y) => (x.v < y.v ? -1 : 1))[0];
-    throw new X402BudgetExceededError(
-      cheapest?.v ?? 0n,
-      maxAmount,
-      cheapest?.asset ?? 'unknown',
-    );
+    const cheapest = cheapestAmount(required);
+    throw new X402BudgetExceededError(cheapest.v, maxAmount, cheapest.asset, scope);
   }
 }
 
-/** Pick the cheapest affordable "exact" requirement without X402Client. */
+/** Pick the cheapest affordable "exact" requirement. */
 export function pickAffordableRequirement(
   required: X402PaymentRequiredResponse,
   maxAmount: bigint,
@@ -154,6 +304,21 @@ export function pickAffordableRequirement(
         : 1,
     );
   return affordable.find((a) => a.scheme === 'exact') ?? affordable[0];
+}
+
+/**
+ * Pick the cheapest `exact`-scheme requirement from a list without a
+ * budget filter. Used after policy has already approved the spend.
+ */
+export function pickCheapestExact(
+  accepts: X402PaymentRequirements[],
+): X402PaymentRequirements | undefined {
+  const sorted = [...accepts].sort((x, y) =>
+    safeBigInt(x.maxAmountRequired) < safeBigInt(y.maxAmountRequired)
+      ? -1
+      : 1,
+  );
+  return sorted.find((a) => a.scheme === 'exact') ?? sorted[0];
 }
 
 // ─── Display helpers ────────────────────────────────────────────────
@@ -169,7 +334,7 @@ export function printPaymentRequirement(
   }
   console.log(
     chalk.gray(
-      `  (budget: ${budget.toString()} atomic — use --max-amount to change)`,
+      `  (gate budget: ${budget.toString()} atomic — use --max-amount to change)`,
     ),
   );
   console.log();
@@ -177,50 +342,42 @@ export function printPaymentRequirement(
 
 export function printEmbeddedChallenge(
   challenge: EmbeddedX402Challenge,
-  budget: bigint,
+  ceiling: bigint,
 ): void {
   console.log(chalk.bold.magenta('x402: embedded payment required'));
   console.log(chalk.gray('─'.repeat(40)));
   if (challenge.artifactName) {
     console.log(`  ${chalk.bold('artifact:')} ${challenge.artifactName}`);
   }
-  // Surface any non-x402 fields on the data wrapper (cartId, total, etc.)
-  // so the user sees what they're paying for.
   const summary = summarizeEmbeddedData(challenge.data);
   if (summary.length > 0) {
     for (const line of summary) console.log(`  ${line}`);
   }
   for (const accept of challenge.required.accepts) {
-    printAccept(accept, budget);
+    printAccept(accept, ceiling);
   }
-  console.log(
-    chalk.gray(
-      `  (budget: ${budget.toString()} atomic — use --max-amount to change)`,
-    ),
-  );
-  console.log();
 }
 
 function summarizeEmbeddedData(data: Record<string, unknown>): string[] {
   const out: string[] = [];
   for (const [key, value] of Object.entries(data)) {
-    // Skip the x402 challenge itself; the rows below already print it.
     if (key === 'x402.payment.required') continue;
     if (value === null || value === undefined) continue;
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       out.push(`${chalk.bold(`${key}:`)} ${String(value)}`);
     } else {
-      // Compact JSON for nested shapes (cart items list, total object, …).
       out.push(`${chalk.bold(`${key}:`)} ${chalk.gray(JSON.stringify(value))}`);
     }
   }
   return out;
 }
 
-function printAccept(accept: X402PaymentRequirements, budget: bigint): void {
+function printAccept(accept: X402PaymentRequirements, ceiling: bigint): void {
   const amount = accept.maxAmountRequired;
-  const overBudget = safeBigInt(amount) > budget;
-  const amountLine = overBudget ? chalk.red(`${amount} (over budget)`) : amount;
+  const overCeiling = safeBigInt(amount) > ceiling;
+  const amountLine = overCeiling
+    ? chalk.red(`${amount} (over budget)`)
+    : amount;
   console.log(`  ${chalk.bold('network:')}  ${chalk.cyan(accept.network)}`);
   console.log(`  ${chalk.bold('scheme:')}   ${accept.scheme}`);
   console.log(
@@ -236,13 +393,9 @@ function printAccept(accept: X402PaymentRequirements, budget: bigint): void {
 
 /**
  * True when `artifact` carries an x402 embedded payment challenge —
- * either the bare SDK shape (`x402.payment.required` key on a data part)
- * or any `x402PaymentRequiredResponse`-shaped object nested inside a
- * higher-level wrapper.
- *
- * The stream command uses this to skip dumping the raw challenge JSON
- * into the text stream; the payment-dance block re-renders it with
- * proper formatting.
+ * either the bare SDK shape (`x402.payment.required` key on a data
+ * part) or any `x402PaymentRequiredResponse`-shaped object nested
+ * inside a higher-level wrapper.
  */
 export function isEmbeddedChallengeArtifact(artifact: Artifact): boolean {
   const probe: Task = {
@@ -256,24 +409,51 @@ export function isEmbeddedChallengeArtifact(artifact: Artifact): boolean {
 // ─── Error handling ─────────────────────────────────────────────────
 
 /**
- * Centralised pretty-printer for the three x402 error classes the
- * CLI can surface. Returns the exit code the caller should use, or
- * `null` if the error wasn't an x402 one (caller handles it).
+ * Centralised pretty-printer for the x402 error classes the CLI can
+ * surface. Returns the exit code the caller should use, or `null` if
+ * the error wasn't an x402 one (caller handles it).
  */
 export function printX402Error(err: unknown): number | null {
   if (err instanceof X402BudgetExceededError) {
     console.error();
     console.error(
       chalk.red('✗'),
-      chalk.bold.red('x402 payment refused (over budget)'),
+      chalk.bold.red(
+        err.scope === 'embedded'
+          ? 'x402 embedded payment refused (over budget)'
+          : 'x402 gate payment refused (over budget)',
+      ),
     );
     console.error(
       `  cheapest option: ${err.cheapest.toString()} atomic of ${err.asset}`,
     );
-    console.error(`  --max-amount:    ${err.budget.toString()}`);
+    console.error(`  budget:          ${err.budget.toString()}`);
+    if (err.scope === 'embedded') {
+      console.error(
+        chalk.yellow(
+          '\n  Raise the ceiling with `--max-embedded-amount <atomic>` if you trust the merchant.',
+        ),
+      );
+    } else {
+      console.error(
+        chalk.yellow(
+          '\n  Raise the ceiling with `--max-amount <atomic>` if you trust the merchant.',
+        ),
+      );
+    }
+    return 2;
+  }
+
+  if (err instanceof X402EmbeddedDeclinedError) {
+    console.error();
+    console.error(
+      chalk.red('✗'),
+      chalk.bold.red('x402 embedded payment declined'),
+    );
+    console.error(`  ${err.message}`);
     console.error(
       chalk.yellow(
-        '\n  Raise the ceiling with `--max-amount <atomic>` if you trust the merchant.',
+        '\n  Re-run with `--auto-embedded --max-embedded-amount <atomic>` to skip the prompt.',
       ),
     );
     return 2;

--- a/samples/nextjs-x402/README.md
+++ b/samples/nextjs-x402/README.md
@@ -46,8 +46,17 @@ a2x wallet use default
 
 # Call the paywalled agent — the CLI handles the full x402 dance
 a2x a2a send http://localhost:3000/api/a2a "sku-air-max"
-# Two payments will settle: the 0.001 USDC gate, then 0.12 USDC for the Air Max.
+# Gate (0.001 USDC) auto-signs under the default --max-amount ceiling.
+# Then the CLI pauses and prompts for the 0.12 USDC Nike Air Max checkout:
+#   Approve this embedded payment? [y/N] y
 # Try "sku-react-tee" for the cheaper inventory item.
+
+# Skip the prompt in scripts with an explicit embedded ceiling:
+a2x a2a send http://localhost:3000/api/a2a "sku-air-max" \
+  --auto-embedded --max-embedded-amount 120000
+
+# Refuse every embedded charge outright (the gate still runs):
+a2x a2a send http://localhost:3000/api/a2a "sku-react-tee" --no-embedded
 ```
 
 Using the SDK directly:

--- a/samples/nextjs-x402/README.md
+++ b/samples/nextjs-x402/README.md
@@ -1,14 +1,20 @@
 # nextjs-x402 sample
 
-An [A2A](https://a2a-protocol.org) agent built with Next.js and `@a2x/sdk` where every call is paywalled using the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension.
+An [A2A](https://a2a-protocol.org) agent built with Next.js and `@a2x/sdk` that demos **both** payment flows defined by [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402):
 
-The agent itself is a trivial echo — the interesting bit is the x402 payment flow:
+- **Standalone gate.** A fixed browsing fee (0.001 USDC on Base Sepolia) is charged before the agent even starts.
+- **Embedded checkout.** Once inside, the agent offers a tiny inventory and asks for a per-item payment mid-execution via an artifact-shaped challenge. Ship happens after the embedded charge settles.
+
+The two charges stack: a single `sendMessage` call settles the gate, lets the agent think, settles the embedded checkout, and returns the completed task with both receipts.
+
+### Payment lifecycle
 
 1. Client sends a message.
-2. Server responds with task state `input-required` and `x402.payment.required` metadata (0.001 USDC on Base Sepolia).
-3. Client signs an EIP-3009 authorization over that requirement with their wallet.
-4. Client resubmits the same task with `x402.payment.submitted` + signed `PaymentPayload`.
-5. Server verifies + settles through the Coinbase facilitator, runs the agent, and attaches the settlement receipt to the completed task.
+2. Server responds with `input-required` + `x402.payment.required` (gate challenge, 0.001 USDC).
+3. Client signs an EIP-3009 authorization and resubmits → gate settles → agent runs.
+4. Agent yields `paymentRequired` → server emits an artifact-shaped cart challenge (0.05–0.12 USDC).
+5. Client signs the embedded payload and resubmits → embedded payment settles → agent resumes and ships the item.
+6. Completed task carries two receipts stacked under `x402.payment.receipts`.
 
 ## Setup
 
@@ -39,7 +45,9 @@ a2x wallet use default
 # Select "Base Sepolia" and use the address from `a2x wallet show`
 
 # Call the paywalled agent — the CLI handles the full x402 dance
-a2x a2a send http://localhost:3000/api/a2a "hello"
+a2x a2a send http://localhost:3000/api/a2a "sku-air-max"
+# Two payments will settle: the 0.001 USDC gate, then 0.12 USDC for the Air Max.
+# Try "sku-react-tee" for the cheaper inventory item.
 ```
 
 Using the SDK directly:
@@ -57,15 +65,16 @@ const task = await x402.sendMessage({
   message: {
     messageId: crypto.randomUUID(),
     role: 'user',
-    parts: [{ text: 'hello' }],
+    parts: [{ text: 'sku-air-max' }],
   },
 });
 
-console.log(task); // { state: "completed", artifacts: [...], receipts: [...] }
+console.log(task); // { state: "completed", artifacts: [...cart + shipping...], receipts: [gate, embedded] }
 ```
 
 ## What to tweak
 
-- `src/lib/a2x-setup.ts` — swap `EchoAgent` for `LlmAgent` + your preferred provider to paywall a real assistant.
-- `accepts[]` in the same file — adjust price, switch networks (e.g. `base` mainnet), or list multiple accept options.
+- `src/lib/a2x-setup.ts` — swap `StorefrontAgent` for `LlmAgent` + your preferred provider to paywall a real assistant. Drop the gate `accepts` entirely for a purchase-only (no gate) flow.
+- `INVENTORY` in the same file — add SKUs, rename, reprice. The embedded challenge is built from the selected entry.
+- `accepts[]` in the same file — adjust the gate price, switch networks (e.g. `base` mainnet), or list multiple accept options.
 - `facilitator` — point at your own facilitator via `X402_FACILITATOR_URL`.

--- a/samples/nextjs-x402/src/app/page.tsx
+++ b/samples/nextjs-x402/src/app/page.tsx
@@ -6,8 +6,9 @@ export default function Home() {
           a2x x402 Sample
         </h1>
         <p className="mt-2 text-gray-600">
-          An A2A agent paywalled with the a2a-x402 v0.2 extension. Every
-          call is gated behind a 0.001 USDC payment on Base Sepolia.
+          An A2A agent paywalled with the a2a-x402 v0.2 extension. Each
+          call settles two charges on Base Sepolia: a 0.001 USDC browsing
+          gate, then a per-item embedded checkout (0.05–0.12 USDC).
         </p>
       </header>
 
@@ -39,8 +40,8 @@ a2x wallet use default
 
 # 2. Fund the wallet with Base Sepolia USDC (faucet: https://faucet.circle.com)
 
-# 3. Call the agent
-a2x a2a send http://localhost:3000/api/a2a "hello"`}
+# 3. Call the agent — the CLI handles the full two-payment dance
+a2x a2a send http://localhost:3000/api/a2a "sku-air-max"`}
         </pre>
       </section>
     </main>

--- a/samples/nextjs-x402/src/lib/a2x-setup.ts
+++ b/samples/nextjs-x402/src/lib/a2x-setup.ts
@@ -9,37 +9,90 @@ import {
   StreamingMode,
   X402PaymentExecutor,
   X402_EXTENSION_URI,
+  paymentRequiredEvent,
   type AgentEvent,
 } from '@a2x/sdk';
 import type { InvocationContext } from '@a2x/sdk';
 
 /**
- * A deliberately boring agent: we're showcasing the x402 payment gate,
- * not LLM integration. The agent just echoes the last text part it
- * received along with a greeting.
+ * A toy storefront agent to showcase both x402 flows:
  *
- * Swap in `LlmAgent` + a provider if you want a real response here.
+ *  - **Standalone gate**: the executor charges a tiny "browsing fee" up
+ *    front before the agent runs.
+ *  - **Embedded flow**: once the user is past the gate, the agent hands
+ *    back a cart artifact with an x402 challenge sized to the chosen
+ *    SKU — a per-purchase charge that settles before shoes ship.
+ *
+ * The SKUs are hardcoded in a fake inventory. Real integrations would
+ * swap this for a price lookup, stripping out the trailing "ship"
+ * message into whatever post-purchase work your agent actually does.
  */
-class EchoAgent extends BaseAgent {
+const INVENTORY: Record<string, { name: string; priceUsdc: string }> = {
+  'sku-air-max': { name: 'Nike Air Max', priceUsdc: '120000' },   // 0.12 USDC
+  'sku-react-tee': { name: 'React Tee', priceUsdc: '50000' },     // 0.05 USDC
+};
+
+class StorefrontAgent extends BaseAgent {
   constructor() {
     super({
-      name: 'echo_agent',
-      description: 'Echoes the most recent user message back to the caller.',
+      name: 'storefront_agent',
+      description:
+        'Sells a tiny in-memory inventory via an x402 embedded-flow checkout.',
     });
   }
 
   async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
-    // The Runner pushes the incoming user message into session.events as a
-    // text event right before invoking agent.run(). The most recent
-    // user-role text event is what we want to echo.
     const last = [...context.session.events]
       .reverse()
       .find((e) => e.type === 'text' && e.role === 'user');
-    const text = last && last.type === 'text' ? last.text : '(empty message)';
+    const text = last && last.type === 'text' ? last.text : '';
 
-    yield { type: 'text', role: 'agent', text: `You said: ${text}` };
+    // Pick a SKU out of the user text; default to the first.
+    const skuId =
+      Object.keys(INVENTORY).find((id) => text.includes(id)) ??
+      'sku-air-max';
+    const sku = INVENTORY[skuId]!;
+
+    yield {
+      type: 'text',
+      role: 'agent',
+      text: `Adding ${sku.name} to cart (${formatUsdc(sku.priceUsdc)} USDC)… `,
+    };
+
+    // Suspend until the client pays for the item.
+    yield paymentRequiredEvent({
+      accepts: [
+        {
+          network: 'base-sepolia',
+          amount: sku.priceUsdc,
+          asset: USDC_BASE_SEPOLIA,
+          payTo: resolveMerchantAddress(),
+          description: `Checkout: ${sku.name}`,
+        },
+      ],
+      embeddedObject: {
+        cartId: `cart-${skuId}`,
+        items: [{ id: skuId, name: sku.name }],
+        total: {
+          currency: 'USD',
+          // Friendly decimal value for UIs; ignore for payment math.
+          value: Number(sku.priceUsdc) / 1_000_000,
+        },
+      },
+      artifactName: 'demo-cart',
+    });
+
+    yield {
+      type: 'text',
+      role: 'agent',
+      text: `Shipped ${sku.name}! Thanks for the purchase.`,
+    };
     yield { type: 'done' };
   }
+}
+
+function formatUsdc(amount: string): string {
+  return (Number(amount) / 1_000_000).toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
 }
 
 const MISSING_ADDRESS_PLACEHOLDER = '0x0000000000000000000000000000000000000000';
@@ -60,7 +113,7 @@ const resolveMerchantAddress = (): string => {
 // USDC contract address on Base Sepolia (official Circle deployment).
 const USDC_BASE_SEPOLIA = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
 
-const agent = new EchoAgent();
+const agent = new StorefrontAgent();
 const runner = new InMemoryRunner({ agent, appName: 'nextjs-x402' });
 
 const innerExecutor = new AgentExecutor({
@@ -88,14 +141,15 @@ const mockFacilitator = process.env.X402_MOCK_FACILITATOR === '1'
   : undefined;
 
 const paymentExecutor = new X402PaymentExecutor(innerExecutor, {
+  // Standalone "browsing fee" gate — 0.001 USDC. Set `requiresPayment: () =>
+  // false` or remove `accepts` entirely for a pure embedded-only flow.
   accepts: [
     {
       network: 'base-sepolia',
-      // 0.001 USDC — tiny enough to be a believable per-call price on testnet.
       amount: '1000',
       asset: USDC_BASE_SEPOLIA,
       payTo: resolveMerchantAddress(),
-      description: 'Per-call echo',
+      description: 'Storefront browsing fee',
     },
   ],
   ...(mockFacilitator
@@ -115,10 +169,11 @@ export const a2xAgent = new A2XAgent({
     `${process.env.BASE_URL ?? 'http://localhost:3000'}/api/a2a`,
   )
   .addSkill({
-    id: 'echo',
-    name: 'Paid Echo',
-    description: 'Echoes your message back — paid per call via x402.',
-    tags: ['echo', 'x402', 'demo'],
+    id: 'shop',
+    name: 'x402 Storefront',
+    description:
+      'Browse and buy a tiny demo inventory. Gate fee + per-item checkout via x402 embedded flow.',
+    tags: ['shop', 'x402', 'embedded', 'demo'],
   })
   .addExtension({ uri: X402_EXTENSION_URI, required: true });
 


### PR DESCRIPTION
Closes #71.

## Summary

Extends `@a2x/sdk/x402` with a2a-x402 v0.2's **Embedded Flow** so agents can charge mid-execution (cart checkout, premium asset delivery, etc.) on top of — or instead of — the Standalone gate. The gate + any number of embedded charges stack; a single `X402Client.sendMessage` call settles all of them, and `@a2x/cli` (`a2a send`, `a2a stream`) drives the same loop with per-hop budget enforcement.

## Server — agent yields mid-execution

```ts
import { paymentRequiredEvent } from '@a2x/sdk/x402';

class CartAgent extends BaseAgent {
  async *run() {
    yield { type: 'text', text: 'Your cart: 1× Nike Air Max.' };
    yield paymentRequiredEvent({
      accepts: [{ network: 'base', amount: '120000000', asset: USDC, payTo, description: 'Checkout' }],
      embeddedObject: { cartId: 'shoes-123', total: { currency: 'USD', value: 120 } },
      artifactName: 'demo-cart',
    });
    yield { type: 'text', text: 'Shipped!' };
    yield { type: 'done' };
  }
}
```

The executor stashes the paused generator, emits the challenge on an artifact, transitions the task into `input-required` (no `x402.payment.required` in metadata per spec §4.2), and resumes the *same generator* once the client submits a signed payload.

Pure embedded-only (no gate) setups work out of the box — just omit `accepts` in the executor options.

## Dynamic pricing

```ts
new X402PaymentExecutor(inner, {
  resolveAccepts: async ({ embeddedObject }) => {
    const unitPrice = await priceBook.lookup(embeddedObject.productId);
    return [{ network: 'base', amount: unitPrice, asset: USDC, payTo }];
  },
});
```

## Client SDK

```ts
const x402 = new X402Client(new A2XClient(url), {
  signer,
  onEmbeddedPaymentRequired: (challenge) => console.log('Mid-flight charge:', challenge.required.accepts),
  maxPaymentHops: 8,
});
const task = await x402.sendMessage({ message });
// task.status.state === 'completed', with gate + embedded receipts stacked under x402.payment.receipts
```

Or inspect challenges yourself via `getEmbeddedX402Challenges(task)` — it recognizes the bare SDK shape and any `x402PaymentRequiredResponse`-shaped object nested inside a higher-level wrapper (AP2 `CartMandate`, your own schema).

## CLI (`@a2x/cli`)

Both `a2x a2a send` and `a2x a2a stream` now settle gate + embedded challenges in one call, with `--max-amount` enforced per hop. Example:

```bash
# Run the nextjs-x402 sample, which charges a 0.001 USDC gate + a 0.12 USDC cart embedded checkout.
a2x a2a send http://localhost:3000 "sku-air-max" --max-amount 120000
a2x a2a stream http://localhost:3000 "sku-air-max" --max-amount 120000
```

The stream renderer now detects embedded challenge artifacts and skips their raw JSON (previously the challenge data-part collided with streaming agent text on the same line); the payment-dance block re-renders the challenge with cart details + per-hop budget.

## Key changes

- **New AgentEvent variant.** `{ type: 'paymentRequired', accepts?, embeddedObject?, artifactName?, ... }` — generic enough that the base AgentExecutor ignores it safely when x402 is not installed.
- **New helper.** `paymentRequiredEvent({ ... })` narrows `accepts` back to `X402Accept[]` for ergonomic agent code.
- **New options.** `resolveAccepts` hook, `maxPaymentHops` cap, `onEmbeddedPaymentRequired` callback. `X402PaymentExecutorOptions.accepts` is now optional.
- **New helpers.** `getEmbeddedX402Challenges(task)`, `X402_EMBEDDED_ARTIFACT_NAME`, `X402_EMBEDDED_DATA_KEY`.
- **CLI.** `x402-cli.ts` now wires `onEmbeddedPaymentRequired` with budget enforcement and a dedicated renderer; `stream.ts` loops the payment dance up to `MAX_PAYMENT_HOPS`; `isEmbeddedChallengeArtifact` lets the stream renderer skip raw challenge JSON.
- **Docs.** New Embedded Flow section in `docs/guides/advanced/x402-payments.md`, README bullets refreshed on both root and `@a2x/sdk`.
- **Sample.** `samples/nextjs-x402` now demos a gate + per-item checkout with a tiny hardcoded storefront.
- **Changeset.** Minor bump on `@a2x/sdk`. (`@a2x/cli` is on the changeset ignore list and ships via tag-driven GitHub Release.)

Backwards-compatible: every existing x402 test passes unchanged.

## Test plan

- [x] `pnpm test` — 434 tests passing (24 new across SDK + CLI).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (one pre-existing warning unrelated to this PR).
- [x] `pnpm -r build` — clean.
- [x] Manual: nextjs-x402 sample exercised via `a2x a2a send` and `a2x a2a stream` with mock facilitator; gate + embedded charges both settled end-to-end, output no longer garbled.