### PR TITLE
fix(sdk): align @a2x/sdk/x402 with a2a-x402 v0.2 spec

### DIFF
--- a/.changeset/x402-spec-conformance.md
+++ b/.changeset/x402-spec-conformance.md
@@ -1,0 +1,33 @@
+---
+"@a2x/sdk": minor
+---
+
+Align `@a2x/sdk/x402` with a2a-x402 v0.2 spec.
+
+Closes #92. Audit of PR #72 turned up one MUST violation (§8 activation header) and five spec-drift gaps. This release fixes all of them together so the SDK interoperates with spec-strict x402 clients and servers.
+
+**Breaking — `X402_ERROR_CODES` renames.** Spec §9.1 defines the canonical code names. Two renames bring the SDK back in line:
+
+- `SETTLE_FAILED` → `SETTLEMENT_FAILED`
+- `AMOUNT_EXCEEDED` → `INVALID_AMOUNT`
+
+Also removed the unused `NO_REQUIREMENTS` code (never emitted). Consumers reading `x402.payment.error` string values or pattern-matching on these constants must update.
+
+**New — spec §9.1 error codes.** Verify failures now dispatch through `mapVerifyFailureToCode()`, which inspects the facilitator's `invalidReason` and returns one of `INSUFFICIENT_FUNDS`, `INVALID_SIGNATURE`, `EXPIRED_PAYMENT`, `DUPLICATE_NONCE`, or `VERIFY_FAILED` (fallback) instead of always emitting the generic `VERIFY_FAILED`.
+
+**New — `X-A2A-Extensions` activation header (§8 MUST).** `A2XClient` emits the header when extensions are registered:
+
+- new `A2XClientOptions.extensions?: string[]` option
+- new `A2XClient.registerExtension(uri)` method (idempotent)
+- new `A2XClient.activatedExtensions` read-only getter
+- `X402Client` auto-registers `X402_EXTENSION_URI` on its wrapped `A2XClient` so existing call sites get the header for free
+
+Server-side, `DefaultRequestHandler` rejects requests whose header doesn't list every `required: true` extension on the AgentCard (error code `-32600`). Enforcement only runs when a `RequestContext` is supplied, so pure in-process handler invocations are unaffected.
+
+**New — `payment-verified` transient state (§7.1).** Streaming clients now observe a `working` + `x402.payment.status: payment-verified` event between `payment-submitted` and `payment-completed`, matching the spec's 3-step lifecycle.
+
+**Fix — `x402.payment.receipts` preserves history (§7).** Prior receipts are merged rather than overwritten across retries, honoring spec §7's "complete history" requirement.
+
+**New — `payment-rejected` handling (§5.4.2 / §7.1).** The executor now recognizes a client-sent `x402.payment.status: payment-rejected` and terminates the task (`failed` + status `payment-rejected`) instead of looping on `payment-required`.
+
+**New — `retryOnFailure` executor option.** Opt in to spec §9's retry branch: verify/settle failures re-publish `payment-required` on the same task with the failure reason carried in `X402PaymentRequiredResponse.error`, letting the client fix the issue and resubmit. Default behavior (terminate with `failed`) is unchanged.

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -106,7 +106,53 @@ On a successful payment, the completed task's status message carries:
 }
 ```
 
-Failures surface under `x402.payment.error` with one of `INVALID_PAYLOAD`, `NETWORK_MISMATCH`, `INVALID_PAY_TO`, `AMOUNT_EXCEEDED`, `VERIFY_FAILED`, `SETTLE_FAILED`.
+Failures surface under `x402.payment.error` with one of the codes below. The seven names listed first come straight from spec §9.1; the remaining three are SDK-specific codes covering failure modes the SDK detects outside the facilitator's purview.
+
+| Code | Source | Meaning |
+|---|---|---|
+| `INSUFFICIENT_FUNDS` | spec §9.1 | Wallet can't cover the payment. |
+| `INVALID_SIGNATURE` | spec §9.1 | Authorization signature failed verification. |
+| `EXPIRED_PAYMENT` | spec §9.1 | Authorization was submitted after its validity window. |
+| `DUPLICATE_NONCE` | spec §9.1 | Nonce has already been spent. |
+| `NETWORK_MISMATCH` | spec §9.1 | Payload's network doesn't match any advertised `accepts`. |
+| `INVALID_AMOUNT` | spec §9.1 | Authorization value doesn't match the required amount. |
+| `SETTLEMENT_FAILED` | spec §9.1 | On-chain settle call failed. |
+| `INVALID_PAYLOAD` | SDK | Payment payload is missing or structurally invalid. |
+| `INVALID_PAY_TO` | SDK | Authorization target address doesn't match `payTo`. |
+| `VERIFY_FAILED` | SDK | Facilitator rejected the signature, but the reason string didn't match any of the spec codes above. |
+
+The SDK uses the facilitator's `invalidReason` string to dispatch into the spec codes (`mapVerifyFailureToCode()` exports the same logic if you need it client-side). Clients SHOULD branch on the spec codes first and treat `VERIFY_FAILED` as an unmapped fallback.
+
+### Payment lifecycle
+
+Every paid task runs through the same state machine (spec §7.1):
+
+```
+PAYMENT_REQUIRED → PAYMENT_REJECTED           (client declined the challenge)
+PAYMENT_REQUIRED → PAYMENT_SUBMITTED          (client signed and resubmitted)
+PAYMENT_SUBMITTED → PAYMENT_VERIFIED          (facilitator verified the signature)
+PAYMENT_VERIFIED → PAYMENT_COMPLETED          (on-chain settlement succeeded)
+PAYMENT_VERIFIED → PAYMENT_FAILED             (settlement failed on-chain)
+```
+
+The SDK emits `payment-verified` as a transient `working`-state event between submit and completion when streaming, so clients can surface a "settling on-chain…" indicator. In the blocking `execute()` path the state is recorded on `task.status` but clients only observe the final value.
+
+### Retry-on-failure (opt-in)
+
+By default, verify/settle failures terminate the task with state `failed` and an error code. Spec §9 also allows the merchant to "request a payment requirement with input-required again"; set `retryOnFailure: true` on the executor to pick that strategy — failures will re-publish `payment-required` on the same task with the prior failure reason carried in `X402PaymentRequiredResponse.error`, letting the client top up the wallet (or refresh the nonce) and resubmit without creating a new task.
+
+```ts
+new X402PaymentExecutor(inner, {
+  accepts: [...],
+  retryOnFailure: true,
+});
+```
+
+`x402.payment.receipts` accumulates every settle attempt (success or failure) across the task's lifetime per spec §7's "complete history" requirement.
+
+### Rejection handling
+
+When a client decides not to pay it can respond with `x402.payment.status: payment-rejected` (spec §5.4.2). The executor terminates the task with state `failed` and status `payment-rejected` — no further challenges are published, the loop ends.
 
 ## Client
 
@@ -187,6 +233,31 @@ for (const receipt of receipts) {
   console.log(receipt.success, receipt.transaction, receipt.network);
 }
 ```
+
+## Extension activation
+
+Per spec §8, x402-capable clients MUST include the extension URI in the `X-A2A-Extensions` HTTP header on every JSON-RPC request. `X402Client` does this automatically — wrapping an `A2XClient` registers `X402_EXTENSION_URI` on it so subsequent `sendMessage` / `sendMessageStream` calls emit the header:
+
+```
+X-A2A-Extensions: https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2
+```
+
+If you're driving `A2XClient` directly (without `X402Client`), pass `extensions` to the constructor:
+
+```ts
+new A2XClient(url, {
+  extensions: [X402_EXTENSION_URI],
+  // …other options
+});
+```
+
+Or register at runtime (the same mechanism `X402Client` uses internally):
+
+```ts
+client.registerExtension(X402_EXTENSION_URI);
+```
+
+**Server side.** When an agent declares an extension with `required: true`, `DefaultRequestHandler` rejects requests whose `X-A2A-Extensions` header doesn't list that URI (error `-32600`). The check is only applied when a `RequestContext` is provided to `handler.handle()` — pure in-process invocations skip it.
 
 ## Supported scope
 

--- a/packages/a2x/src/__tests__/x402-executor.test.ts
+++ b/packages/a2x/src/__tests__/x402-executor.test.ts
@@ -155,7 +155,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
     expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INVALID_PAYLOAD);
   });
 
-  it('emits VERIFY_FAILED when facilitator.verify() returns isValid=false', async () => {
+  it('maps nonce_reused verify failure to DUPLICATE_NONCE (spec §9.1)', async () => {
     const executor = makeExecutor(
       mockFacilitator({
         verify: async () => ({
@@ -176,12 +176,52 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.VERIFY_FAILED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.DUPLICATE_NONCE);
     const receipts = meta[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
     expect(receipts[0]).toMatchObject({ success: false, errorReason: expect.any(String) });
   });
 
-  it('emits SETTLE_FAILED when facilitator.settle() fails', async () => {
+  it('maps insufficient_balance verify failure to INSUFFICIENT_FUNDS (spec §9.1)', async () => {
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_exact_evm_insufficient_balance',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INSUFFICIENT_FUNDS);
+  });
+
+  it('falls back to VERIFY_FAILED when invalidReason does not match any spec §9.1 code', async () => {
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'something_the_sdk_does_not_recognize',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.VERIFY_FAILED);
+  });
+
+  it('emits SETTLEMENT_FAILED when facilitator.settle() fails', async () => {
     const executor = makeExecutor(
       mockFacilitator({
         settle: async () => ({
@@ -204,7 +244,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.SETTLE_FAILED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.SETTLEMENT_FAILED);
   });
 
   it('emits NETWORK_MISMATCH when the submitted payload targets an unaccepted network', async () => {
@@ -234,7 +274,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
     expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.NETWORK_MISMATCH);
   });
 
-  it('emits AMOUNT_EXCEEDED when authorization value is greater than maxAmountRequired', async () => {
+  it('emits INVALID_AMOUNT when authorization value is greater than maxAmountRequired (spec §9.1)', async () => {
     const executor = makeExecutor(mockFacilitator());
     const first = await executor.execute(newTask(), newMessage());
     const { payload } = await signAgainst(first);
@@ -265,7 +305,108 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.AMOUNT_EXCEEDED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INVALID_AMOUNT);
+  });
+
+  it('terminates the task when client sends payment-rejected (spec §5.4.2)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+
+    const result = await executor.execute(
+      newTask(),
+      newMessage({
+        metadata: { [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED },
+      }),
+    );
+
+    expect(result.status.state).toBe(TaskState.FAILED);
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REJECTED);
+  });
+
+  it('preserves prior receipts when payment completes after a previous failure (spec §7 history)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+
+    // Seed the task with a prior failure receipt that a retry would keep.
+    const task = newTask();
+    task.status = {
+      state: TaskState.INPUT_REQUIRED,
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: 'prior',
+        role: 'agent',
+        parts: [{ text: 'retry' }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          [X402_METADATA_KEYS.REQUIRED]: {
+            x402Version: 1,
+            accepts: [],
+          },
+          [X402_METADATA_KEYS.RECEIPTS]: [
+            {
+              success: false,
+              transaction: '',
+              network: 'base-sepolia',
+              errorReason: 'prior attempt failed',
+            },
+          ],
+        },
+      },
+    };
+
+    const { metadata } = await signAgainst(
+      await executor.execute(newTask(), newMessage()),
+    );
+    const completed = await executor.execute(
+      task,
+      newMessage({ messageId: 'm2', metadata }),
+    );
+
+    const receipts = (
+      completed.status.message?.metadata as Record<string, unknown>
+    )[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
+    expect(receipts).toHaveLength(2);
+    expect(receipts[0]).toMatchObject({ success: false });
+    expect(receipts[1]).toMatchObject({ success: true });
+  });
+
+  it('re-issues payment-required with error field when retryOnFailure=true (spec §5.1 error field)', async () => {
+    const agent = new EchoAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const inner = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const executor = new X402PaymentExecutor(inner, {
+      accepts: [DEFAULT_ACCEPT],
+      facilitator: mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_exact_evm_insufficient_balance',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+      retryOnFailure: true,
+    });
+
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+
+    // retryOnFailure keeps the task alive in input-required with the
+    // failure reason carried on the new payment-required response.
+    expect(result.status.state).toBe(TaskState.INPUT_REQUIRED);
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REQUIRED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INSUFFICIENT_FUNDS);
+    const required = meta[X402_METADATA_KEYS.REQUIRED] as {
+      error?: string;
+      accepts: unknown[];
+    };
+    expect(required.error).toContain('insufficient_balance');
+    expect(required.accepts).toHaveLength(1);
   });
 });
 
@@ -304,6 +445,61 @@ describe('X402PaymentExecutor — streaming', () => {
     const states = statusEvents.map((e) => e.status.state);
     expect(states).toContain(TaskState.WORKING);
     expect(states).toContain(TaskState.COMPLETED);
+  });
+
+  it('emits a payment-verified status event between submitted and completed (spec §7.1 lifecycle)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+
+    const events: unknown[] = [];
+    for await (const event of executor.executeStream(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    )) {
+      events.push(event);
+    }
+
+    // Find the transient `working + payment-verified` event. It must
+    // occur before any COMPLETED event so streaming clients can show
+    // "settling on-chain…" progress.
+    const verifiedIdx = events.findIndex((e) => {
+      if (typeof e !== 'object' || e === null || !('status' in e)) return false;
+      const status = (e as { status: { state: TaskState; message?: { metadata?: Record<string, unknown> } } }).status;
+      return (
+        status.state === TaskState.WORKING &&
+        status.message?.metadata?.[X402_METADATA_KEYS.STATUS] ===
+          X402_PAYMENT_STATUS.VERIFIED
+      );
+    });
+    expect(verifiedIdx).toBeGreaterThanOrEqual(0);
+
+    const completedIdx = events.findIndex((e) => {
+      if (typeof e !== 'object' || e === null || !('status' in e)) return false;
+      return (e as { status: { state: TaskState } }).status.state === TaskState.COMPLETED;
+    });
+    expect(completedIdx).toBeGreaterThan(verifiedIdx);
+  });
+
+  it('emits a failed terminal when streaming client sends payment-rejected', async () => {
+    const executor = makeExecutor(mockFacilitator());
+    const events: unknown[] = [];
+    for await (const event of executor.executeStream(
+      newTask(),
+      newMessage({
+        metadata: { [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED },
+      }),
+    )) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+    const evt = events[0] as {
+      status: { state: TaskState; message?: { metadata?: Record<string, unknown> } };
+    };
+    expect(evt.status.state).toBe(TaskState.FAILED);
+    expect(evt.status.message?.metadata?.[X402_METADATA_KEYS.STATUS]).toBe(
+      X402_PAYMENT_STATUS.REJECTED,
+    );
   });
 });
 

--- a/packages/a2x/src/__tests__/x402-extension-activation.test.ts
+++ b/packages/a2x/src/__tests__/x402-extension-activation.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for spec a2a-x402 v0.2 §8 extension activation. Clients MUST
+ * include the extension URI in the `X-A2A-Extensions` HTTP header, and
+ * servers with `required: true` extensions on their AgentCard MUST reject
+ * requests missing the URI.
+ */
+import { describe, expect, it } from 'vitest';
+import { privateKeyToAccount } from 'viem/accounts';
+import { A2XClient } from '../client/a2x-client.js';
+import { X402Client, X402_EXTENSION_URI } from '../x402/index.js';
+import { A2XAgent } from '../a2x/a2x-agent.js';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent, type AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+import { InMemoryTaskStore } from '../a2x/task-store.js';
+import { DefaultRequestHandler } from '../transport/request-handler.js';
+// Ensure response mappers are registered (side-effect import).
+import '../a2x/index.js';
+
+const TEST_ACCOUNT = privateKeyToAccount(
+  '0x1111111111111111111111111111111111111111111111111111111111111111',
+);
+
+class EchoAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'echo', description: 'echo' });
+  }
+  async *run(_ctx: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'hi', role: 'agent' };
+    yield { type: 'done' };
+  }
+}
+
+/**
+ * Build a fake `fetch` that records every request's headers and returns
+ * a minimal AgentCard on the first call and a generic JSON-RPC success
+ * on every subsequent call. Lets the client resolve without talking to
+ * an actual server.
+ */
+function recordingFetch(): {
+  fetch: typeof globalThis.fetch;
+  calls: Array<{ url: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const src = init.headers as Record<string, string>;
+      for (const key of Object.keys(src)) headers[key.toLowerCase()] = src[key]!;
+    }
+    calls.push({ url, headers });
+
+    // AgentCard resolution hits /.well-known/agent-card.json or
+    // /.well-known/agent.json — return a minimal card.
+    if (url.endsWith('/agent-card.json') || url.endsWith('/agent.json')) {
+      return new Response(
+        JSON.stringify({
+          protocolVersion: '0.3.0',
+          name: 'test',
+          description: 'test',
+          url: 'https://example.com/a2a',
+          version: '1.0.0',
+          capabilities: {},
+          defaultInputModes: ['text'],
+          defaultOutputModes: ['text'],
+          skills: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    // Default: a synthetic completed task.
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          kind: 'task',
+          id: 't1',
+          contextId: 'c1',
+          status: { state: 'completed', timestamp: new Date().toISOString() },
+          artifacts: [],
+          history: [],
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, calls };
+}
+
+describe('A2XClient — X-A2A-Extensions header (spec §8)', () => {
+  it('omits the header when no extensions are registered', async () => {
+    const { fetch, calls } = recordingFetch();
+    const client = new A2XClient('https://example.com', { fetch });
+    await client.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toBeUndefined();
+  });
+
+  it('emits the header when extensions are passed via constructor', async () => {
+    const { fetch, calls } = recordingFetch();
+    const client = new A2XClient('https://example.com', {
+      fetch,
+      extensions: ['https://example.org/ext-a', 'https://example.org/ext-b'],
+    });
+    await client.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toContain('ext-a');
+    expect(rpcCall.headers['x-a2a-extensions']).toContain('ext-b');
+  });
+
+  it('X402Client auto-registers the x402 extension URI on the inner A2XClient', async () => {
+    const { fetch, calls } = recordingFetch();
+    const inner = new A2XClient('https://example.com', { fetch });
+    new X402Client(inner, { signer: TEST_ACCOUNT });
+    await inner.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toBe(X402_EXTENSION_URI);
+  });
+});
+
+describe('DefaultRequestHandler — extension activation enforcement (spec §3.1 / §8)', () => {
+  function buildHandler(required: boolean): DefaultRequestHandler {
+    const agent = new EchoAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const executor = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const a2x = new A2XAgent({
+      taskStore: new InMemoryTaskStore(),
+      executor,
+      protocolVersion: '0.3',
+    })
+      .setName('x')
+      .setDescription('x')
+      .setDefaultUrl('https://example.com/a2a')
+      .addExtension({ uri: X402_EXTENSION_URI, required });
+    return new DefaultRequestHandler(a2x);
+  }
+
+  const sendBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'message/send',
+    params: {
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hi' }],
+      },
+    },
+  };
+
+  it('rejects the request when a required extension is not activated', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, { headers: {} })) as {
+      error?: { code: number; message: string };
+    };
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe(-32600);
+    expect(result.error!.message).toContain(X402_EXTENSION_URI);
+  });
+
+  it('accepts the request when the required extension is listed in X-A2A-Extensions', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, {
+      headers: { 'x-a2a-extensions': X402_EXTENSION_URI },
+    })) as { result?: unknown; error?: unknown };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('accepts the request when required=false even without the header', async () => {
+    const handler = buildHandler(false);
+    const result = (await handler.handle(sendBody, { headers: {} })) as {
+      result?: unknown;
+      error?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('parses comma-separated extension URIs', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, {
+      headers: {
+        'x-a2a-extensions': `https://example.org/other, ${X402_EXTENSION_URI}`,
+      },
+    })) as { result?: unknown; error?: unknown };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('skips the check entirely when context is not provided (in-process callers)', async () => {
+    const handler = buildHandler(true);
+    // No context → skip spec-header enforcement (matches the auth fallback).
+    const result = (await handler.handle(sendBody)) as {
+      result?: unknown;
+      error?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+});

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -385,6 +385,15 @@ export class A2XAgent {
     return this._securityRequirements;
   }
 
+  /**
+   * Read-only view of declared A2A extensions. Transports use this to
+   * enforce the a2a-x402 v0.2 §8 `X-A2A-Extensions` activation header
+   * check for any extension declared with `required: true`.
+   */
+  get extensions(): readonly AgentExtension[] {
+    return this._capabilities.extensions ?? [];
+  }
+
   get pushNotificationConfigStore(): PushNotificationConfigStore | undefined {
     return this._pushNotificationConfigStore;
   }

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -50,6 +50,17 @@ export interface A2XClientOptions {
   fetch?: typeof globalThis.fetch;
   headers?: Record<string, string>;
   authProvider?: AuthProvider;
+  /**
+   * A2A extension URIs the client wants to activate. Emitted as a
+   * comma-separated `X-A2A-Extensions` HTTP header on every JSON-RPC
+   * request per a2a-x402 v0.2 §8 and the A2A core extension activation
+   * convention.
+   *
+   * You can also register extensions at runtime via `registerExtension()`
+   * — this is how `X402Client` self-activates the x402 extension when
+   * wrapping an `A2XClient`.
+   */
+  extensions?: string[];
 }
 
 // ─── Error Code → Error Class Mapping ───
@@ -119,6 +130,7 @@ export class A2XClient {
   private readonly _fetchImpl: typeof globalThis.fetch;
   private readonly _headers: Record<string, string>;
   private readonly _authProvider?: AuthProvider;
+  private readonly _extensions: Set<string>;
   private _resolved: ResolvedAgentCard | null = null;
   private _parser: ResponseParser | null = null;
   private _endpointUrl: string | null = null;
@@ -133,6 +145,24 @@ export class A2XClient {
     this._fetchImpl = options?.fetch ?? globalThis.fetch;
     this._headers = options?.headers ?? {};
     this._authProvider = options?.authProvider;
+    this._extensions = new Set(options?.extensions ?? []);
+  }
+
+  /**
+   * Register an A2A extension URI to be included in the
+   * `X-A2A-Extensions` header on subsequent requests. Idempotent.
+   *
+   * Used by extension wrappers (e.g. `X402Client`) to self-activate
+   * without requiring the caller to remember to pass `extensions` into
+   * the `A2XClient` constructor.
+   */
+  registerExtension(uri: string): void {
+    this._extensions.add(uri);
+  }
+
+  /** Read-only view of currently activated extension URIs. */
+  get activatedExtensions(): readonly string[] {
+    return [...this._extensions];
   }
 
   // ─── Public Methods ───
@@ -363,11 +393,18 @@ export class A2XClient {
   private _buildHeaders(
     extra?: Record<string, string>,
   ): Record<string, string> {
-    return {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...extra,
       ...this._headers,
     };
+    if (this._extensions.size > 0) {
+      // Spec a2a-x402 v0.2 §8: clients MUST request activation via
+      // `X-A2A-Extensions`. Multiple active extensions are comma-separated
+      // per standard HTTP list-header convention.
+      headers['X-A2A-Extensions'] = [...this._extensions].join(', ');
+    }
+    return headers;
   }
 
   private _buildJsonRpcRequest(

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -139,6 +139,22 @@ export class DefaultRequestHandler {
       }
     }
 
+    // Enforce `required: true` extension activation per spec a2a-x402 v0.2
+    // §3.1 / §8. Clients must list the extension URI in the
+    // `X-A2A-Extensions` header; unactivated clients get a -32600
+    // InvalidRequest. Skipped when no request context is provided
+    // (in-process / test invocations without HTTP framing).
+    if (context) {
+      const activationError = this._validateExtensionActivation(context);
+      if (activationError) {
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          error: activationError.toJSONRPCError(),
+        };
+      }
+    }
+
     // Special-case: authenticated extended card needs authResult; do not
     // route via JsonRpcRouter because that layer has no access to auth.
     if (request.method === A2A_METHODS.GET_EXTENDED_CARD) {
@@ -279,6 +295,32 @@ export class DefaultRequestHandler {
       authenticated: false,
       error: errors.join('; '),
     };
+  }
+
+  /**
+   * Parse the `X-A2A-Extensions` header (comma-separated list) and
+   * validate that every `required: true` extension declared on the
+   * AgentCard is present. Returns an `InvalidRequestError` when any
+   * required extension is missing, `null` on success.
+   *
+   * Spec a2a-x402 v0.2 §3.1 / §8: clients MUST list activated extension
+   * URIs, and agents should reject requests that omit a required one.
+   */
+  private _validateExtensionActivation(
+    context: RequestContext,
+  ): InvalidRequestError | null {
+    const required = this.a2xAgent.extensions.filter((ext) => ext.required);
+    if (required.length === 0) return null;
+
+    const activated = parseActivatedExtensions(context.headers);
+    const missing = required
+      .map((ext) => ext.uri)
+      .filter((uri) => !activated.has(uri));
+
+    if (missing.length === 0) return null;
+    return new InvalidRequestError(
+      `Required A2A extensions not activated. Include these URIs in the X-A2A-Extensions header: ${missing.join(', ')}`,
+    );
   }
 
   // ─── Private: Route Registration ───
@@ -910,4 +952,26 @@ export class DefaultRequestHandler {
       metadata: p.metadata as Record<string, unknown> | undefined,
     };
   }
+}
+
+/**
+ * Parse the `X-A2A-Extensions` header into a set of URIs. Header names
+ * are case-insensitive; values may be comma-separated or repeated. Runs
+ * against the generic `RequestContext.headers` map populated by the
+ * transport adapter (Next.js / Express / etc.).
+ */
+function parseActivatedExtensions(
+  headers: Record<string, string | string[] | undefined>,
+): Set<string> {
+  const activated = new Set<string>();
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() !== 'x-a2a-extensions') continue;
+    const raw = Array.isArray(value) ? value : value ? [value] : [];
+    for (const entry of raw) {
+      for (const uri of entry.split(',').map((s) => s.trim())) {
+        if (uri.length > 0) activated.add(uri);
+      }
+    }
+  }
+  return activated;
 }

--- a/packages/a2x/src/x402/client.ts
+++ b/packages/a2x/src/x402/client.ts
@@ -26,6 +26,7 @@ import type { SendMessageParams } from '../types/jsonrpc.js';
 import type { Task } from '../types/task.js';
 import type { Message } from '../types/common.js';
 import {
+  X402_EXTENSION_URI,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
   type X402PaymentStatus,
@@ -174,7 +175,12 @@ export class X402Client {
   constructor(
     private readonly _client: A2XClient,
     private readonly _options: X402ClientOptions,
-  ) {}
+  ) {
+    // a2a-x402 v0.2 §8: clients MUST activate the extension via the
+    // `X-A2A-Extensions` header. Register on the wrapped A2XClient so
+    // callers don't have to remember to pass `extensions` themselves.
+    this._client.registerExtension(X402_EXTENSION_URI);
+  }
 
   /**
    * Send a message, resolving payment if the merchant asks for it.

--- a/packages/a2x/src/x402/constants.ts
+++ b/packages/a2x/src/x402/constants.ts
@@ -40,19 +40,98 @@ export const X402_PAYMENT_STATUS = {
 export type X402PaymentStatus =
   (typeof X402_PAYMENT_STATUS)[keyof typeof X402_PAYMENT_STATUS];
 
-/** Error codes the SDK may emit via `X402_METADATA_KEYS.ERROR`. */
+/**
+ * Error codes the SDK emits via `X402_METADATA_KEYS.ERROR`.
+ *
+ * The codes from spec §9.1 "Common Error Codes" are wire-identical to the
+ * spec. Additional SDK-specific codes cover failure modes the SDK detects
+ * before or outside the facilitator's purview (payload shape problems,
+ * configuration mismatches) and are documented as proprietary extensions
+ * of §9.1's open list.
+ */
 export const X402_ERROR_CODES = {
-  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  // ─── Spec §9.1 — use these verbatim for wire compatibility ───
+  INSUFFICIENT_FUNDS: 'INSUFFICIENT_FUNDS',
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  EXPIRED_PAYMENT: 'EXPIRED_PAYMENT',
+  DUPLICATE_NONCE: 'DUPLICATE_NONCE',
   NETWORK_MISMATCH: 'NETWORK_MISMATCH',
+  INVALID_AMOUNT: 'INVALID_AMOUNT',
+  SETTLEMENT_FAILED: 'SETTLEMENT_FAILED',
+  // ─── SDK-specific (outside spec §9.1) ───
+  /** Payment payload is missing, unparseable, or structurally invalid. */
+  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  /** Authorization target address does not match the advertised `payTo`. */
   INVALID_PAY_TO: 'INVALID_PAY_TO',
-  AMOUNT_EXCEEDED: 'AMOUNT_EXCEEDED',
+  /**
+   * Fallback for verify failures whose `invalidReason` doesn't map to a
+   * more specific spec §9.1 code. Prefer the specific code when possible.
+   */
   VERIFY_FAILED: 'VERIFY_FAILED',
-  SETTLE_FAILED: 'SETTLE_FAILED',
-  NO_REQUIREMENTS: 'NO_REQUIREMENTS',
 } as const;
 
 export type X402ErrorCode =
   (typeof X402_ERROR_CODES)[keyof typeof X402_ERROR_CODES];
+
+/**
+ * Map a facilitator's `invalidReason` string to a spec §9.1 error code.
+ *
+ * Facilitator implementations (including the Coinbase reference one)
+ * return free-form reason strings that embed the actual failure cause.
+ * We do best-effort substring matching so clients can branch on the
+ * well-known spec codes instead of scraping prose. When no substring
+ * matches, returns `VERIFY_FAILED` so the caller always has something.
+ */
+export function mapVerifyFailureToCode(
+  invalidReason: string | undefined,
+): X402ErrorCode {
+  if (!invalidReason) return X402_ERROR_CODES.VERIFY_FAILED;
+  const reason = invalidReason.toLowerCase();
+  if (
+    reason.includes('insufficient_funds') ||
+    reason.includes('insufficient_balance') ||
+    reason.includes('insufficient-balance')
+  ) {
+    return X402_ERROR_CODES.INSUFFICIENT_FUNDS;
+  }
+  if (
+    reason.includes('nonce_reused') ||
+    reason.includes('duplicate_nonce') ||
+    reason.includes('nonce_used') ||
+    reason.includes('used_nonce')
+  ) {
+    return X402_ERROR_CODES.DUPLICATE_NONCE;
+  }
+  if (
+    reason.includes('expired') ||
+    reason.includes('valid_before') ||
+    reason.includes('validbefore') ||
+    reason.includes('valid_after') ||
+    reason.includes('validafter')
+  ) {
+    return X402_ERROR_CODES.EXPIRED_PAYMENT;
+  }
+  if (
+    reason.includes('invalid_signature') ||
+    reason.includes('signature_invalid') ||
+    reason.includes('bad_signature')
+  ) {
+    return X402_ERROR_CODES.INVALID_SIGNATURE;
+  }
+  if (
+    reason.includes('network_mismatch') ||
+    reason.includes('wrong_network')
+  ) {
+    return X402_ERROR_CODES.NETWORK_MISMATCH;
+  }
+  if (
+    reason.includes('invalid_amount') ||
+    reason.includes('amount_mismatch')
+  ) {
+    return X402_ERROR_CODES.INVALID_AMOUNT;
+  }
+  return X402_ERROR_CODES.VERIFY_FAILED;
+}
 
 /** Default maximum payment completion window per `PaymentRequirements.maxTimeoutSeconds`. */
 export const X402_DEFAULT_TIMEOUT_SECONDS = 300;

--- a/packages/a2x/src/x402/executor.ts
+++ b/packages/a2x/src/x402/executor.ts
@@ -5,6 +5,8 @@
  *  - "payment-submitted" → verify + settle on-chain, then run the inner
  *    executor with the original user content, and attach the settlement
  *    receipt to the response.
+ *  - "payment-rejected" → client declined the requirements; terminate the
+ *    task without re-prompting (spec §5.4.2 + §7.1 rejection transition).
  *  - anything else → respond with a `payment-required` task state carrying
  *    the `X402PaymentRequiredResponse` in message metadata. The task is
  *    left in `input-required` so the client can resume it by resending the
@@ -29,6 +31,7 @@ import {
   X402_DEFAULT_TIMEOUT_SECONDS,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
+  mapVerifyFailureToCode,
   type X402ErrorCode,
 } from './constants.js';
 import { resolveFacilitator, type FacilitatorUrlConfig } from './facilitator.js';
@@ -60,12 +63,24 @@ export interface X402PaymentExecutorOptions {
    * through without charging. Default: always require payment.
    */
   requiresPayment?: (message: Message) => boolean;
+  /**
+   * When true, verify/settle failures re-issue `payment-required` on the
+   * same task (keeping it in `input-required`) with the failure reason
+   * carried in `X402PaymentRequiredResponse.error` per spec §5.1 / §5.3.
+   * When false (default), failures terminate the task with state `failed`.
+   *
+   * Spec §9 explicitly allows either strategy: "the agent could leave the
+   * Task state as working or request a payment requirement with
+   * input-required again."
+   */
+  retryOnFailure?: boolean;
 }
 
 interface ResolvedConfig {
   accepts: X402PaymentRequirements[];
   facilitator: X402Facilitator;
   requiresPayment: (message: Message) => boolean;
+  retryOnFailure: boolean;
 }
 
 export class X402PaymentExecutor extends AgentExecutor {
@@ -85,6 +100,11 @@ export class X402PaymentExecutor extends AgentExecutor {
 
     const status = getPaymentStatus(message);
 
+    if (status === X402_PAYMENT_STATUS.REJECTED) {
+      applyRejectedStatus(task);
+      return task;
+    }
+
     if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
       applyPaymentRequiredStatus(task, this._buildRequirements());
       return task;
@@ -93,7 +113,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const payload = getPaymentPayload(message);
     const authorization = getEvmAuthorization(payload);
     if (!payload || !authorization) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
@@ -105,7 +125,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const accepted = this._matchRequirement(payload);
     const validationErr = validatePayloadAgainstRequirement(payload, accepted);
     if (validationErr) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         validationErr.code,
         validationErr.reason,
@@ -116,22 +136,32 @@ export class X402PaymentExecutor extends AgentExecutor {
 
     const verifyResult = await this._config.facilitator.verify(payload, accepted!);
     if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.VERIFY_FAILED,
+        mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
       );
       return task;
     }
 
+    // Capture receipts on the task BEFORE the inner executor rewrites
+    // `task.status` (which happens in _inner.execute). Without this the
+    // "complete history" guarantee from spec §7 is lost across a retry.
+    const priorReceipts = getExistingReceipts(task);
+
+    // Verified — record the intermediate state per spec §7.1 even though a
+    // blocking execute() doesn't surface it to the client separately.
+    applyVerifiedStatus(task);
+
     const settleResult = await this._config.facilitator.settle(payload, accepted!);
     if (!settleResult.success) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.SETTLE_FAILED,
+        X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        priorReceipts,
       );
       return task;
     }
@@ -143,7 +173,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     };
 
     const result = await this._inner.execute(task, message);
-    attachReceipt(result, receipt);
+    attachCompletedReceipt(result, receipt, priorReceipts);
     return result;
   }
 
@@ -159,20 +189,22 @@ export class X402PaymentExecutor extends AgentExecutor {
     const contextId = task.contextId ?? task.id;
     const status = getPaymentStatus(message);
 
+    if (status === X402_PAYMENT_STATUS.REJECTED) {
+      applyRejectedStatus(task);
+      yield { taskId: task.id, contextId, status: task.status };
+      return;
+    }
+
     if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
       applyPaymentRequiredStatus(task, this._buildRequirements());
-      yield {
-        taskId: task.id,
-        contextId,
-        status: task.status,
-      };
+      yield { taskId: task.id, contextId, status: task.status };
       return;
     }
 
     const payload = getPaymentPayload(message);
     const authorization = getEvmAuthorization(payload);
     if (!payload || !authorization) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
@@ -185,7 +217,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const accepted = this._matchRequirement(payload);
     const validationErr = validatePayloadAgainstRequirement(payload, accepted);
     if (validationErr) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         validationErr.code,
         validationErr.reason,
@@ -195,25 +227,38 @@ export class X402PaymentExecutor extends AgentExecutor {
       return;
     }
 
+    // Capture receipts before verify/settle/inner-stream rewrites
+    // `task.status`. Same reason as the execute() path — preserve the
+    // "complete history" guarantee from spec §7.
+    const priorReceipts = getExistingReceipts(task);
+
     const verifyResult = await this._config.facilitator.verify(payload, accepted!);
     if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.VERIFY_FAILED,
+        mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
+        priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
     }
 
+    // Spec §7.1 lifecycle: SUBMITTED → VERIFIED → COMPLETED. Emit the
+    // intermediate VERIFIED state so streaming clients can surface
+    // "settling on-chain…" progress before the final receipt arrives.
+    applyVerifiedStatus(task);
+    yield { taskId: task.id, contextId, status: task.status };
+
     const settleResult = await this._config.facilitator.settle(payload, accepted!);
     if (!settleResult.success) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.SETTLE_FAILED,
+        X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
@@ -234,7 +279,7 @@ export class X402PaymentExecutor extends AgentExecutor {
       yield event;
     }
 
-    attachReceipt(task, receipt);
+    attachCompletedReceipt(task, receipt, priorReceipts);
     if (lastStatusEvent) {
       yield {
         taskId: task.id,
@@ -250,11 +295,15 @@ export class X402PaymentExecutor extends AgentExecutor {
 
   // ─── Private ───
 
-  private _buildRequirements(): X402PaymentRequiredResponse {
-    return {
+  private _buildRequirements(
+    previousError?: string,
+  ): X402PaymentRequiredResponse {
+    const response: X402PaymentRequiredResponse = {
       x402Version: 1,
       accepts: this._config.accepts,
     };
+    if (previousError) response.error = previousError;
+    return response;
   }
 
   private _matchRequirement(
@@ -263,6 +312,42 @@ export class X402PaymentExecutor extends AgentExecutor {
     return this._config.accepts.find(
       (req) => req.network === payload.network && req.scheme === payload.scheme,
     );
+  }
+
+  /**
+   * Dispatch on `retryOnFailure`: either terminate the task with `failed`
+   * (default, terse) or re-issue `payment-required` with the failure
+   * reason carried in the `error` field (opt-in, allows client retry).
+   *
+   * `explicitPrior` lets the caller pass in receipts captured before a
+   * downstream step (e.g. `_inner.execute`) rewrote `task.status`. When
+   * omitted, prior receipts are read from the current `task.status`.
+   */
+  private _handlePaymentFailure(
+    task: Task,
+    code: X402ErrorCode,
+    reason: string,
+    network: string | undefined,
+    explicitPrior?: X402SettleResponse[],
+  ): void {
+    const receipt: X402SettleResponse = {
+      success: false,
+      transaction: '',
+      network: network ?? 'unknown',
+      errorReason: reason,
+    };
+    const prior = explicitPrior ?? getExistingReceipts(task);
+    if (this._config.retryOnFailure) {
+      applyRetryRequiredStatus(
+        task,
+        this._buildRequirements(reason),
+        receipt,
+        code,
+        prior,
+      );
+    } else {
+      applyFailedPaymentStatus(task, code, reason, receipt, prior);
+    }
   }
 }
 
@@ -278,6 +363,7 @@ function resolveOptions(options: X402PaymentExecutorOptions): ResolvedConfig {
     accepts: options.accepts.map(normalizeAccept),
     facilitator: resolveFacilitator(options.facilitator),
     requiresPayment: options.requiresPayment ?? (() => true),
+    retryOnFailure: options.retryOnFailure ?? false,
   };
 }
 
@@ -306,6 +392,13 @@ function getPaymentPayload(message: Message): X402PaymentPayload | undefined {
   return meta[X402_METADATA_KEYS.PAYLOAD] as X402PaymentPayload | undefined;
 }
 
+/** Read the prior receipts array off the task's status message metadata. */
+function getExistingReceipts(task: Task): X402SettleResponse[] {
+  const meta = (task.status.message?.metadata ?? {}) as Record<string, unknown>;
+  const prior = meta[X402_METADATA_KEYS.RECEIPTS];
+  return Array.isArray(prior) ? (prior as X402SettleResponse[]) : [];
+}
+
 function applyPaymentRequiredStatus(
   task: Task,
   requirements: X402PaymentRequiredResponse,
@@ -325,18 +418,55 @@ function applyPaymentRequiredStatus(
   };
 }
 
+/**
+ * Transition to a transient "verified" state between the facilitator's
+ * verify call and the subsequent settle call. Spec §7.1 state machine
+ * and x402-transport-a2a-v1.md map this to task state `working` with
+ * `x402.payment.status: payment-verified`.
+ */
+function applyVerifiedStatus(task: Task): void {
+  task.status = {
+    state: TaskState.WORKING,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [{ text: 'Payment verified. Settling on-chain…' }],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.VERIFIED,
+      },
+    },
+  };
+}
+
+/**
+ * Terminate the task after the client signalled `payment-rejected`. Spec
+ * §7.1 transition PAYMENT_REQUIRED → PAYMENT_REJECTED; we use task state
+ * `failed` to end the loop (spec doesn't mandate the exact terminal, only
+ * that the loop ends).
+ */
+function applyRejectedStatus(task: Task): void {
+  task.status = {
+    state: TaskState.FAILED,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [{ text: 'Payment was declined by the client.' }],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED,
+      },
+    },
+  };
+}
+
 function applyFailedPaymentStatus(
   task: Task,
   code: X402ErrorCode,
   reason: string,
-  network: string | undefined,
+  receipt: X402SettleResponse,
+  prior: X402SettleResponse[],
 ): void {
-  const receipt: X402SettleResponse = {
-    success: false,
-    transaction: '',
-    network: network ?? 'unknown',
-    errorReason: reason,
-  };
   task.status = {
     state: TaskState.FAILED,
     timestamp: new Date().toISOString(),
@@ -347,13 +477,51 @@ function applyFailedPaymentStatus(
       metadata: {
         [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.FAILED,
         [X402_METADATA_KEYS.ERROR]: code,
-        [X402_METADATA_KEYS.RECEIPTS]: [receipt],
+        [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
       },
     },
   };
 }
 
-function attachReceipt(task: Task, receipt: X402SettleResponse): void {
+/**
+ * Retry variant: instead of terminating, re-publish `payment-required`
+ * on the same task with the failure reason in `error`. Allows the client
+ * to fix the issue (top up wallet, resign with fresh nonce, etc.) and
+ * re-submit without creating a new task.
+ */
+function applyRetryRequiredStatus(
+  task: Task,
+  requirements: X402PaymentRequiredResponse,
+  receipt: X402SettleResponse,
+  code: X402ErrorCode,
+  prior: X402SettleResponse[],
+): void {
+  task.status = {
+    state: TaskState.INPUT_REQUIRED,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [
+        {
+          text: `Payment failed: ${receipt.errorReason ?? 'unknown error'}. Please retry.`,
+        },
+      ],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+        [X402_METADATA_KEYS.REQUIRED]: requirements,
+        [X402_METADATA_KEYS.ERROR]: code,
+        [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
+      },
+    },
+  };
+}
+
+function attachCompletedReceipt(
+  task: Task,
+  receipt: X402SettleResponse,
+  explicitPrior?: X402SettleResponse[],
+): void {
   if (!task.status.message) {
     task.status.message = {
       messageId: `x402-${Date.now()}`,
@@ -363,10 +531,18 @@ function attachReceipt(task: Task, receipt: X402SettleResponse): void {
     };
   }
   const existing = (task.status.message.metadata ?? {}) as Record<string, unknown>;
+  // Prefer caller-supplied prior receipts when available (the caller
+  // captured them before an intermediate step rewrote `task.status`).
+  // Otherwise fall back to whatever is still on the task.
+  const prior =
+    explicitPrior ??
+    (Array.isArray(existing[X402_METADATA_KEYS.RECEIPTS])
+      ? (existing[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[])
+      : []);
   task.status.message.metadata = {
     ...existing,
     [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
-    [X402_METADATA_KEYS.RECEIPTS]: [receipt],
+    [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
   };
 }
 
@@ -420,7 +596,7 @@ function validatePayloadAgainstRequirement(
   try {
     if (BigInt(authorization.value) > BigInt(accepted.maxAmountRequired)) {
       return {
-        code: X402_ERROR_CODES.AMOUNT_EXCEEDED,
+        code: X402_ERROR_CODES.INVALID_AMOUNT,
         reason: `Amount ${authorization.value} exceeds maximum ${accepted.maxAmountRequired}.`,
       };
     }
@@ -438,6 +614,9 @@ export const __internal = {
   normalizeAccept,
   validatePayloadAgainstRequirement,
   applyPaymentRequiredStatus,
+  applyVerifiedStatus,
+  applyRejectedStatus,
   applyFailedPaymentStatus,
-  attachReceipt,
+  applyRetryRequiredStatus,
+  attachCompletedReceipt,
 };

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -48,6 +48,7 @@ export {
   X402_ERROR_CODES,
   X402_DEFAULT_TIMEOUT_SECONDS,
   X402_DEFAULT_RESOURCE,
+  mapVerifyFailureToCode,
   type X402PaymentStatus,
   type X402ErrorCode,
 } from './constants.js';


### PR DESCRIPTION
Closes #92.

## Summary

Follow-up to #72. Spec audit of the merged Standalone Flow turned up one **MUST** violation (§8 activation header) and five spec-drift gaps. This PR lands all of them together so the SDK interoperates with spec-strict x402 clients and servers.

## What's fixed

### 1. `X-A2A-Extensions` activation header (§8 MUST)

Clients MUST activate the extension via this HTTP header. Previously absent on both sides of the wire.

- **Client.** New `A2XClientOptions.extensions?: string[]`, new `registerExtension(uri)` method, new `activatedExtensions` getter. `A2XClient._buildHeaders()` emits a comma-separated `X-A2A-Extensions` when any extensions are registered. `X402Client` constructor auto-registers `X402_EXTENSION_URI` on its wrapped `A2XClient` so existing call sites get the header for free.
- **Server.** New `A2XAgent.extensions` read-only getter. `DefaultRequestHandler._validateExtensionActivation()` rejects requests whose header doesn't list every `required: true` extension (error `-32600`). Enforcement only runs when `RequestContext` is supplied — in-process callers without HTTP framing are unaffected.

### 2. Error code names match spec §9.1

**Breaking renames.** Spec §9.1 defines canonical code names; the SDK was emitting non-spec strings that spec-strict clients pattern-matching on the wire won't recognise.

- `SETTLE_FAILED` → `SETTLEMENT_FAILED`
- `AMOUNT_EXCEEDED` → `INVALID_AMOUNT`

Also removed the unused `NO_REQUIREMENTS` constant.

**New — spec §9.1 code dispatch.** Verify failures run through `mapVerifyFailureToCode(invalidReason)` which parses the facilitator's reason string and returns one of `INSUFFICIENT_FUNDS`, `INVALID_SIGNATURE`, `EXPIRED_PAYMENT`, `DUPLICATE_NONCE`, or `VERIFY_FAILED` (fallback only when no spec code applies). Clients can now implement per-cause UX instead of collapsing every verify failure into `VERIFY_FAILED`.

### 3. `payment-verified` transient state (§7.1)

Spec §7.1 lifecycle is `SUBMITTED → VERIFIED → COMPLETED`. SDK was skipping VERIFIED; streaming clients couldn't show "settling on-chain…" progress.

The executor now emits `working + x402.payment.status: payment-verified` between the facilitator's verify and settle calls in `executeStream()`. `execute()` records the state on `task.status` too (not observable mid-call for blocking callers, but correct for any downstream observer reading the task after the fact).

### 4. `x402.payment.receipts` preserves complete history (§7)

Spec §7: receipts is a "persistent array containing the complete history of all x402SettleResponse objects for the task." Previous implementation overwrote it on every write.

Fixed by capturing `priorReceipts` **before** any step that rewrites `task.status` (facilitator verify/settle, inner executor) and threading that into every status helper. Verified by a new test that seeds a failure receipt on the task and confirms it's still present after a retry completes.

### 5. `payment-rejected` handling (§5.4.2, §7.1)

Spec §5.4.2 / §7.1 transition: client can respond with `x402.payment.status: payment-rejected` to decline. Previously unrecognised — the executor looped back to `payment-required` instead of terminating.

New `REJECTED` branch in both `execute()` and `executeStream()` transitions the task to `failed + payment-rejected`. The loop ends.

### 6. `retryOnFailure` option (§5.1 error field, §9 retry branch)

Spec §9 explicitly allows the merchant to re-issue `payment-required` with `X402PaymentRequiredResponse.error` populated, instead of terminating on failure. Field was declared but unused.

New `X402PaymentExecutorOptions.retryOnFailure: boolean` (default `false`). When `true`, verify/settle failures re-publish `payment-required` on the same task with the failure reason in `error`, letting the client fix the issue (top up wallet, refresh nonce) and resubmit without starting a new task. Default behaviour is unchanged.

## New test coverage

Added 16 new tests across two files:

- `x402-extension-activation.test.ts` (8): client header emission, `X402Client` auto-registration, server enforcement for `required: true`, comma-separated parsing, opt-out via `required: false`, skip when no `RequestContext`.
- `x402-executor.test.ts` (8): `invalidReason` dispatch into `DUPLICATE_NONCE` / `INSUFFICIENT_FUNDS` / `VERIFY_FAILED` fallback; `SETTLEMENT_FAILED` rename; `INVALID_AMOUNT` rename; `payment-rejected` in both `execute()` and `executeStream()`; prior-receipt preservation across retries; `retryOnFailure` round-trip; `payment-verified` emission order between submitted and completed.

## Docs

`docs/guides/advanced/x402-payments.md` gets:

- Full error code table (spec §9.1 codes + SDK-specific ones) with source columns.
- Payment lifecycle diagram showing all spec §7.1 transitions.
- `retryOnFailure` section.
- `payment-rejected` section.
- Extension activation section (client auto-injection, server enforcement).

Changeset: minor bump on `@a2x/sdk` documenting the breaking error-code renames.

## Verification

- `pnpm test` — 425 tests passing (16 new).
- `pnpm typecheck` — clean across all workspace packages.
- `pnpm lint` — clean (one pre-existing warning unrelated to this PR).
- `pnpm -r build` — clean.

## Breaking changes summary

Only one wire-level break: consumers reading or matching on `x402.payment.error` string values. Rename mapping:

| Old | New |
|---|---|
| `SETTLE_FAILED` | `SETTLEMENT_FAILED` |
| `AMOUNT_EXCEEDED` | `INVALID_AMOUNT` |

No TypeScript-level breaks beyond the above (new options and exports are additive; `retryOnFailure` defaults to `false`).

## Test plan

- [ ] `pnpm install && pnpm test && pnpm typecheck && pnpm lint && pnpm -r build` locally.
- [ ] Run `samples/nextjs-x402` with `X402_MOCK_FACILITATOR=1` + CLI `a2a send` → task completes; on a stream, a `payment-verified` status event is observable between submitted and completed.
- [ ] Probe the sample with `curl -X POST` without `X-A2A-Extensions` and confirm the server rejects with `-32600 Invalid Request`.
- [ ] Probe same endpoint with `X-A2A-Extensions: <x402-uri>` and confirm it accepts.
