### PR TITLE
fix(sdk): return HTTP 401 for auth failures, enable client token refresh

### DIFF
--- a/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
+++ b/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
@@ -78,11 +78,11 @@ function createHandler(options: HandlerBuildOptions = {}): DefaultRequestHandler
   return new DefaultRequestHandler(a2xAgent);
 }
 
-function isAsyncGenerator(value: unknown): value is AsyncGenerator {
+function isAsyncGeneratorBody(result: { body: unknown }): boolean {
   return (
-    value !== null &&
-    typeof value === 'object' &&
-    Symbol.asyncIterator in (value as object)
+    result.body !== null &&
+    typeof result.body === 'object' &&
+    Symbol.asyncIterator in (result.body as object)
   );
 }
 
@@ -106,10 +106,10 @@ describe('agent/getAuthenticatedExtendedCard', () => {
   it('returns AuthenticatedExtendedCardNotConfiguredError when no provider is registered', async () => {
     const handler = createHandler({ withAuth: true });
 
-    const response = await handler.handle(extendedCardRequest, validContext);
+    const result = await handler.handle(extendedCardRequest, validContext);
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('error' in rpc).toBe(true);
     expect((rpc as JSONRPCErrorResponse).error.code).toBe(
       A2A_ERROR_CODES.AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED,
@@ -124,12 +124,12 @@ describe('agent/getAuthenticatedExtendedCard', () => {
 
     // Missing API key — auth will fail and the pre-dispatch block returns
     // AUTHENTICATION_REQUIRED before the special-case branch runs.
-    const response = await handler.handle(extendedCardRequest, {
+    const result = await handler.handle(extendedCardRequest, {
       headers: {},
     });
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('error' in rpc).toBe(true);
     expect((rpc as JSONRPCErrorResponse).error.code).toBe(
       A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
@@ -145,10 +145,10 @@ describe('agent/getAuthenticatedExtendedCard', () => {
       withProvider: () => ({ description: 'Extended' }),
     });
 
-    const response = await handler.handle(extendedCardRequest);
+    const result = await handler.handle(extendedCardRequest);
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('error' in rpc).toBe(true);
     expect((rpc as JSONRPCErrorResponse).error.code).toBe(
       A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
@@ -172,10 +172,10 @@ describe('agent/getAuthenticatedExtendedCard', () => {
       }),
     });
 
-    const response = await handler.handle(extendedCardRequest, validContext);
+    const result = await handler.handle(extendedCardRequest, validContext);
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('result' in rpc).toBe(true);
     const card = (rpc as { result: unknown }).result as AgentCardV03;
 
@@ -203,10 +203,10 @@ describe('agent/getAuthenticatedExtendedCard', () => {
       }),
     });
 
-    const response = await handler.handle(extendedCardRequest, validContext);
+    const result = await handler.handle(extendedCardRequest, validContext);
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('result' in rpc).toBe(true);
     const card = (rpc as { result: unknown }).result as AgentCardV10;
 
@@ -227,10 +227,10 @@ describe('agent/getAuthenticatedExtendedCard', () => {
       },
     });
 
-    const response = await handler.handle(extendedCardRequest, validContext);
+    const result = await handler.handle(extendedCardRequest, validContext);
 
-    expect(isAsyncGenerator(response)).toBe(false);
-    const rpc = response as JSONRPCResponse;
+    expect(isAsyncGeneratorBody(result)).toBe(false);
+    const rpc = result.body as JSONRPCResponse;
     expect('result' in rpc).toBe(true);
 
     expect(captured).toBeDefined();

--- a/packages/a2x/src/__tests__/client-auth.test.ts
+++ b/packages/a2x/src/__tests__/client-auth.test.ts
@@ -15,6 +15,7 @@ import type { AuthProvider } from '../client/auth-provider.js';
 import type { AgentCardV10 } from '../types/agent-card.js';
 import type { SecuritySchemeV03, SecuritySchemeV10 } from '../types/security.js';
 import { TaskState } from '../types/task.js';
+import { A2A_ERROR_CODES, AuthenticationRequiredError } from '../types/errors.js';
 
 // ─── Test Fixtures ───
 
@@ -709,5 +710,122 @@ describe('A2XClient auth integration', () => {
         message: { role: 'user', parts: [{ text: 'Hello' }] },
       }),
     ).rejects.toThrow('Auth required');
+  });
+
+  it('JSON-RPC -32008 fallback triggers refresh and retries successfully', async () => {
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: HTTP 200 but JSON-RPC auth error
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () =>
+            Promise.resolve({
+              jsonrpc: '2.0',
+              id: 1,
+              error: {
+                code: A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+                message: 'Token expired',
+              },
+            }),
+          headers: new Headers({ 'content-type': 'application/json' }),
+        });
+      }
+      // Second call: success
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve(createJsonRpcSuccess(TASK_RESULT)),
+        headers: new Headers({ 'content-type': 'application/json' }),
+      });
+    });
+
+    const refresh = vi.fn().mockImplementation(async (schemes: AuthScheme[]) => {
+      for (const scheme of schemes) {
+        if (scheme instanceof ApiKeyAuthScheme) {
+          scheme.setCredential('refreshed-key');
+        }
+      }
+      return schemes;
+    });
+
+    const authProvider: AuthProvider = {
+      async provide(requirements) {
+        for (const group of requirements) {
+          if (group[0] instanceof ApiKeyAuthScheme) {
+            return [group[0].setCredential('old-key')];
+          }
+        }
+        throw new Error('No supported scheme');
+      },
+      refresh,
+    };
+
+    const client = new A2XClient(V10_CARD_WITH_AUTH, {
+      fetch: mockFetch,
+      authProvider,
+    });
+
+    const result = await client.sendMessage({
+      message: { role: 'user', parts: [{ text: 'Hello' }] },
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.id).toBe(TASK_RESULT.id);
+    // Second call should have the refreshed key
+    const secondCallHeaders = mockFetch.mock.calls[1][1].headers;
+    expect(secondCallHeaders['x-api-key']).toBe('refreshed-key');
+  });
+
+  it('JSON-RPC -32008 fallback does not retry more than once', async () => {
+    const mockFetch = vi.fn().mockImplementation(() => {
+      // Always return HTTP 200 with JSON-RPC auth error
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve({
+            jsonrpc: '2.0',
+            id: 1,
+            error: {
+              code: A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+              message: 'Still expired',
+            },
+          }),
+        headers: new Headers({ 'content-type': 'application/json' }),
+      });
+    });
+
+    const refresh = vi.fn().mockImplementation(async (schemes: AuthScheme[]) => {
+      return schemes;
+    });
+
+    const authProvider: AuthProvider = {
+      async provide(requirements) {
+        return [requirements[0][0].setCredential('key')];
+      },
+      refresh,
+    };
+
+    const client = new A2XClient(V10_CARD_WITH_AUTH, {
+      fetch: mockFetch,
+      authProvider,
+    });
+
+    await expect(
+      client.sendMessage({
+        message: { role: 'user', parts: [{ text: 'Hello' }] },
+      }),
+    ).rejects.toThrow(AuthenticationRequiredError);
+
+    // Once for initial, once for retry — no more
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DefaultRequestHandler } from '../transport/request-handler.js';
+import { DefaultRequestHandler, getHttpStatus, getHttpHeaders } from '../transport/request-handler.js';
 import { A2XAgent } from '../a2x/a2x-agent.js';
 import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
@@ -76,11 +76,11 @@ function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
   return { handler: new DefaultRequestHandler(a2xAgent), pushStore };
 }
 
-function isAsyncGenerator(value: unknown): value is AsyncGenerator {
+function isAsyncGeneratorBody(body: unknown): body is AsyncGenerator {
   return (
-    value !== null &&
-    typeof value === 'object' &&
-    Symbol.asyncIterator in (value as object)
+    body !== null &&
+    typeof body === 'object' &&
+    Symbol.asyncIterator in (body as object)
   );
 }
 
@@ -88,10 +88,10 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('JSON-RPC error handling', () => {
     it('should return parse error for invalid JSON string', async () => {
       const handler = createHandler();
-      const response = await handler.handle('not json');
+      const result = await handler.handle('not json');
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect(rpc.jsonrpc).toBe('2.0');
       expect(rpc.id).toBeNull();
       expect('error' in rpc).toBe(true);
@@ -102,14 +102,14 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
     it('should return invalid request for missing jsonrpc version', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '1.0' as '2.0',
         id: 1,
         method: 'test',
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.INVALID_REQUEST,
@@ -118,14 +118,14 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
     it('should return method not found for unknown method', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'unknown/method',
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.METHOD_NOT_FOUND,
@@ -136,7 +136,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('message/send', () => {
     it('should process a message and return a task', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -149,8 +149,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
       const task = (rpc as { result: unknown }).result as { id: string; status: { state: string } };
       expect(task.id).toBeDefined();
@@ -160,15 +160,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
     it('should return invalid params when message is missing', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
         params: {},
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.INVALID_PARAMS,
@@ -179,7 +179,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('message/send - v0.3 response format', () => {
     it('should include kind discriminators in v0.3 mode', async () => {
       const handler = createHandler('0.3');
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -192,8 +192,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
       const task = (rpc as { result: unknown }).result as Record<string, unknown>;
 
@@ -216,7 +216,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
     it('should default artifact name to "response" in v0.3 mode', async () => {
       const handler = createHandler('0.3');
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -229,7 +229,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      const rpc = response as JSONRPCResponse;
+      const rpc = result.body as JSONRPCResponse;
       const task = (rpc as { result: unknown }).result as Record<string, unknown>;
       const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
 
@@ -245,7 +245,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('message/send - v1.0 response format', () => {
     it('should NOT include kind discriminators in v1.0 mode', async () => {
       const handler = createHandler('1.0');
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -258,8 +258,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
       const task = (rpc as { result: unknown }).result as Record<string, unknown>;
 
@@ -277,15 +277,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('tasks/get', () => {
     it('should return task not found for non-existent task', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/get',
         params: { id: 'non-existent' },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -296,7 +296,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const handler = createHandler();
 
       // Create a task first
-      const sendResponse = await handler.handle({
+      const sendResult = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -309,18 +309,18 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      const task = ((sendResponse as JSONRPCResponse) as { result: unknown }).result as { id: string };
+      const task = ((sendResult.body as JSONRPCResponse) as { result: unknown }).result as { id: string };
 
       // Get the task
-      const getResponse = await handler.handle({
+      const getResult = await handler.handle({
         jsonrpc: '2.0',
         id: 2,
         method: 'tasks/get',
         params: { id: task.id },
       });
 
-      expect(isAsyncGenerator(getResponse)).toBe(false);
-      const rpc = getResponse as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(getResult.body)).toBe(false);
+      const rpc = getResult.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
       const retrieved = (rpc as { result: unknown }).result as { id: string };
       expect(retrieved.id).toBe(task.id);
@@ -330,7 +330,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const handler = createHandler('1.0');
 
       // Create a task
-      const sendResponse = await handler.handle({
+      const sendResult = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -343,17 +343,17 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      const task = ((sendResponse as JSONRPCResponse) as { result: unknown }).result as { id: string };
+      const task = ((sendResult.body as JSONRPCResponse) as { result: unknown }).result as { id: string };
 
       // Get the task
-      const getResponse = await handler.handle({
+      const getResult = await handler.handle({
         jsonrpc: '2.0',
         id: 2,
         method: 'tasks/get',
         params: { id: task.id },
       });
 
-      const rpc = getResponse as JSONRPCResponse;
+      const rpc = getResult.body as JSONRPCResponse;
       const retrieved = (rpc as { result: unknown }).result as Record<string, unknown>;
 
       // v1.0: no kind, UPPER_SNAKE_CASE state
@@ -365,7 +365,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const handler = createHandler('0.3');
 
       // Create a task
-      const sendResponse = await handler.handle({
+      const sendResult = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
@@ -378,17 +378,17 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      const task = ((sendResponse as JSONRPCResponse) as { result: unknown }).result as { id: string };
+      const task = ((sendResult.body as JSONRPCResponse) as { result: unknown }).result as { id: string };
 
       // Get the task
-      const getResponse = await handler.handle({
+      const getResult = await handler.handle({
         jsonrpc: '2.0',
         id: 2,
         method: 'tasks/get',
         params: { id: task.id },
       });
 
-      const rpc = getResponse as JSONRPCResponse;
+      const rpc = getResult.body as JSONRPCResponse;
       const retrieved = (rpc as { result: unknown }).result as Record<string, unknown>;
 
       // v0.3: has kind, lowercase state
@@ -400,15 +400,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('tasks/cancel', () => {
     it('should return task not found for non-existent task', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/cancel',
         params: { id: 'non-existent' },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -442,15 +442,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       // Cancel the WORKING task — this should NOT throw InternalError
       // Before fix: cancel() mutated task to CANCELED, then updateTask()
       // hit the terminal state guard and threw "Cannot update task in terminal state"
-      const cancelResponse = await handler.handle({
+      const cancelResult = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/cancel',
         params: { id: task.id },
       });
 
-      expect(isAsyncGenerator(cancelResponse)).toBe(false);
-      const rpc = cancelResponse as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(cancelResult.body)).toBe(false);
+      const rpc = cancelResult.body as JSONRPCResponse;
       expect('error' in rpc).toBe(false);
       expect('result' in rpc).toBe(true);
     });
@@ -472,10 +472,10 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(result)).toBe(true);
+      expect(isAsyncGeneratorBody(result.body)).toBe(true);
 
       // Consume the async generator and collect events
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const generator = result.body as AsyncGenerator<Record<string, unknown>>;
       const events: unknown[] = [];
 
       for await (const event of generator) {
@@ -515,9 +515,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(result)).toBe(true);
+      expect(isAsyncGeneratorBody(result.body)).toBe(true);
 
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const generator = result.body as AsyncGenerator<Record<string, unknown>>;
       const events: Record<string, unknown>[] = [];
 
       for await (const event of generator) {
@@ -560,9 +560,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(result)).toBe(true);
+      expect(isAsyncGeneratorBody(result.body)).toBe(true);
 
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const generator = result.body as AsyncGenerator<Record<string, unknown>>;
       const events: Record<string, unknown>[] = [];
 
       for await (const event of generator) {
@@ -634,9 +634,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
       });
 
       // No context → no auth check → should proceed
-      const response = await handler.handle(validRequest);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
     });
 
@@ -654,9 +654,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const context: RequestContext = {
         headers: { 'x-api-key': 'secret-123' },
       };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
     });
 
@@ -674,9 +674,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const context: RequestContext = {
         headers: { 'x-api-key': 'wrong-key' },
       };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
@@ -695,9 +695,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
       });
 
       const context: RequestContext = { headers: {} };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
@@ -731,9 +731,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
           authorization: 'Bearer valid-token',
         },
       };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
     });
 
@@ -763,9 +763,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
           authorization: 'Bearer wrong-token',
         },
       };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
@@ -783,25 +783,76 @@ describe('Layer 4: DefaultRequestHandler', () => {
       });
 
       const context: RequestContext = { headers: {} };
-      const response = await handler.handle(validRequest, context);
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      const result = await handler.handle(validRequest, context);
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
+    });
+
+    it('should return HTTP 401 status for auth failures', async () => {
+      const handler = createAuthHandler((agent) => {
+        agent
+          .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+            in: 'header',
+            name: 'x-api-key',
+            keys: ['secret-123'],
+          }))
+          .addSecurityRequirement({ apiKey: [] });
+      });
+
+      const context: RequestContext = {
+        headers: { 'x-api-key': 'wrong-key' },
+      };
+      const result = await handler.handle(validRequest, context);
+      expect(result.http?.status).toBe(401);
+      expect(result.http?.headers?.['WWW-Authenticate']).toBe('Bearer');
+      const rpc = result.body as JSONRPCErrorResponse;
+      expect(rpc.error.code).toBe(A2A_ERROR_CODES.AUTHENTICATION_REQUIRED);
+    });
+
+    it('should not include HTTP metadata for non-auth errors', async () => {
+      const handler = createHandler();
+      const result = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'unknown/method',
+      });
+
+      expect(result.http).toBeUndefined();
+      expect(getHttpStatus(result)).toBe(200);
+    });
+
+    it('should not include HTTP metadata for successful responses', async () => {
+      const handler = createHandler();
+      const result = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+        },
+      });
+
+      expect(result.http).toBeUndefined();
     });
   });
 
   describe('tasks/pushNotificationConfig/delete', () => {
     it('should return PushNotificationNotSupported when no store configured', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/pushNotificationConfig/delete',
         params: { taskId: 'task-1', id: 'config-1' },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
@@ -821,15 +872,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
         };
         await pushStore.set(config);
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { taskId: 'task-1', id: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toBeNull();
 
@@ -840,15 +891,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return TaskNotFound when config does not exist', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { taskId: 'task-1', id: 'non-existent' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -858,15 +909,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when taskId is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { id: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -876,15 +927,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when id is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { taskId: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -905,15 +956,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
         };
         await pushStore.set(config);
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toBeNull();
 
@@ -924,15 +975,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return TaskNotFound when config does not exist', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { id: 'task-1', pushNotificationConfigId: 'non-existent' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -942,15 +993,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when id (task ID) is missing', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { pushNotificationConfigId: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -960,15 +1011,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when pushNotificationConfigId is missing', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/delete',
           params: { id: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -980,7 +1031,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('tasks/pushNotificationConfig/set', () => {
     it('should return PushNotificationNotSupported when no store configured', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/pushNotificationConfig/set',
@@ -993,8 +1044,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
         },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
@@ -1005,7 +1056,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should store a new config and return the v0.3 nested shape', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1019,8 +1070,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({
           taskId: 'task-1',
@@ -1045,7 +1096,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should auto-generate pushNotificationConfig.id when client omits it', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1055,11 +1106,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
-        const generatedId = result.pushNotificationConfig.id;
+        const rpcResult = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
+        const generatedId = rpcResult.pushNotificationConfig.id;
         expect(typeof generatedId).toBe('string');
         expect(generatedId).not.toEqual('');
 
@@ -1071,7 +1122,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should treat empty-string pushNotificationConfig.id as absent and auto-generate', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1081,11 +1132,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
-        const generatedId = result.pushNotificationConfig.id;
+        const rpcResult = (rpc as { result: { pushNotificationConfig: { id?: string } } }).result;
+        const generatedId = rpcResult.pushNotificationConfig.id;
         expect(typeof generatedId).toBe('string');
         expect(generatedId).not.toEqual('');
 
@@ -1098,7 +1149,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should store a new config and return the v1.0 flattened shape', async () => {
         const { handler, pushStore } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1112,8 +1163,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({
           id: 'config-1',
@@ -1138,15 +1189,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when params is not an object', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
           params: 'not-an-object',
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1156,7 +1207,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when taskId is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1168,8 +1219,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1179,15 +1230,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when pushNotificationConfig is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
           params: { taskId: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1197,7 +1248,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when pushNotificationConfig.url is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1207,8 +1258,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1218,7 +1269,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when authentication.schemes is empty', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1232,8 +1283,8 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1243,7 +1294,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should accept valid authentication info', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/set',
@@ -1257,11 +1308,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: { authentication: unknown } }).result;
-        expect(result.authentication).toEqual({ schemes: ['Bearer'], credentials: 'abc123' });
+        const rpcResult = (rpc as { result: { authentication: unknown } }).result;
+        expect(rpcResult.authentication).toEqual({ schemes: ['Bearer'], credentials: 'abc123' });
       });
     });
   });
@@ -1269,15 +1320,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('tasks/pushNotificationConfig/get', () => {
     it('should return PushNotificationNotSupported when no store configured', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/pushNotificationConfig/get',
         params: { taskId: 'task-1', id: 'config-1' },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
@@ -1298,15 +1349,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
         };
         await pushStore.set(config);
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { taskId: 'task-1', id: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({
           id: 'config-1',
@@ -1319,15 +1370,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return TaskNotFound when config does not exist', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { taskId: 'task-1', id: 'non-existent' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -1337,15 +1388,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when taskId is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { id: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1355,15 +1406,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when id is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { taskId: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1384,15 +1435,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
         };
         await pushStore.set(config);
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { id: 'task-1', pushNotificationConfigId: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({
           taskId: 'task-1',
@@ -1406,15 +1457,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return TaskNotFound when config does not exist', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { id: 'task-1', pushNotificationConfigId: 'nope' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -1424,15 +1475,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when id (task ID) is missing', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { pushNotificationConfigId: 'config-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1451,15 +1502,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
         };
         await pushStore.set(first);
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { id: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({
           taskId: 'task-1',
@@ -1473,15 +1524,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return TaskNotFound when pushNotificationConfigId is omitted and no configs exist', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/get',
           params: { id: 'task-without-configs' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.TASK_NOT_FOUND,
@@ -1493,15 +1544,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('tasks/pushNotificationConfig/list', () => {
     it('should return PushNotificationNotSupported when no store configured', async () => {
       const handler = createHandler();
-      const response = await handler.handle({
+      const result = await handler.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'tasks/pushNotificationConfig/list',
         params: { taskId: 'task-1' },
       });
 
-      expect(isAsyncGenerator(response)).toBe(false);
-      const rpc = response as JSONRPCResponse;
+      expect(isAsyncGeneratorBody(result.body)).toBe(false);
+      const rpc = result.body as JSONRPCResponse;
       expect('error' in rpc).toBe(true);
       expect((rpc as JSONRPCErrorResponse).error.code).toBe(
         A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
@@ -1527,21 +1578,21 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: { taskId: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
-        expect(result.nextPageToken).toBe('');
-        expect(Array.isArray(result.configs)).toBe(true);
-        expect(result.configs).toHaveLength(2);
-        expect(result.configs).toEqual(
+        const rpcResult = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
+        expect(rpcResult.nextPageToken).toBe('');
+        expect(Array.isArray(rpcResult.configs)).toBe(true);
+        expect(rpcResult.configs).toHaveLength(2);
+        expect(rpcResult.configs).toEqual(
           expect.arrayContaining([
             {
               id: 'config-1',
@@ -1560,15 +1611,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return { configs: [], nextPageToken: "" } when no configs exist', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: { taskId: 'unknown-task' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({ configs: [], nextPageToken: '' });
       });
@@ -1581,33 +1632,33 @@ describe('Layer 4: DefaultRequestHandler', () => {
           pushNotificationConfig: { id: 'config-1', url: 'https://example.com/webhook' },
         });
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: { taskId: 'task-1', pageSize: 10, pageToken: 'ignored' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
-        expect(result.configs).toHaveLength(1);
-        expect(result.nextPageToken).toBe('');
+        const rpcResult = (rpc as { result: { configs: unknown[]; nextPageToken: string } }).result;
+        expect(rpcResult.configs).toHaveLength(1);
+        expect(rpcResult.nextPageToken).toBe('');
       });
 
       it('should return InvalidParams when taskId is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: {},
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,
@@ -1627,20 +1678,20 @@ describe('Layer 4: DefaultRequestHandler', () => {
           },
         });
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: { id: 'task-1' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
-        const result = (rpc as { result: unknown }).result as unknown[];
-        expect(Array.isArray(result)).toBe(true);
-        expect(result).toHaveLength(1);
-        expect(result[0]).toEqual({
+        const rpcResult = (rpc as { result: unknown }).result as unknown[];
+        expect(Array.isArray(rpcResult)).toBe(true);
+        expect(rpcResult).toHaveLength(1);
+        expect(rpcResult[0]).toEqual({
           taskId: 'task-1',
           pushNotificationConfig: {
             id: 'config-1',
@@ -1652,15 +1703,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return an empty bare array when no configs exist', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: { id: 'unknown-task' },
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual([]);
       });
@@ -1668,15 +1719,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
       it('should return InvalidParams when id is missing', async () => {
         const { handler } = createHandlerWithPushNotification('0.3');
 
-        const response = await handler.handle({
+        const result = await handler.handle({
           jsonrpc: '2.0',
           id: 1,
           method: 'tasks/pushNotificationConfig/list',
           params: {},
         });
 
-        expect(isAsyncGenerator(response)).toBe(false);
-        const rpc = response as JSONRPCResponse;
+        expect(isAsyncGeneratorBody(result.body)).toBe(false);
+        const rpc = result.body as JSONRPCResponse;
         expect('error' in rpc).toBe(true);
         expect((rpc as JSONRPCErrorResponse).error.code).toBe(
           A2A_ERROR_CODES.INVALID_PARAMS,

--- a/packages/a2x/src/__tests__/task-resubscribe.test.ts
+++ b/packages/a2x/src/__tests__/task-resubscribe.test.ts
@@ -62,16 +62,16 @@ describe('tasks/resubscribe', () => {
       params: { id: 'nonexistent' },
     });
 
-    // Stream handlers return an AsyncGenerator; the TaskNotFoundError is
-    // thrown from within the generator when iteration starts.
+    // Stream handlers return an AsyncGenerator in result.body; the
+    // TaskNotFoundError is thrown from within the generator when iteration starts.
     expect(result).toBeDefined();
     expect(
-      result !== null &&
-        typeof result === 'object' &&
-        Symbol.asyncIterator in (result as object),
+      result.body !== null &&
+        typeof result.body === 'object' &&
+        Symbol.asyncIterator in (result.body as object),
     ).toBe(true);
 
-    const generator = result as AsyncGenerator<unknown>;
+    const generator = result.body as AsyncGenerator<unknown>;
     await expect(async () => {
       for await (const _ of generator) {
         // drain
@@ -98,7 +98,7 @@ describe('tasks/resubscribe', () => {
       params: { id: task.id },
     });
 
-    const generator = result as AsyncGenerator<Record<string, unknown>>;
+    const generator = result.body as AsyncGenerator<Record<string, unknown>>;
     const events: Record<string, unknown>[] = [];
     for await (const event of generator) {
       events.push(event);
@@ -136,7 +136,7 @@ describe('tasks/resubscribe', () => {
     const resubEvents: Record<string, unknown>[] = [];
     let taskId: string | undefined;
 
-    const originalIter = streamResult as AsyncGenerator<Record<string, unknown>>;
+    const originalIter = streamResult.body as AsyncGenerator<Record<string, unknown>>;
 
     const originalConsumer = (async () => {
       for await (const event of originalIter) {
@@ -161,7 +161,7 @@ describe('tasks/resubscribe', () => {
       method: 'tasks/resubscribe',
       params: { id: taskId! },
     });
-    const resubIter = resubResult as AsyncGenerator<Record<string, unknown>>;
+    const resubIter = resubResult.body as AsyncGenerator<Record<string, unknown>>;
 
     const resubConsumer = (async () => {
       for await (const event of resubIter) {
@@ -200,7 +200,7 @@ describe('tasks/resubscribe', () => {
       },
     });
 
-    const originalIter = streamResult as AsyncGenerator<Record<string, unknown>>;
+    const originalIter = streamResult.body as AsyncGenerator<Record<string, unknown>>;
     const originalEvents: Record<string, unknown>[] = [];
     let taskId: string | undefined;
 
@@ -222,7 +222,7 @@ describe('tasks/resubscribe', () => {
       method: 'tasks/resubscribe',
       params: { id: taskId! },
     });
-    const resubIter = resubResult as AsyncGenerator<Record<string, unknown>>;
+    const resubIter = resubResult.body as AsyncGenerator<Record<string, unknown>>;
 
     // Consume both streams; after the primary stream ends, the resubscriber
     // must also end (done: true).

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -123,6 +123,7 @@ export class A2XClient {
   private _parser: ResponseParser | null = null;
   private _endpointUrl: string | null = null;
   private _resolvedSchemes?: AuthScheme[];
+  private _streamAuthRetried = false;
   private _requestId = 0;
 
   constructor(
@@ -180,6 +181,25 @@ export class A2XClient {
       signal,
     });
 
+    // Token refresh on HTTP 401 (streaming path)
+    if (
+      !this._streamAuthRetried &&
+      response.status === 401 &&
+      this._authProvider?.refresh &&
+      this._resolvedSchemes
+    ) {
+      this._streamAuthRetried = true;
+      try {
+        this._resolvedSchemes = await this._authProvider.refresh(
+          this._resolvedSchemes,
+        );
+        yield* this.sendMessageStream(params, signal);
+      } finally {
+        this._streamAuthRetried = false;
+      }
+      return;
+    }
+
     if (!response.ok) {
       throw new InternalError(
         `HTTP ${response.status}: ${response.statusText}`,
@@ -193,6 +213,26 @@ export class A2XClient {
       const jsonRpcResponse = (await response.json()) as JSONRPCResponse;
       if ('error' in jsonRpcResponse && jsonRpcResponse.error) {
         const { code, message, data } = jsonRpcResponse.error;
+
+        // Fallback: refresh on JSON-RPC auth error (HTTP 200, older servers)
+        if (
+          !this._streamAuthRetried &&
+          code === A2A_ERROR_CODES.AUTHENTICATION_REQUIRED &&
+          this._authProvider?.refresh &&
+          this._resolvedSchemes
+        ) {
+          this._streamAuthRetried = true;
+          try {
+            this._resolvedSchemes = await this._authProvider.refresh(
+              this._resolvedSchemes,
+            );
+            yield* this.sendMessageStream(params, signal);
+          } finally {
+            this._streamAuthRetried = false;
+          }
+          return;
+        }
+
         const ErrorClass = ERROR_CODE_MAP[code] ?? InternalError;
         throw new ErrorClass(message, data);
       }
@@ -420,6 +460,21 @@ export class A2XClient {
 
     if ('error' in jsonRpcResponse && jsonRpcResponse.error) {
       const { code, message, data } = jsonRpcResponse.error;
+
+      // Fallback: trigger refresh on JSON-RPC auth error when server
+      // returned HTTP 200 instead of 401 (older server compatibility).
+      if (
+        !isRetry &&
+        code === A2A_ERROR_CODES.AUTHENTICATION_REQUIRED &&
+        this._authProvider?.refresh &&
+        this._resolvedSchemes
+      ) {
+        this._resolvedSchemes = await this._authProvider.refresh(
+          this._resolvedSchemes,
+        );
+        return this._postJsonRpc(request, true);
+      }
+
       const ErrorClass = ERROR_CODE_MAP[code] ?? InternalError;
       throw new ErrorClass(message, data);
     }

--- a/packages/a2x/src/transport/index.ts
+++ b/packages/a2x/src/transport/index.ts
@@ -2,8 +2,8 @@
  * Layer 4: Transport - public API
  */
 
-export { DefaultRequestHandler } from './request-handler.js';
-export type { HandleResult } from './request-handler.js';
+export { DefaultRequestHandler, getHttpStatus, getHttpHeaders } from './request-handler.js';
+export type { HandleResult, HandleHttpResult, HttpResponseMeta } from './request-handler.js';
 export { JsonRpcRouter } from './jsonrpc-router.js';
 export type { MethodHandler, StreamMethodHandler } from './jsonrpc-router.js';
 export { createSSEStream } from './sse-handler.js';

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -46,10 +46,36 @@ import type { ResponseMapper } from '../a2x/response-mapper.js';
 import { ResponseMapperFactory } from '../a2x/response-mapper.js';
 import type { RequestContext, AuthResult } from '../types/auth.js';
 
-/** Return type of `handle()`. */
+/**
+ * Return type of `handle()`.
+ * @deprecated Use {@link HandleHttpResult} instead — it wraps the response
+ * body and carries optional HTTP metadata (status, headers).
+ */
 export type HandleResult =
   | JSONRPCResponse
   | AsyncGenerator<unknown>;
+
+/** HTTP metadata attached to responses that require a non-200 status. */
+export interface HttpResponseMeta {
+  status: number;
+  headers?: Record<string, string>;
+}
+
+/** Extended result from handle() that carries optional HTTP metadata. */
+export interface HandleHttpResult {
+  body: JSONRPCResponse | AsyncGenerator<unknown>;
+  http?: HttpResponseMeta;
+}
+
+/** Extract the HTTP status code from a HandleHttpResult (defaults to 200). */
+export function getHttpStatus(result: HandleHttpResult): number {
+  return result.http?.status ?? 200;
+}
+
+/** Extract optional HTTP headers from a HandleHttpResult. */
+export function getHttpHeaders(result: HandleHttpResult): Record<string, string> {
+  return result.http?.headers ?? {};
+}
 
 export class DefaultRequestHandler {
   private readonly a2xAgent: A2XAgent;
@@ -66,9 +92,10 @@ export class DefaultRequestHandler {
   /**
    * Handle a JSON-RPC request body.
    *
-   * Returns a `JSONRPCResponse` for synchronous methods (`message/send`,
-   * `tasks/get`, `tasks/cancel`) or an `AsyncGenerator` for streaming
-   * methods (`message/stream`).
+   * Returns a `HandleHttpResult` whose `.body` is either a
+   * `JSONRPCResponse` (sync methods) or an `AsyncGenerator` (streaming).
+   * The optional `.http` field carries status/headers for non-200 cases
+   * (e.g. 401 for authentication failures).
    *
    * When `context` is provided and the agent has security requirements,
    * authentication is evaluated before routing. When omitted, no auth
@@ -77,17 +104,17 @@ export class DefaultRequestHandler {
    * The caller inspects the return value:
    * ```ts
    * const result = await handler.handle(body, { headers: req.headers });
-   * if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+   * if (result.body && typeof result.body === 'object' && Symbol.asyncIterator in result.body) {
    *   // stream → convert to SSE Response
    * } else {
-   *   // sync → return as JSON
+   *   // sync → return as JSON using getHttpStatus(result) / getHttpHeaders(result)
    * }
    * ```
    */
   async handle(
     body: JSONRPCRequest | string | unknown,
     context?: RequestContext,
-  ): Promise<HandleResult> {
+  ): Promise<HandleHttpResult> {
     let request: JSONRPCRequest;
 
     // Parse if string
@@ -97,9 +124,11 @@ export class DefaultRequestHandler {
       } catch {
         const error = new JSONParseError();
         return {
-          jsonrpc: '2.0',
-          id: null,
-          error: error.toJSONRPCError(),
+          body: {
+            jsonrpc: '2.0',
+            id: null,
+            error: error.toJSONRPCError(),
+          },
         };
       }
     } else {
@@ -115,9 +144,11 @@ export class DefaultRequestHandler {
     ) {
       const error = new InvalidRequestError('Invalid JSON-RPC 2.0 request');
       return {
-        jsonrpc: '2.0',
-        id: request?.id ?? null,
-        error: error.toJSONRPCError(),
+        body: {
+          jsonrpc: '2.0',
+          id: request?.id ?? null,
+          error: error.toJSONRPCError(),
+        },
       };
     }
 
@@ -132,9 +163,12 @@ export class DefaultRequestHandler {
           authResult.error ?? 'Authentication required',
         );
         return {
-          jsonrpc: '2.0',
-          id: request.id,
-          error: error.toJSONRPCError(),
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            error: error.toJSONRPCError(),
+          },
+          http: { status: 401, headers: { 'WWW-Authenticate': 'Bearer' } },
         };
       }
     }
@@ -153,9 +187,11 @@ export class DefaultRequestHandler {
         }
         const card = await this.a2xAgent.getAuthenticatedExtendedCard(authResult);
         return {
-          jsonrpc: '2.0',
-          id: request.id,
-          result: card,
+          body: {
+            jsonrpc: '2.0',
+            id: request.id,
+            result: card,
+          },
         };
       } catch (err) {
         return this._toErrorResponse(request.id, err);
@@ -165,7 +201,7 @@ export class DefaultRequestHandler {
     // Streaming method → return AsyncGenerator
     if (this.router.isStreamMethod(request.method)) {
       try {
-        return this.router.routeStream(request) as AsyncGenerator<unknown>;
+        return { body: this.router.routeStream(request) as AsyncGenerator<unknown> };
       } catch (err) {
         return this._toErrorResponse(request.id, err);
       }
@@ -173,7 +209,7 @@ export class DefaultRequestHandler {
 
     // Synchronous method → return JSONRPCResponse
     try {
-      return await this.router.route(request);
+      return { body: await this.router.route(request) as JSONRPCResponse };
     } catch (err) {
       return this._toErrorResponse(request.id, err);
     }
@@ -586,21 +622,27 @@ export class DefaultRequestHandler {
   private _toErrorResponse(
     id: string | number | null,
     err: unknown,
-  ): JSONRPCResponse {
+  ): HandleHttpResult {
     if (err && typeof err === 'object' && 'toJSONRPCError' in err) {
+      const isAuthError = err instanceof AuthenticationRequiredError;
       return {
-        jsonrpc: '2.0',
-        id,
-        error: (err as A2AError).toJSONRPCError(),
+        body: {
+          jsonrpc: '2.0',
+          id,
+          error: (err as A2AError).toJSONRPCError(),
+        },
+        ...(isAuthError ? { http: { status: 401, headers: { 'WWW-Authenticate': 'Bearer' } } } : {}),
       };
     }
     const internalError = new InternalError(
       err instanceof Error ? err.message : 'Internal error',
     );
     return {
-      jsonrpc: '2.0',
-      id,
-      error: internalError.toJSONRPCError(),
+      body: {
+        jsonrpc: '2.0',
+        id,
+        error: internalError.toJSONRPCError(),
+      },
     };
   }
 

--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -11,7 +11,7 @@ import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { A2XAgent } from '../a2x/a2x-agent.js';
-import { DefaultRequestHandler } from './request-handler.js';
+import { DefaultRequestHandler, getHttpStatus, getHttpHeaders } from './request-handler.js';
 import { createSSEStream } from './sse-handler.js';
 import type { RequestContext } from '../types/auth.js';
 
@@ -144,9 +144,9 @@ export function toA2x(
 
             // Streaming → AsyncGenerator → SSE
             if (
-              result &&
-              typeof result === 'object' &&
-              Symbol.asyncIterator in result
+              result.body &&
+              typeof result.body === 'object' &&
+              Symbol.asyncIterator in result.body
             ) {
               res.writeHead(200, {
                 'Content-Type': 'text/event-stream',
@@ -155,7 +155,7 @@ export function toA2x(
               });
 
               const stream = createSSEStream(
-                result as AsyncGenerator<never>,
+                result.body as AsyncGenerator<never>,
               );
               const reader = stream.getReader();
 
@@ -195,8 +195,10 @@ export function toA2x(
             }
 
             // Standard JSON-RPC response
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify(result));
+            const status = getHttpStatus(result);
+            const extraHeaders = getHttpHeaders(result);
+            res.writeHead(status, { 'Content-Type': 'application/json', ...extraHeaders });
+            res.end(JSON.stringify(result.body));
           } catch {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -9,6 +9,8 @@ import {
   A2XAgent,
   DefaultRequestHandler,
   createSSEStream,
+  getHttpStatus,
+  getHttpHeaders,
   ApiKeyAuthorization,
   OAuth2DeviceCodeAuthorization,
 } from '@a2x/sdk';
@@ -122,15 +124,18 @@ app.post('/a2a', async (req, res) => {
 
   try {
     const result = await handler.handle(req.body, context);
+    const status = getHttpStatus(result);
+    const extraHeaders = getHttpHeaders(result);
 
     // Streaming → SSE
-    if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    if (result.body && typeof result.body === 'object' && Symbol.asyncIterator in result.body) {
       res.setHeader('Content-Type', 'text/event-stream');
       res.setHeader('Cache-Control', 'no-cache');
       res.setHeader('Connection', 'keep-alive');
+      for (const [k, v] of Object.entries(extraHeaders)) res.setHeader(k, v);
 
       const stream = createSSEStream(
-        result as AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
+        result.body as AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
       );
       const reader = stream.getReader();
 
@@ -151,7 +156,7 @@ app.post('/a2a', async (req, res) => {
     }
 
     // Standard JSON-RPC response
-    res.json(result);
+    res.status(status).set(extraHeaders).json(result.body);
   } catch {
     res.status(400).json({
       jsonrpc: '2.0',

--- a/samples/nextjs-skill/src/app/api/a2a/route.ts
+++ b/samples/nextjs-skill/src/app/api/a2a/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { handler } from "@/lib/a2x-setup";
-import { createSSEStream } from "@a2x/sdk";
+import { createSSEStream, getHttpStatus, getHttpHeaders } from "@a2x/sdk";
 import type { RequestContext } from "@a2x/sdk";
 
 const SSE_HEADERS = {
@@ -27,11 +27,13 @@ export async function POST(request: Request): Promise<Response> {
   };
 
   const result = await handler.handle(body, context);
+  const status = getHttpStatus(result);
+  const extraHeaders = getHttpHeaders(result);
 
-  if (result && typeof result === "object" && Symbol.asyncIterator in result) {
-    const stream = createSSEStream(result as AsyncGenerator<never>);
-    return new Response(stream, { headers: SSE_HEADERS });
+  if (result.body && typeof result.body === "object" && Symbol.asyncIterator in result.body) {
+    const stream = createSSEStream(result.body as AsyncGenerator<never>);
+    return new Response(stream, { headers: { ...SSE_HEADERS, ...extraHeaders } });
   }
 
-  return NextResponse.json(result);
+  return NextResponse.json(result.body, { status, headers: extraHeaders });
 }

--- a/samples/nextjs-x402/src/app/api/a2a/route.ts
+++ b/samples/nextjs-x402/src/app/api/a2a/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handler } from '@/lib/a2x-setup';
-import { createSSEStream } from '@a2x/sdk';
+import { createSSEStream, getHttpStatus, getHttpHeaders } from '@a2x/sdk';
 import type { RequestContext } from '@a2x/sdk';
 
 const SSE_HEADERS = {
@@ -43,9 +43,11 @@ export async function POST(request: Request): Promise<Response> {
   };
 
   const result = await handler.handle(body, context);
+  const status = getHttpStatus(result);
+  const extraHeaders = getHttpHeaders(result);
 
-  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
-    const source = result as AsyncGenerator<unknown>;
+  if (result.body && typeof result.body === 'object' && Symbol.asyncIterator in result.body) {
+    const source = result.body as AsyncGenerator<unknown>;
     const logged: AsyncGenerator<unknown> = LOGGING
       ? (async function* () {
           let i = 0;
@@ -60,9 +62,9 @@ export async function POST(request: Request): Promise<Response> {
         })()
       : source;
     const stream = createSSEStream(logged as AsyncGenerator<never>);
-    return new Response(stream, { headers: SSE_HEADERS });
+    return new Response(stream, { headers: { ...SSE_HEADERS, ...extraHeaders } });
   }
 
-  log('response', result);
-  return NextResponse.json(result);
+  log('response', result.body);
+  return NextResponse.json(result.body, { status, headers: extraHeaders });
 }

--- a/samples/nextjs/src/app/api/a2a/route.ts
+++ b/samples/nextjs/src/app/api/a2a/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { handler } from "@/lib/a2x-setup";
-import { createSSEStream } from "@a2x/sdk";
+import { createSSEStream, getHttpStatus, getHttpHeaders } from "@a2x/sdk";
 import type { RequestContext } from "@a2x/sdk";
 
 const SSE_HEADERS = {
@@ -28,15 +28,17 @@ export async function POST(request: Request): Promise<Response> {
   };
 
   const result = await handler.handle(body, context);
+  const status = getHttpStatus(result);
+  const extraHeaders = getHttpHeaders(result);
 
   // Streaming → AsyncGenerator → SSE response
-  if (result && typeof result === "object" && Symbol.asyncIterator in result) {
+  if (result.body && typeof result.body === "object" && Symbol.asyncIterator in result.body) {
     const stream = createSSEStream(
-      result as AsyncGenerator<never>,
+      result.body as AsyncGenerator<never>,
     );
-    return new Response(stream, { headers: SSE_HEADERS });
+    return new Response(stream, { headers: { ...SSE_HEADERS, ...extraHeaders } });
   }
 
   // Synchronous → JSON response
-  return NextResponse.json(result);
+  return NextResponse.json(result.body, { status, headers: extraHeaders });
 }


### PR DESCRIPTION
## Summary
- Server `DefaultRequestHandler.handle()` now returns `HandleHttpResult` with optional HTTP metadata — auth failures produce **HTTP 401** + `WWW-Authenticate: Bearer` instead of HTTP 200
- Client `A2XClient` adds **JSON-RPC -32008 fallback**: when an older server returns HTTP 200 with error code -32008, `AuthProvider.refresh()` is triggered and the request retried once
- Streaming path (`sendMessageStream`) also handles HTTP 401 refresh with infinite-recursion guard
- All 4 sample adapters (nextjs, nextjs-skill, nextjs-x402, express) and the built-in `toA2x` adapter updated to use `getHttpStatus()` / `getHttpHeaders()` helpers

Closes #94

## Changes

### Server (SDK)
- `packages/a2x/src/transport/request-handler.ts`: New `HandleHttpResult`, `HttpResponseMeta` types; `getHttpStatus()`, `getHttpHeaders()` helpers; `handle()` returns `{ body, http? }` shape; auth failures include `http: { status: 401 }`
- `packages/a2x/src/transport/index.ts`: Export new types and helpers
- `packages/a2x/src/transport/to-a2x.ts`: Use `result.body` + `getHttpStatus()`

### Client (SDK)
- `packages/a2x/src/client/a2x-client.ts`: `-32008` fallback refresh in `_postJsonRpc()`; HTTP 401 + `-32008` refresh in `sendMessageStream()` with `_streamAuthRetried` guard

### Adapters
- `samples/nextjs/src/app/api/a2a/route.ts`
- `samples/nextjs-skill/src/app/api/a2a/route.ts`
- `samples/nextjs-x402/src/app/api/a2a/route.ts`
- `samples/express/src/index.ts`

### Tests
- `request-handler.test.ts`: 63 existing tests migrated to `HandleHttpResult` + 3 new (HTTP 401 status, no metadata for non-auth errors, no metadata for success)
- `client-auth.test.ts`: 2 new tests (-32008 fallback refresh, retry-once guard)
- `authenticated-extended-card.test.ts`, `task-resubscribe.test.ts`: Migrated to `result.body` pattern

## Test plan
- [x] 397/397 tests pass (2 pre-existing x402 viem failures unrelated)
- [x] Server returns HTTP 401 + WWW-Authenticate for auth failures verified in tests
- [x] Client -32008 fallback triggers refresh and retries verified in tests
- [x] Client does not retry more than once verified in tests
- [ ] Manual test with expired bearer token against a live agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)