### PR TITLE
fix(sdk): align @a2x/sdk/x402 with v0.2 spec, fold dance into A2XClient

### DIFF
--- a/.changeset/x402-spec-conformance.md
+++ b/.changeset/x402-spec-conformance.md
@@ -2,9 +2,32 @@
 "@a2x/sdk": minor
 ---
 
-Align `@a2x/sdk/x402` with a2a-x402 v0.2 spec.
+Align `@a2x/sdk/x402` with a2a-x402 v0.2 spec, and fold x402 handling into `A2XClient` natively.
 
-Closes #92. Audit of PR #72 turned up one MUST violation (§8 activation header) and five spec-drift gaps. This release fixes all of them together so the SDK interoperates with spec-strict x402 clients and servers.
+Closes #92. Two-part change:
+
+1. Six spec-conformance fixes (one MUST violation, five drift gaps).
+2. `X402Client` is removed — `A2XClient` itself runs the Standalone Flow when given an `x402` option, so callers no longer have to know up front whether the target agent gates on x402.
+
+**Breaking — client surface.** The `X402Client` wrapper class is gone. Migrate by passing the same options to `A2XClient` instead:
+
+```ts
+// Before
+import { X402Client } from '@a2x/sdk/x402';
+const x402 = new X402Client(new A2XClient(url), { signer });
+await x402.sendMessage({ message });
+
+// After
+import { A2XClient } from '@a2x/sdk/client';
+const client = new A2XClient(url, { x402: { signer } });
+await client.sendMessage({ message });
+```
+
+`A2XClient.sendMessage` and `A2XClient.sendMessageStream` now both transparently detect `payment-required`, sign one of the merchant's `accepts[]` requirements, and resubmit on the same task — the caller observes the final settled task (blocking) or a single merged event stream (streaming) with no manual orchestration. The streaming case in particular: the dance happens in-band, so consumers see `payment-required → payment-verified → working → artifacts → payment-completed` on one generator.
+
+The new `A2XClientX402Options` carries `signer`, optional `maxAmount` (atomic-unit ceiling enforced before the selector runs), `selectRequirement`, and `onPaymentRequired`. Setting `x402` automatically registers `X402_EXTENSION_URI` on the client's `extensions` set so the §8 header is emitted on every request.
+
+The low-level primitives (`signX402Payment`, `getX402PaymentRequirements`, `getX402Receipts`, `getX402Status`) remain exported for callers that need to drive the dance manually — e.g. inspect the `payment-required` task before signing.
 
 **Breaking — `X402_ERROR_CODES` renames.** Spec §9.1 defines the canonical code names. Two renames bring the SDK back in line:
 
@@ -20,7 +43,7 @@ Also removed the unused `NO_REQUIREMENTS` code (never emitted). Consumers readin
 - new `A2XClientOptions.extensions?: string[]` option
 - new `A2XClient.registerExtension(uri)` method (idempotent)
 - new `A2XClient.activatedExtensions` read-only getter
-- `X402Client` auto-registers `X402_EXTENSION_URI` on its wrapped `A2XClient` so existing call sites get the header for free
+- setting `A2XClientOptions.x402` auto-registers `X402_EXTENSION_URI` so the header is emitted with no extra wiring
 
 Server-side, `DefaultRequestHandler` rejects requests whose header doesn't list every `required: true` extension on the AgentCard (error code `-32600`). Enforcement only runs when a `RequestContext` is supplied, so pure in-process handler invocations are unaffected.
 

--- a/.changeset/x402-spec-conformance.md
+++ b/.changeset/x402-spec-conformance.md
@@ -1,0 +1,33 @@
+---
+"@a2x/sdk": minor
+---
+
+Align `@a2x/sdk/x402` with a2a-x402 v0.2 spec.
+
+Closes #92. Audit of PR #72 turned up one MUST violation (§8 activation header) and five spec-drift gaps. This release fixes all of them together so the SDK interoperates with spec-strict x402 clients and servers.
+
+**Breaking — `X402_ERROR_CODES` renames.** Spec §9.1 defines the canonical code names. Two renames bring the SDK back in line:
+
+- `SETTLE_FAILED` → `SETTLEMENT_FAILED`
+- `AMOUNT_EXCEEDED` → `INVALID_AMOUNT`
+
+Also removed the unused `NO_REQUIREMENTS` code (never emitted). Consumers reading `x402.payment.error` string values or pattern-matching on these constants must update.
+
+**New — spec §9.1 error codes.** Verify failures now dispatch through `mapVerifyFailureToCode()`, which inspects the facilitator's `invalidReason` and returns one of `INSUFFICIENT_FUNDS`, `INVALID_SIGNATURE`, `EXPIRED_PAYMENT`, `DUPLICATE_NONCE`, or `VERIFY_FAILED` (fallback) instead of always emitting the generic `VERIFY_FAILED`.
+
+**New — `X-A2A-Extensions` activation header (§8 MUST).** `A2XClient` emits the header when extensions are registered:
+
+- new `A2XClientOptions.extensions?: string[]` option
+- new `A2XClient.registerExtension(uri)` method (idempotent)
+- new `A2XClient.activatedExtensions` read-only getter
+- `X402Client` auto-registers `X402_EXTENSION_URI` on its wrapped `A2XClient` so existing call sites get the header for free
+
+Server-side, `DefaultRequestHandler` rejects requests whose header doesn't list every `required: true` extension on the AgentCard (error code `-32600`). Enforcement only runs when a `RequestContext` is supplied, so pure in-process handler invocations are unaffected.
+
+**New — `payment-verified` transient state (§7.1).** Streaming clients now observe a `working` + `x402.payment.status: payment-verified` event between `payment-submitted` and `payment-completed`, matching the spec's 3-step lifecycle.
+
+**Fix — `x402.payment.receipts` preserves history (§7).** Prior receipts are merged rather than overwritten across retries, honoring spec §7's "complete history" requirement.
+
+**New — `payment-rejected` handling (§5.4.2 / §7.1).** The executor now recognizes a client-sent `x402.payment.status: payment-rejected` and terminates the task (`failed` + status `payment-rejected`) instead of looping on `payment-required`.
+
+**New — `retryOnFailure` executor option.** Opt in to spec §9's retry branch: verify/settle failures re-publish `payment-required` on the same task with the failure reason carried in `X402PaymentRequiredResponse.error`, letting the client fix the issue and resubmit. Default behavior (terminate with `failed`) is unchanged.

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -338,13 +338,12 @@ Client:
 
 ```typescript
 import { A2XClient } from '@a2x/sdk/client';
-import { X402Client } from '@a2x/sdk/x402';
 import { privateKeyToAccount } from 'viem/accounts';
 
-const x402 = new X402Client(new A2XClient(url), {
-  signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+const client = new A2XClient(url, {
+  x402: { signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`) },
 });
-const task = await x402.sendMessage({ message: { role: 'user', parts: [{ text: '...' }] } });
+const task = await client.sendMessage({ message: { role: 'user', parts: [{ text: '...' }] } });
 ```
 
 Full guide: [docs/guides/advanced/x402-payments.md](./docs/guides/advanced/x402-payments.md).

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -106,7 +106,53 @@ On a successful payment, the completed task's status message carries:
 }
 ```
 
-Failures surface under `x402.payment.error` with one of `INVALID_PAYLOAD`, `NETWORK_MISMATCH`, `INVALID_PAY_TO`, `AMOUNT_EXCEEDED`, `VERIFY_FAILED`, `SETTLE_FAILED`.
+Failures surface under `x402.payment.error` with one of the codes below. The seven names listed first come straight from spec §9.1; the remaining three are SDK-specific codes covering failure modes the SDK detects outside the facilitator's purview.
+
+| Code | Source | Meaning |
+|---|---|---|
+| `INSUFFICIENT_FUNDS` | spec §9.1 | Wallet can't cover the payment. |
+| `INVALID_SIGNATURE` | spec §9.1 | Authorization signature failed verification. |
+| `EXPIRED_PAYMENT` | spec §9.1 | Authorization was submitted after its validity window. |
+| `DUPLICATE_NONCE` | spec §9.1 | Nonce has already been spent. |
+| `NETWORK_MISMATCH` | spec §9.1 | Payload's network doesn't match any advertised `accepts`. |
+| `INVALID_AMOUNT` | spec §9.1 | Authorization value doesn't match the required amount. |
+| `SETTLEMENT_FAILED` | spec §9.1 | On-chain settle call failed. |
+| `INVALID_PAYLOAD` | SDK | Payment payload is missing or structurally invalid. |
+| `INVALID_PAY_TO` | SDK | Authorization target address doesn't match `payTo`. |
+| `VERIFY_FAILED` | SDK | Facilitator rejected the signature, but the reason string didn't match any of the spec codes above. |
+
+The SDK uses the facilitator's `invalidReason` string to dispatch into the spec codes (`mapVerifyFailureToCode()` exports the same logic if you need it client-side). Clients SHOULD branch on the spec codes first and treat `VERIFY_FAILED` as an unmapped fallback.
+
+### Payment lifecycle
+
+Every paid task runs through the same state machine (spec §7.1):
+
+```
+PAYMENT_REQUIRED → PAYMENT_REJECTED           (client declined the challenge)
+PAYMENT_REQUIRED → PAYMENT_SUBMITTED          (client signed and resubmitted)
+PAYMENT_SUBMITTED → PAYMENT_VERIFIED          (facilitator verified the signature)
+PAYMENT_VERIFIED → PAYMENT_COMPLETED          (on-chain settlement succeeded)
+PAYMENT_VERIFIED → PAYMENT_FAILED             (settlement failed on-chain)
+```
+
+The SDK emits `payment-verified` as a transient `working`-state event between submit and completion when streaming, so clients can surface a "settling on-chain…" indicator. In the blocking `execute()` path the state is recorded on `task.status` but clients only observe the final value.
+
+### Retry-on-failure (opt-in)
+
+By default, verify/settle failures terminate the task with state `failed` and an error code. Spec §9 also allows the merchant to "request a payment requirement with input-required again"; set `retryOnFailure: true` on the executor to pick that strategy — failures will re-publish `payment-required` on the same task with the prior failure reason carried in `X402PaymentRequiredResponse.error`, letting the client top up the wallet (or refresh the nonce) and resubmit without creating a new task.
+
+```ts
+new X402PaymentExecutor(inner, {
+  accepts: [...],
+  retryOnFailure: true,
+});
+```
+
+`x402.payment.receipts` accumulates every settle attempt (success or failure) across the task's lifetime per spec §7's "complete history" requirement.
+
+### Rejection handling
+
+When a client decides not to pay it can respond with `x402.payment.status: payment-rejected` (spec §5.4.2). The executor terminates the task with state `failed` and status `payment-rejected` — no further challenges are published, the loop ends.
 
 ## Client
 
@@ -187,6 +233,31 @@ for (const receipt of receipts) {
   console.log(receipt.success, receipt.transaction, receipt.network);
 }
 ```
+
+## Extension activation
+
+Per spec §8, x402-capable clients MUST include the extension URI in the `X-A2A-Extensions` HTTP header on every JSON-RPC request. `X402Client` does this automatically — wrapping an `A2XClient` registers `X402_EXTENSION_URI` on it so subsequent `sendMessage` / `sendMessageStream` calls emit the header:
+
+```
+X-A2A-Extensions: https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2
+```
+
+If you're driving `A2XClient` directly (without `X402Client`), pass `extensions` to the constructor:
+
+```ts
+new A2XClient(url, {
+  extensions: [X402_EXTENSION_URI],
+  // …other options
+});
+```
+
+Or register at runtime (the same mechanism `X402Client` uses internally):
+
+```ts
+client.registerExtension(X402_EXTENSION_URI);
+```
+
+**Server side.** When an agent declares an extension with `required: true`, `DefaultRequestHandler` rejects requests whose `X-A2A-Extensions` header doesn't list that URI (error `-32600`). The check is only applied when a `RequestContext` is provided to `handler.handle()` — pure in-process invocations skip it.
 
 ## Supported scope
 

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -156,21 +156,25 @@ When a client decides not to pay it can respond with `x402.payment.status: payme
 
 ## Client
 
-### High-level: `X402Client`
+### High-level: `A2XClient` with `x402`
+
+`A2XClient` itself runs the x402 dance when you pass an `x402` option. Whether the agent gates on x402 is a property of its AgentCard, not the caller — so you don't have to pick between two client classes. If the agent never asks for payment, the client behaves as a plain A2A client.
 
 ```ts
 import { A2XClient } from '@a2x/sdk/client';
-import { X402Client } from '@a2x/sdk/x402';
 import { privateKeyToAccount } from 'viem/accounts';
 
-const x402 = new X402Client(new A2XClient('https://agent.example.com'), {
-  signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
-  onPaymentRequired: (required) => {
-    console.log('Merchant asks for', required.accepts);
+const client = new A2XClient('https://agent.example.com', {
+  x402: {
+    signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+    maxAmount: 10_000n,                          // optional; refuse anything above this
+    onPaymentRequired: (required) => {
+      console.log('Merchant asks for', required.accepts);
+    },
   },
 });
 
-const task = await x402.sendMessage({
+const task = await client.sendMessage({
   message: {
     messageId: crypto.randomUUID(),
     role: 'user',
@@ -181,17 +185,52 @@ const task = await x402.sendMessage({
 console.log(task.status.state); // "completed"
 ```
 
-If the merchant rejects the payment (verify or settle failed), `sendMessage` throws `X402PaymentFailedError` with the on-chain reason attached.
+The same call site works for streaming. The dance happens in-band — the generator yields the merchant's `payment-required` event and then continues with the followup stream's `payment-verified → working → artifacts → payment-completed` events:
+
+```ts
+for await (const event of client.sendMessageStream({ message: { … } })) {
+  console.log(event);
+}
+```
+
+If the merchant rejects the payment (verify or settle failed), the call throws `X402PaymentFailedError` with the on-chain reason attached. If every requirement in `accepts[]` exceeds `maxAmount`, signing throws `X402NoSupportedRequirementError` before any authorization is created.
+
+The full option surface:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `signer` | required | viem `LocalAccount` used to produce the EIP-3009 authorization. |
+| `maxAmount` | no cap | Atomic-unit ceiling. Filters `accepts[]` before the selector runs, so a custom `selectRequirement` only sees the affordable subset. |
+| `selectRequirement` | first `scheme === 'exact'` | Predicate over the (already filtered) requirements. Return `undefined` to abort. |
+| `onPaymentRequired` | none | Hook that fires after `payment-required` and before signing. Throw to abort the dance — the caller observes the unmodified `payment-required` task (blocking) or a stream that closes after the `payment-required` event (streaming). |
+
+### Extension activation header
+
+Setting the `x402` option auto-registers `X402_EXTENSION_URI` so every JSON-RPC request carries the `X-A2A-Extensions` activation header (spec §8). You don't need to pass `extensions` separately for x402.
+
+To activate other extensions, list them in `extensions` or call `client.registerExtension(uri)` at runtime:
+
+```ts
+new A2XClient(url, {
+  extensions: ['https://example.org/some-extension'],
+  x402: { signer },                              // X402_EXTENSION_URI auto-added
+});
+```
 
 ### Low-level: `signX402Payment`
 
-Use this when you need to inspect the `payment-required` task before signing — e.g. to show the user a confirmation modal, to fetch the signer's balance, or to route across multiple wallets.
+When you need to inspect the `payment-required` task before signing — e.g. to show the user a confirmation modal, fetch the signer's balance, or route across multiple wallets — drive the dance manually using the primitives. `A2XClient` without the `x402` option will hand you the raw `payment-required` task, and `signX402Payment` produces the metadata block to attach to the followup `message/send` call.
 
 ```ts
+import { A2XClient } from '@a2x/sdk/client';
 import {
   signX402Payment,
   getX402PaymentRequirements,
 } from '@a2x/sdk/x402';
+
+const client = new A2XClient(url, {
+  extensions: [X402_EXTENSION_URI], // still required for header activation
+});
 
 const first = await client.sendMessage({ message: { … } });
 const required = getX402PaymentRequirements(first);
@@ -234,30 +273,17 @@ for (const receipt of receipts) {
 }
 ```
 
-## Extension activation
+## Server-side enforcement
 
-Per spec §8, x402-capable clients MUST include the extension URI in the `X-A2A-Extensions` HTTP header on every JSON-RPC request. `X402Client` does this automatically — wrapping an `A2XClient` registers `X402_EXTENSION_URI` on it so subsequent `sendMessage` / `sendMessageStream` calls emit the header:
+Per spec §8, x402-capable clients MUST include the extension URI in the `X-A2A-Extensions` HTTP header on every JSON-RPC request:
 
 ```
 X-A2A-Extensions: https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2
 ```
 
-If you're driving `A2XClient` directly (without `X402Client`), pass `extensions` to the constructor:
+When the merchant agent declares the extension with `required: true` on its AgentCard, `DefaultRequestHandler` rejects requests whose header doesn't list that URI (error `-32600`). The check only runs when a `RequestContext` is provided to `handler.handle()` — pure in-process invocations skip it.
 
-```ts
-new A2XClient(url, {
-  extensions: [X402_EXTENSION_URI],
-  // …other options
-});
-```
-
-Or register at runtime (the same mechanism `X402Client` uses internally):
-
-```ts
-client.registerExtension(X402_EXTENSION_URI);
-```
-
-**Server side.** When an agent declares an extension with `required: true`, `DefaultRequestHandler` rejects requests whose `X-A2A-Extensions` header doesn't list that URI (error `-32600`). The check is only applied when a `RequestContext` is provided to `handler.handle()` — pure in-process invocations skip it.
+The client side is covered for you when you set `A2XClientOptions.x402` — see the section above. If you drive the dance manually via `signX402Payment`, pass `extensions: [X402_EXTENSION_URI]` to the `A2XClient` constructor (or call `client.registerExtension(X402_EXTENSION_URI)`) so the header gets emitted on every request.
 
 ## Supported scope
 

--- a/packages/a2x/src/__tests__/a2x-client-x402.test.ts
+++ b/packages/a2x/src/__tests__/a2x-client-x402.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Tests for `A2XClient`'s native a2a-x402 v0.2 Standalone Flow handling.
+ *
+ * The dance has two distinct surfaces — `sendMessage` (blocking) and
+ * `sendMessageStream` — and both must transparently:
+ *
+ *  1. Activate the extension via `X-A2A-Extensions` (covered in
+ *     `x402-extension-activation.test.ts`).
+ *  2. Detect the merchant's `payment-required` reply.
+ *  3. Sign one of the merchant's `accepts[]` requirements (subject to
+ *     `maxAmount` and any caller-supplied `selectRequirement` /
+ *     `onPaymentRequired`).
+ *  4. Resubmit on the same task with `x402.payment.submitted` metadata.
+ *  5. Surface the final settled task to the caller — no manual dance
+ *     orchestration in user code.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { privateKeyToAccount } from 'viem/accounts';
+import { A2XClient } from '../client/a2x-client.js';
+import {
+  X402_EXTENSION_URI,
+  X402_METADATA_KEYS,
+  X402_PAYMENT_STATUS,
+} from '../x402/constants.js';
+import {
+  X402NoSupportedRequirementError,
+  X402PaymentFailedError,
+} from '../x402/errors.js';
+
+const TEST_ACCOUNT = privateKeyToAccount(
+  '0x1111111111111111111111111111111111111111111111111111111111111111',
+);
+
+const AGENT_URL = 'https://example.com';
+const RPC_PATH = '/a2a';
+const RPC_URL = `${AGENT_URL}${RPC_PATH}`;
+
+function agentCardResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      protocolVersion: '0.3.0',
+      name: 'test',
+      description: 'test',
+      url: RPC_URL,
+      version: '1.0.0',
+      capabilities: {},
+      defaultInputModes: ['text'],
+      defaultOutputModes: ['text'],
+      skills: [],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+function paymentRequiredTask(): unknown {
+  return {
+    kind: 'task',
+    id: 't1',
+    contextId: 'c1',
+    status: {
+      state: 'input-required',
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: 'x402-1',
+        role: 'agent',
+        parts: [{ kind: 'text', text: 'pay up' }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          [X402_METADATA_KEYS.REQUIRED]: {
+            x402Version: 1,
+            accepts: [
+              {
+                scheme: 'exact',
+                network: 'base-sepolia',
+                maxAmountRequired: '1000',
+                resource: 'a2a-x402/access',
+                description: 'Per-call',
+                mimeType: 'application/json',
+                payTo: '0x000000000000000000000000000000000000dEaD',
+                maxTimeoutSeconds: 300,
+                asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+                extra: { name: 'USDC', version: '2' },
+              },
+            ],
+          },
+        },
+      },
+    },
+    artifacts: [],
+    history: [],
+  };
+}
+
+function completedTaskWithReceipt(): unknown {
+  return {
+    kind: 'task',
+    id: 't1',
+    contextId: 'c1',
+    status: {
+      state: 'completed',
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: 'x402-2',
+        role: 'agent',
+        parts: [{ kind: 'text', text: 'done' }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
+          [X402_METADATA_KEYS.RECEIPTS]: [
+            {
+              success: true,
+              transaction: '0xabc',
+              network: 'base-sepolia',
+            },
+          ],
+        },
+      },
+    },
+    artifacts: [],
+    history: [],
+  };
+}
+
+function failedTaskWithReceipt(reason: string, code: string): unknown {
+  return {
+    kind: 'task',
+    id: 't1',
+    contextId: 'c1',
+    status: {
+      state: 'failed',
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: 'x402-2',
+        role: 'agent',
+        parts: [{ kind: 'text', text: reason }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.FAILED,
+          [X402_METADATA_KEYS.ERROR]: code,
+          [X402_METADATA_KEYS.RECEIPTS]: [
+            {
+              success: false,
+              transaction: '',
+              network: 'base-sepolia',
+              errorReason: reason,
+            },
+          ],
+        },
+      },
+    },
+    artifacts: [],
+    history: [],
+  };
+}
+
+function jsonRpcOk(result: unknown): Response {
+  return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * Build a fake fetch that serves a sequence of responses for /a2a calls,
+ * always returning the AgentCard for /.well-known/* probes.
+ */
+function scriptedFetch(replies: Array<() => Response>): {
+  fetch: typeof globalThis.fetch;
+  rpcRequests: Array<{ body: unknown; headers: Record<string, string> }>;
+} {
+  const rpcRequests: Array<{ body: unknown; headers: Record<string, string> }> = [];
+  let cursor = 0;
+  const fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/agent-card.json') || url.endsWith('/agent.json')) {
+      return agentCardResponse();
+    }
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const src = init.headers as Record<string, string>;
+      for (const k of Object.keys(src)) headers[k.toLowerCase()] = src[k]!;
+    }
+    const body = init?.body
+      ? JSON.parse(init.body as string)
+      : undefined;
+    rpcRequests.push({ body, headers });
+    const make = replies[cursor];
+    if (!make) {
+      throw new Error(`No scripted reply for RPC call #${cursor + 1}`);
+    }
+    cursor += 1;
+    return make();
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, rpcRequests };
+}
+
+describe('A2XClient.sendMessage — native x402 dance', () => {
+  it('returns the first task untouched when the agent does not require payment', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(completedTaskWithReceipt()),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('completed');
+    expect(rpcRequests).toHaveLength(1);
+  });
+
+  it('detects payment-required, signs, resubmits, and surfaces the settled task', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () => jsonRpcOk(completedTaskWithReceipt()),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+
+    expect(task.status.state).toBe('completed');
+    expect(rpcRequests).toHaveLength(2);
+
+    // Both calls carry the activation header.
+    expect(rpcRequests[0]!.headers['x-a2a-extensions']).toBe(X402_EXTENSION_URI);
+    expect(rpcRequests[1]!.headers['x-a2a-extensions']).toBe(X402_EXTENSION_URI);
+
+    // Followup carries the signed payload + same taskId/contextId.
+    const followupParams = (rpcRequests[1]!.body as { params: { message: Record<string, unknown> } }).params;
+    expect(followupParams.message.taskId).toBe('t1');
+    expect(followupParams.message.contextId).toBe('c1');
+    const meta = followupParams.message.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.SUBMITTED);
+    expect(meta[X402_METADATA_KEYS.PAYLOAD]).toBeDefined();
+  });
+
+  it('throws X402PaymentFailedError when the settle receipt is unsuccessful', async () => {
+    const { fetch } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () =>
+        jsonRpcOk(
+          failedTaskWithReceipt('insufficient_funds', 'INSUFFICIENT_FUNDS'),
+        ),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    await expect(
+      client.sendMessage({
+        message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+      }),
+    ).rejects.toBeInstanceOf(X402PaymentFailedError);
+  });
+
+  it('invokes onPaymentRequired before signing and aborts when it throws', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+    ]);
+    const onPaymentRequired = vi.fn().mockImplementation(() => {
+      throw new Error('user declined');
+    });
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT, onPaymentRequired },
+    });
+    await expect(
+      client.sendMessage({
+        message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+      }),
+    ).rejects.toThrow('user declined');
+    expect(onPaymentRequired).toHaveBeenCalledTimes(1);
+    expect(rpcRequests).toHaveLength(1); // never reached the followup
+  });
+
+  it('rejects with X402NoSupportedRequirementError when every accept exceeds maxAmount', async () => {
+    const { fetch } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT, maxAmount: 100n }, // requirement is 1000
+    });
+    await expect(
+      client.sendMessage({
+        message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+      }),
+    ).rejects.toBeInstanceOf(X402NoSupportedRequirementError);
+  });
+
+  it('honours a caller-supplied selectRequirement', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () => jsonRpcOk(completedTaskWithReceipt()),
+    ]);
+    const selectRequirement = vi.fn().mockImplementation((reqs) => reqs[0]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT, selectRequirement },
+    });
+    await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(selectRequirement).toHaveBeenCalledTimes(1);
+    expect(rpcRequests).toHaveLength(2);
+  });
+
+  it('does not run the dance when no x402 option is configured', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+    ]);
+    const client = new A2XClient(AGENT_URL, { fetch });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('input-required');
+    expect(rpcRequests).toHaveLength(1);
+    expect(rpcRequests[0]!.headers['x-a2a-extensions']).toBeUndefined();
+  });
+});
+
+describe('A2XClient.sendMessageStream — native x402 dance', () => {
+  function sseResponse(events: string[]): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const ev of events) {
+          controller.enqueue(encoder.encode(`data: ${ev}\n\n`));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  }
+
+  function statusUpdate(
+    state: string,
+    metadata: Record<string, unknown> | undefined,
+    final: boolean,
+  ): string {
+    return JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        kind: 'status-update',
+        taskId: 't1',
+        contextId: 'c1',
+        status: {
+          state,
+          timestamp: new Date().toISOString(),
+          ...(metadata
+            ? {
+                message: {
+                  messageId: `m-${state}`,
+                  role: 'agent',
+                  parts: [{ kind: 'text', text: state }],
+                  metadata,
+                },
+              }
+            : {}),
+        },
+        final,
+      },
+    });
+  }
+
+  it('yields payment-required, signs, opens the followup stream, and yields completion', async () => {
+    const firstStream = sseResponse([
+      statusUpdate(
+        'input-required',
+        {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          [X402_METADATA_KEYS.REQUIRED]: {
+            x402Version: 1,
+            accepts: [
+              {
+                scheme: 'exact',
+                network: 'base-sepolia',
+                maxAmountRequired: '1000',
+                resource: 'a2a-x402/access',
+                description: 'Per-call',
+                mimeType: 'application/json',
+                payTo: '0x000000000000000000000000000000000000dEaD',
+                maxTimeoutSeconds: 300,
+                asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+                extra: { name: 'USDC', version: '2' },
+              },
+            ],
+          },
+        },
+        true,
+      ),
+    ]);
+    const secondStream = sseResponse([
+      statusUpdate(
+        'working',
+        { [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.VERIFIED },
+        false,
+      ),
+      statusUpdate(
+        'completed',
+        {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
+          [X402_METADATA_KEYS.RECEIPTS]: [
+            { success: true, transaction: '0xabc', network: 'base-sepolia' },
+          ],
+        },
+        true,
+      ),
+    ]);
+
+    let call = 0;
+    const fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/agent-card.json') || url.endsWith('/agent.json')) {
+        return agentCardResponse();
+      }
+      call += 1;
+      if (call === 1) return firstStream;
+      if (call === 2) return secondStream;
+      throw new Error('Unexpected RPC call');
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const ev of client.sendMessageStream({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    })) {
+      events.push(ev as unknown as Record<string, unknown>);
+    }
+
+    const states = events
+      .filter((e) => 'status' in e)
+      .map((e) => {
+        const status = e.status as { state: string; message?: { metadata?: Record<string, unknown> } };
+        return {
+          state: status.state,
+          x402: status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
+        };
+      });
+
+    // Expect: payment-required → payment-verified → payment-completed
+    expect(states).toEqual([
+      { state: 'input-required', x402: X402_PAYMENT_STATUS.REQUIRED },
+      { state: 'working', x402: X402_PAYMENT_STATUS.VERIFIED },
+      { state: 'completed', x402: X402_PAYMENT_STATUS.COMPLETED },
+    ]);
+    expect(call).toBe(2);
+  });
+
+  it('passes through events untouched when no x402 option is configured', async () => {
+    const stream = sseResponse([
+      statusUpdate('completed', undefined, true),
+    ]);
+    const fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/agent-card.json') || url.endsWith('/agent.json')) {
+        return agentCardResponse();
+      }
+      return stream;
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new A2XClient(AGENT_URL, { fetch });
+    const events: unknown[] = [];
+    for await (const ev of client.sendMessageStream({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    })) {
+      events.push(ev);
+    }
+    expect(events).toHaveLength(1);
+  });
+});

--- a/packages/a2x/src/__tests__/x402-executor.test.ts
+++ b/packages/a2x/src/__tests__/x402-executor.test.ts
@@ -155,7 +155,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
     expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INVALID_PAYLOAD);
   });
 
-  it('emits VERIFY_FAILED when facilitator.verify() returns isValid=false', async () => {
+  it('maps nonce_reused verify failure to DUPLICATE_NONCE (spec §9.1)', async () => {
     const executor = makeExecutor(
       mockFacilitator({
         verify: async () => ({
@@ -176,12 +176,52 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.VERIFY_FAILED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.DUPLICATE_NONCE);
     const receipts = meta[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
     expect(receipts[0]).toMatchObject({ success: false, errorReason: expect.any(String) });
   });
 
-  it('emits SETTLE_FAILED when facilitator.settle() fails', async () => {
+  it('maps insufficient_balance verify failure to INSUFFICIENT_FUNDS (spec §9.1)', async () => {
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_exact_evm_insufficient_balance',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INSUFFICIENT_FUNDS);
+  });
+
+  it('falls back to VERIFY_FAILED when invalidReason does not match any spec §9.1 code', async () => {
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'something_the_sdk_does_not_recognize',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.VERIFY_FAILED);
+  });
+
+  it('emits SETTLEMENT_FAILED when facilitator.settle() fails', async () => {
     const executor = makeExecutor(
       mockFacilitator({
         settle: async () => ({
@@ -204,7 +244,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.SETTLE_FAILED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.SETTLEMENT_FAILED);
   });
 
   it('emits NETWORK_MISMATCH when the submitted payload targets an unaccepted network', async () => {
@@ -234,7 +274,7 @@ describe('X402PaymentExecutor — request/submit flow', () => {
     expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.NETWORK_MISMATCH);
   });
 
-  it('emits AMOUNT_EXCEEDED when authorization value is greater than maxAmountRequired', async () => {
+  it('emits INVALID_AMOUNT when authorization value is greater than maxAmountRequired (spec §9.1)', async () => {
     const executor = makeExecutor(mockFacilitator());
     const first = await executor.execute(newTask(), newMessage());
     const { payload } = await signAgainst(first);
@@ -265,7 +305,108 @@ describe('X402PaymentExecutor — request/submit flow', () => {
 
     expect(result.status.state).toBe(TaskState.FAILED);
     const meta = result.status.message?.metadata as Record<string, unknown>;
-    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.AMOUNT_EXCEEDED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INVALID_AMOUNT);
+  });
+
+  it('terminates the task when client sends payment-rejected (spec §5.4.2)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+
+    const result = await executor.execute(
+      newTask(),
+      newMessage({
+        metadata: { [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED },
+      }),
+    );
+
+    expect(result.status.state).toBe(TaskState.FAILED);
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REJECTED);
+  });
+
+  it('preserves prior receipts when payment completes after a previous failure (spec §7 history)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+
+    // Seed the task with a prior failure receipt that a retry would keep.
+    const task = newTask();
+    task.status = {
+      state: TaskState.INPUT_REQUIRED,
+      timestamp: new Date().toISOString(),
+      message: {
+        messageId: 'prior',
+        role: 'agent',
+        parts: [{ text: 'retry' }],
+        metadata: {
+          [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+          [X402_METADATA_KEYS.REQUIRED]: {
+            x402Version: 1,
+            accepts: [],
+          },
+          [X402_METADATA_KEYS.RECEIPTS]: [
+            {
+              success: false,
+              transaction: '',
+              network: 'base-sepolia',
+              errorReason: 'prior attempt failed',
+            },
+          ],
+        },
+      },
+    };
+
+    const { metadata } = await signAgainst(
+      await executor.execute(newTask(), newMessage()),
+    );
+    const completed = await executor.execute(
+      task,
+      newMessage({ messageId: 'm2', metadata }),
+    );
+
+    const receipts = (
+      completed.status.message?.metadata as Record<string, unknown>
+    )[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
+    expect(receipts).toHaveLength(2);
+    expect(receipts[0]).toMatchObject({ success: false });
+    expect(receipts[1]).toMatchObject({ success: true });
+  });
+
+  it('re-issues payment-required with error field when retryOnFailure=true (spec §5.1 error field)', async () => {
+    const agent = new EchoAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const inner = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const executor = new X402PaymentExecutor(inner, {
+      accepts: [DEFAULT_ACCEPT],
+      facilitator: mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_exact_evm_insufficient_balance',
+          payer: TEST_ACCOUNT.address,
+        }),
+      }),
+      retryOnFailure: true,
+    });
+
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+
+    // retryOnFailure keeps the task alive in input-required with the
+    // failure reason carried on the new payment-required response.
+    expect(result.status.state).toBe(TaskState.INPUT_REQUIRED);
+    const meta = result.status.message?.metadata as Record<string, unknown>;
+    expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REQUIRED);
+    expect(meta[X402_METADATA_KEYS.ERROR]).toBe(X402_ERROR_CODES.INSUFFICIENT_FUNDS);
+    const required = meta[X402_METADATA_KEYS.REQUIRED] as {
+      error?: string;
+      accepts: unknown[];
+    };
+    expect(required.error).toContain('insufficient_balance');
+    expect(required.accepts).toHaveLength(1);
   });
 });
 
@@ -304,6 +445,61 @@ describe('X402PaymentExecutor — streaming', () => {
     const states = statusEvents.map((e) => e.status.state);
     expect(states).toContain(TaskState.WORKING);
     expect(states).toContain(TaskState.COMPLETED);
+  });
+
+  it('emits a payment-verified status event between submitted and completed (spec §7.1 lifecycle)', async () => {
+    const executor = makeExecutor(mockFacilitator());
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+
+    const events: unknown[] = [];
+    for await (const event of executor.executeStream(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    )) {
+      events.push(event);
+    }
+
+    // Find the transient `working + payment-verified` event. It must
+    // occur before any COMPLETED event so streaming clients can show
+    // "settling on-chain…" progress.
+    const verifiedIdx = events.findIndex((e) => {
+      if (typeof e !== 'object' || e === null || !('status' in e)) return false;
+      const status = (e as { status: { state: TaskState; message?: { metadata?: Record<string, unknown> } } }).status;
+      return (
+        status.state === TaskState.WORKING &&
+        status.message?.metadata?.[X402_METADATA_KEYS.STATUS] ===
+          X402_PAYMENT_STATUS.VERIFIED
+      );
+    });
+    expect(verifiedIdx).toBeGreaterThanOrEqual(0);
+
+    const completedIdx = events.findIndex((e) => {
+      if (typeof e !== 'object' || e === null || !('status' in e)) return false;
+      return (e as { status: { state: TaskState } }).status.state === TaskState.COMPLETED;
+    });
+    expect(completedIdx).toBeGreaterThan(verifiedIdx);
+  });
+
+  it('emits a failed terminal when streaming client sends payment-rejected', async () => {
+    const executor = makeExecutor(mockFacilitator());
+    const events: unknown[] = [];
+    for await (const event of executor.executeStream(
+      newTask(),
+      newMessage({
+        metadata: { [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED },
+      }),
+    )) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+    const evt = events[0] as {
+      status: { state: TaskState; message?: { metadata?: Record<string, unknown> } };
+    };
+    expect(evt.status.state).toBe(TaskState.FAILED);
+    expect(evt.status.message?.metadata?.[X402_METADATA_KEYS.STATUS]).toBe(
+      X402_PAYMENT_STATUS.REJECTED,
+    );
   });
 });
 

--- a/packages/a2x/src/__tests__/x402-extension-activation.test.ts
+++ b/packages/a2x/src/__tests__/x402-extension-activation.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for spec a2a-x402 v0.2 §8 extension activation. Clients MUST
+ * include the extension URI in the `X-A2A-Extensions` HTTP header, and
+ * servers with `required: true` extensions on their AgentCard MUST reject
+ * requests missing the URI.
+ */
+import { describe, expect, it } from 'vitest';
+import { privateKeyToAccount } from 'viem/accounts';
+import { A2XClient } from '../client/a2x-client.js';
+import { X402Client, X402_EXTENSION_URI } from '../x402/index.js';
+import { A2XAgent } from '../a2x/a2x-agent.js';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent, type AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+import { InMemoryTaskStore } from '../a2x/task-store.js';
+import { DefaultRequestHandler } from '../transport/request-handler.js';
+// Ensure response mappers are registered (side-effect import).
+import '../a2x/index.js';
+
+const TEST_ACCOUNT = privateKeyToAccount(
+  '0x1111111111111111111111111111111111111111111111111111111111111111',
+);
+
+class EchoAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'echo', description: 'echo' });
+  }
+  async *run(_ctx: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'hi', role: 'agent' };
+    yield { type: 'done' };
+  }
+}
+
+/**
+ * Build a fake `fetch` that records every request's headers and returns
+ * a minimal AgentCard on the first call and a generic JSON-RPC success
+ * on every subsequent call. Lets the client resolve without talking to
+ * an actual server.
+ */
+function recordingFetch(): {
+  fetch: typeof globalThis.fetch;
+  calls: Array<{ url: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const src = init.headers as Record<string, string>;
+      for (const key of Object.keys(src)) headers[key.toLowerCase()] = src[key]!;
+    }
+    calls.push({ url, headers });
+
+    // AgentCard resolution hits /.well-known/agent-card.json or
+    // /.well-known/agent.json — return a minimal card.
+    if (url.endsWith('/agent-card.json') || url.endsWith('/agent.json')) {
+      return new Response(
+        JSON.stringify({
+          protocolVersion: '0.3.0',
+          name: 'test',
+          description: 'test',
+          url: 'https://example.com/a2a',
+          version: '1.0.0',
+          capabilities: {},
+          defaultInputModes: ['text'],
+          defaultOutputModes: ['text'],
+          skills: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    // Default: a synthetic completed task.
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          kind: 'task',
+          id: 't1',
+          contextId: 'c1',
+          status: { state: 'completed', timestamp: new Date().toISOString() },
+          artifacts: [],
+          history: [],
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as unknown as typeof globalThis.fetch;
+  return { fetch, calls };
+}
+
+describe('A2XClient — X-A2A-Extensions header (spec §8)', () => {
+  it('omits the header when no extensions are registered', async () => {
+    const { fetch, calls } = recordingFetch();
+    const client = new A2XClient('https://example.com', { fetch });
+    await client.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toBeUndefined();
+  });
+
+  it('emits the header when extensions are passed via constructor', async () => {
+    const { fetch, calls } = recordingFetch();
+    const client = new A2XClient('https://example.com', {
+      fetch,
+      extensions: ['https://example.org/ext-a', 'https://example.org/ext-b'],
+    });
+    await client.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toContain('ext-a');
+    expect(rpcCall.headers['x-a2a-extensions']).toContain('ext-b');
+  });
+
+  it('X402Client auto-registers the x402 extension URI on the inner A2XClient', async () => {
+    const { fetch, calls } = recordingFetch();
+    const inner = new A2XClient('https://example.com', { fetch });
+    new X402Client(inner, { signer: TEST_ACCOUNT });
+    await inner.sendMessage({
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ text: 'hi' }],
+      },
+    });
+    const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
+    expect(rpcCall.headers['x-a2a-extensions']).toBe(X402_EXTENSION_URI);
+  });
+});
+
+describe('DefaultRequestHandler — extension activation enforcement (spec §3.1 / §8)', () => {
+  function buildHandler(required: boolean): DefaultRequestHandler {
+    const agent = new EchoAgent();
+    const runner = new InMemoryRunner({ agent, appName: 'test' });
+    const executor = new AgentExecutor({
+      runner,
+      runConfig: { streamingMode: StreamingMode.SSE },
+    });
+    const a2x = new A2XAgent({
+      taskStore: new InMemoryTaskStore(),
+      executor,
+      protocolVersion: '0.3',
+    })
+      .setName('x')
+      .setDescription('x')
+      .setDefaultUrl('https://example.com/a2a')
+      .addExtension({ uri: X402_EXTENSION_URI, required });
+    return new DefaultRequestHandler(a2x);
+  }
+
+  const sendBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'message/send',
+    params: {
+      message: {
+        messageId: 'm1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hi' }],
+      },
+    },
+  };
+
+  it('rejects the request when a required extension is not activated', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, { headers: {} })) as {
+      error?: { code: number; message: string };
+    };
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe(-32600);
+    expect(result.error!.message).toContain(X402_EXTENSION_URI);
+  });
+
+  it('accepts the request when the required extension is listed in X-A2A-Extensions', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, {
+      headers: { 'x-a2a-extensions': X402_EXTENSION_URI },
+    })) as { result?: unknown; error?: unknown };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('accepts the request when required=false even without the header', async () => {
+    const handler = buildHandler(false);
+    const result = (await handler.handle(sendBody, { headers: {} })) as {
+      result?: unknown;
+      error?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('parses comma-separated extension URIs', async () => {
+    const handler = buildHandler(true);
+    const result = (await handler.handle(sendBody, {
+      headers: {
+        'x-a2a-extensions': `https://example.org/other, ${X402_EXTENSION_URI}`,
+      },
+    })) as { result?: unknown; error?: unknown };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+
+  it('skips the check entirely when context is not provided (in-process callers)', async () => {
+    const handler = buildHandler(true);
+    // No context → skip spec-header enforcement (matches the auth fallback).
+    const result = (await handler.handle(sendBody)) as {
+      result?: unknown;
+      error?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  });
+});

--- a/packages/a2x/src/__tests__/x402-extension-activation.test.ts
+++ b/packages/a2x/src/__tests__/x402-extension-activation.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import { privateKeyToAccount } from 'viem/accounts';
 import { A2XClient } from '../client/a2x-client.js';
-import { X402Client, X402_EXTENSION_URI } from '../x402/index.js';
+import { X402_EXTENSION_URI } from '../x402/index.js';
 import { A2XAgent } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
@@ -127,11 +127,13 @@ describe('A2XClient — X-A2A-Extensions header (spec §8)', () => {
     expect(rpcCall.headers['x-a2a-extensions']).toContain('ext-b');
   });
 
-  it('X402Client auto-registers the x402 extension URI on the inner A2XClient', async () => {
+  it('auto-registers the x402 extension URI when the x402 option is supplied', async () => {
     const { fetch, calls } = recordingFetch();
-    const inner = new A2XClient('https://example.com', { fetch });
-    new X402Client(inner, { signer: TEST_ACCOUNT });
-    await inner.sendMessage({
+    const client = new A2XClient('https://example.com', {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    await client.sendMessage({
       message: {
         messageId: 'm1',
         role: 'user',
@@ -140,6 +142,7 @@ describe('A2XClient — X-A2A-Extensions header (spec §8)', () => {
     });
     const rpcCall = calls.find((c) => c.url.endsWith('/a2a'))!;
     expect(rpcCall.headers['x-a2a-extensions']).toBe(X402_EXTENSION_URI);
+    expect(client.activatedExtensions).toContain(X402_EXTENSION_URI);
   });
 });
 

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -385,6 +385,15 @@ export class A2XAgent {
     return this._securityRequirements;
   }
 
+  /**
+   * Read-only view of declared A2A extensions. Transports use this to
+   * enforce the a2a-x402 v0.2 §8 `X-A2A-Extensions` activation header
+   * check for any extension declared with `required: true`.
+   */
+  get extensions(): readonly AgentExtension[] {
+    return this._capabilities.extensions ?? [];
+  }
+
   get pushNotificationConfigStore(): PushNotificationConfigStore | undefined {
     return this._pushNotificationConfigStore;
   }

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -5,6 +5,7 @@
  * Protocol version is determined from the AgentCard structure.
  */
 
+import type { LocalAccount } from 'viem';
 import type { AgentCardV03, AgentCardV10 } from '../types/agent-card.js';
 import type { Task } from '../types/task.js';
 import type {
@@ -43,8 +44,66 @@ import { parseSSEStream } from './sse-parser.js';
 import type { AuthProvider } from './auth-provider.js';
 import type { AuthScheme, AuthRequestContext } from './auth-scheme.js';
 import { normalizeRequirements } from './auth-normalizer.js';
+import {
+  X402_EXTENSION_URI,
+  X402_METADATA_KEYS,
+  X402_PAYMENT_STATUS,
+} from '../x402/constants.js';
+import {
+  signX402Payment,
+  getX402PaymentRequirements,
+  getX402Receipts,
+  type SignedX402Payment,
+} from '../x402/client.js';
+import { X402PaymentFailedError } from '../x402/errors.js';
+import type {
+  X402PaymentRequirements,
+  X402PaymentRequiredResponse,
+} from '../x402/types.js';
 
 // ─── Types ───
+
+/**
+ * a2a-x402 v0.2 client options. When supplied to `A2XClientOptions.x402`,
+ * `A2XClient` transparently runs the Standalone Flow: when the agent
+ * returns `payment-required`, the client signs one of the merchant's
+ * `accepts[]` requirements and resubmits with the signed payload, then
+ * surfaces only the final task to the caller.
+ *
+ * Spec: `specification/a2a-x402-v0.2.md`.
+ */
+export interface A2XClientX402Options {
+  /** viem LocalAccount used to sign EIP-3009 authorizations. */
+  signer: LocalAccount;
+  /**
+   * Maximum atomic units the client is willing to authorize per
+   * requirement. Default: no cap.
+   *
+   * Always enforced — any requirement whose `maxAmountRequired` exceeds
+   * this is filtered out before the selector runs, so a custom
+   * `selectRequirement` only sees the affordable subset. If nothing
+   * remains, signing throws `X402NoSupportedRequirementError`.
+   */
+  maxAmount?: bigint;
+  /**
+   * Custom predicate to pick a requirement out of the merchant's
+   * `accepts[]` (already filtered by `maxAmount` if set). Default:
+   * prefer `scheme === 'exact'`, else first remaining.
+   */
+  selectRequirement?: (
+    requirements: X402PaymentRequirements[],
+  ) => X402PaymentRequirements | undefined;
+  /**
+   * Hook invoked after the merchant publishes `payment-required` and
+   * before the client signs. Useful for prompting the user to confirm.
+   * Throw to abort the flow — the caller observes the merchant's
+   * unmodified `payment-required` task (blocking) or a stream that
+   * closes after the `payment-required` event (streaming).
+   */
+  onPaymentRequired?: (
+    required: X402PaymentRequiredResponse,
+  ) => void | Promise<void>;
+}
 
 export interface A2XClientOptions {
   fetch?: typeof globalThis.fetch;
@@ -56,11 +115,18 @@ export interface A2XClientOptions {
    * request per a2a-x402 v0.2 §8 and the A2A core extension activation
    * convention.
    *
-   * You can also register extensions at runtime via `registerExtension()`
-   * — this is how `X402Client` self-activates the x402 extension when
-   * wrapping an `A2XClient`.
+   * You can also register extensions at runtime via `registerExtension()`.
+   *
+   * When `x402` is supplied below, `X402_EXTENSION_URI` is added here
+   * automatically — there's no need to list it manually.
    */
   extensions?: string[];
+  /**
+   * Enables transparent a2a-x402 v0.2 payment handling. Omit when calling
+   * agents that don't gate on x402; the client behaves as a plain A2A
+   * client in that case.
+   */
+  x402?: A2XClientX402Options;
 }
 
 // ─── Error Code → Error Class Mapping ───
@@ -131,6 +197,7 @@ export class A2XClient {
   private readonly _headers: Record<string, string>;
   private readonly _authProvider?: AuthProvider;
   private readonly _extensions: Set<string>;
+  private readonly _x402?: A2XClientX402Options;
   private _resolved: ResolvedAgentCard | null = null;
   private _parser: ResponseParser | null = null;
   private _endpointUrl: string | null = null;
@@ -146,15 +213,17 @@ export class A2XClient {
     this._headers = options?.headers ?? {};
     this._authProvider = options?.authProvider;
     this._extensions = new Set(options?.extensions ?? []);
+    this._x402 = options?.x402;
+    if (this._x402) {
+      // Spec a2a-x402 v0.2 §8: clients MUST activate the extension via
+      // `X-A2A-Extensions`. Auto-register so callers don't have to.
+      this._extensions.add(X402_EXTENSION_URI);
+    }
   }
 
   /**
    * Register an A2A extension URI to be included in the
    * `X-A2A-Extensions` header on subsequent requests. Idempotent.
-   *
-   * Used by extension wrappers (e.g. `X402Client`) to self-activate
-   * without requiring the caller to remember to pass `extensions` into
-   * the `A2XClient` constructor.
    */
   registerExtension(uri: string): void {
     this._extensions.add(uri);
@@ -170,8 +239,124 @@ export class A2XClient {
   /**
    * Send a message and wait for the complete response.
    * Uses JSON-RPC method `message/send`.
+   *
+   * When `options.x402` is set on this client and the agent responds with
+   * `payment-required`, the dance is run transparently — the returned
+   * task is the final settled task.
    */
   async sendMessage(params: SendMessageParams): Promise<Task> {
+    const first = await this._sendMessageOnce(params);
+    if (!this._x402) return first;
+    if (first.status.state !== 'input-required') return first;
+
+    const required = getX402PaymentRequirements(first);
+    if (!required) return first;
+
+    if (this._x402.onPaymentRequired) {
+      await this._x402.onPaymentRequired(required);
+    }
+
+    const signed = await this._signX402(first);
+
+    const followup: SendMessageParams = {
+      ...params,
+      message: {
+        ...params.message,
+        messageId: globalThis.crypto.randomUUID(),
+        taskId: first.id,
+        contextId: first.contextId,
+        metadata: {
+          ...(params.message.metadata ?? {}),
+          ...signed.metadata,
+        },
+      },
+    };
+
+    const second = await this._sendMessageOnce(followup);
+
+    const receipts = getX402Receipts(second);
+    const failed = receipts.find((r) => !r.success);
+    if (failed) {
+      const errorCode =
+        ((second.status.message?.metadata as Record<string, unknown> | undefined)?.[
+          X402_METADATA_KEYS.ERROR
+        ] as string | undefined) ?? 'UNKNOWN';
+      throw new X402PaymentFailedError(
+        failed.errorReason ?? 'Payment failed',
+        errorCode,
+        { transaction: failed.transaction, network: failed.network },
+      );
+    }
+
+    return second;
+  }
+
+  /**
+   * Send a message and stream the response via SSE.
+   * Uses JSON-RPC method `message/stream`.
+   *
+   * When `options.x402` is set on this client and the first stream emits
+   * `payment-required`, the dance runs transparently: that event is
+   * yielded to the caller, the first stream is abandoned, and the
+   * follow-up stream's events (`payment-verified` → `working` →
+   * artifacts → `payment-completed`) are yielded on the same generator.
+   */
+  async *sendMessageStream(
+    params: SendMessageParams,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
+    if (!this._x402) {
+      yield* this._sendMessageStreamOnce(params, signal);
+      return;
+    }
+
+    let firstTask: Task | undefined;
+    for await (const event of this._sendMessageStreamOnce(params, signal)) {
+      yield event;
+      if ('status' in event && event.status?.state === 'input-required') {
+        const meta = event.status.message?.metadata as
+          | Record<string, unknown>
+          | undefined;
+        if (meta?.[X402_METADATA_KEYS.STATUS] === X402_PAYMENT_STATUS.REQUIRED) {
+          firstTask = {
+            id: event.taskId,
+            contextId: event.contextId,
+            status: event.status,
+          } as Task;
+          break;
+        }
+      }
+    }
+
+    if (!firstTask) return;
+
+    const required = getX402PaymentRequirements(firstTask);
+    if (!required) return;
+
+    if (this._x402.onPaymentRequired) {
+      await this._x402.onPaymentRequired(required);
+    }
+
+    const signed = await this._signX402(firstTask);
+
+    const followup: SendMessageParams = {
+      ...params,
+      message: {
+        ...params.message,
+        messageId: globalThis.crypto.randomUUID(),
+        taskId: firstTask.id,
+        contextId: firstTask.contextId,
+        metadata: {
+          ...(params.message.metadata ?? {}),
+          ...signed.metadata,
+        },
+      },
+    };
+
+    yield* this._sendMessageStreamOnce(followup, signal);
+  }
+
+  private async _sendMessageOnce(params: SendMessageParams): Promise<Task> {
     await this._ensureResolved();
     await this._ensureAuthenticated();
     const formatted = this._formatParams(params);
@@ -180,11 +365,7 @@ export class A2XClient {
     return this._parser!.parseTask(result);
   }
 
-  /**
-   * Send a message and stream the response via SSE.
-   * Uses JSON-RPC method `message/stream`.
-   */
-  async *sendMessageStream(
+  private async *_sendMessageStreamOnce(
     params: SendMessageParams,
     signal?: AbortSignal,
   ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
@@ -230,6 +411,27 @@ export class A2XClient {
     }
 
     yield* parseSSEStream(response, this._parser!);
+  }
+
+  private async _signX402(task: Task): Promise<SignedX402Payment> {
+    const x402 = this._x402!;
+    const userSelect = x402.selectRequirement;
+    const select = (
+      reqs: X402PaymentRequirements[],
+    ): X402PaymentRequirements | undefined => {
+      // maxAmount is enforced first regardless of caller predicate, so a
+      // user-provided selectRequirement only sees the affordable subset.
+      const affordable =
+        x402.maxAmount === undefined
+          ? reqs
+          : reqs.filter((r) => isWithinBudget(r, x402.maxAmount!));
+      if (userSelect) return userSelect(affordable);
+      return affordable.find((r) => r.scheme === 'exact') ?? affordable[0];
+    };
+    return signX402Payment(task, {
+      signer: x402.signer,
+      selectRequirement: select,
+    });
   }
 
   /**
@@ -462,5 +664,18 @@ export class A2XClient {
     }
 
     return (jsonRpcResponse as { result: unknown }).result;
+  }
+}
+
+function isWithinBudget(
+  requirement: X402PaymentRequirements,
+  maxAmount: bigint,
+): boolean {
+  try {
+    return BigInt(requirement.maxAmountRequired) <= maxAmount;
+  } catch {
+    // Unparseable amount — defer to the signer to fail loudly rather
+    // than silently swallow the requirement.
+    return true;
   }
 }

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -50,6 +50,17 @@ export interface A2XClientOptions {
   fetch?: typeof globalThis.fetch;
   headers?: Record<string, string>;
   authProvider?: AuthProvider;
+  /**
+   * A2A extension URIs the client wants to activate. Emitted as a
+   * comma-separated `X-A2A-Extensions` HTTP header on every JSON-RPC
+   * request per a2a-x402 v0.2 §8 and the A2A core extension activation
+   * convention.
+   *
+   * You can also register extensions at runtime via `registerExtension()`
+   * — this is how `X402Client` self-activates the x402 extension when
+   * wrapping an `A2XClient`.
+   */
+  extensions?: string[];
 }
 
 // ─── Error Code → Error Class Mapping ───
@@ -119,6 +130,7 @@ export class A2XClient {
   private readonly _fetchImpl: typeof globalThis.fetch;
   private readonly _headers: Record<string, string>;
   private readonly _authProvider?: AuthProvider;
+  private readonly _extensions: Set<string>;
   private _resolved: ResolvedAgentCard | null = null;
   private _parser: ResponseParser | null = null;
   private _endpointUrl: string | null = null;
@@ -133,6 +145,24 @@ export class A2XClient {
     this._fetchImpl = options?.fetch ?? globalThis.fetch;
     this._headers = options?.headers ?? {};
     this._authProvider = options?.authProvider;
+    this._extensions = new Set(options?.extensions ?? []);
+  }
+
+  /**
+   * Register an A2A extension URI to be included in the
+   * `X-A2A-Extensions` header on subsequent requests. Idempotent.
+   *
+   * Used by extension wrappers (e.g. `X402Client`) to self-activate
+   * without requiring the caller to remember to pass `extensions` into
+   * the `A2XClient` constructor.
+   */
+  registerExtension(uri: string): void {
+    this._extensions.add(uri);
+  }
+
+  /** Read-only view of currently activated extension URIs. */
+  get activatedExtensions(): readonly string[] {
+    return [...this._extensions];
   }
 
   // ─── Public Methods ───
@@ -363,11 +393,18 @@ export class A2XClient {
   private _buildHeaders(
     extra?: Record<string, string>,
   ): Record<string, string> {
-    return {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...extra,
       ...this._headers,
     };
+    if (this._extensions.size > 0) {
+      // Spec a2a-x402 v0.2 §8: clients MUST request activation via
+      // `X-A2A-Extensions`. Multiple active extensions are comma-separated
+      // per standard HTTP list-header convention.
+      headers['X-A2A-Extensions'] = [...this._extensions].join(', ');
+    }
+    return headers;
   }
 
   private _buildJsonRpcRequest(

--- a/packages/a2x/src/client/index.ts
+++ b/packages/a2x/src/client/index.ts
@@ -3,7 +3,10 @@
  */
 
 export { A2XClient } from './a2x-client.js';
-export type { A2XClientOptions } from './a2x-client.js';
+export type {
+  A2XClientOptions,
+  A2XClientX402Options,
+} from './a2x-client.js';
 
 export {
   resolveAgentCard,

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -139,6 +139,22 @@ export class DefaultRequestHandler {
       }
     }
 
+    // Enforce `required: true` extension activation per spec a2a-x402 v0.2
+    // §3.1 / §8. Clients must list the extension URI in the
+    // `X-A2A-Extensions` header; unactivated clients get a -32600
+    // InvalidRequest. Skipped when no request context is provided
+    // (in-process / test invocations without HTTP framing).
+    if (context) {
+      const activationError = this._validateExtensionActivation(context);
+      if (activationError) {
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          error: activationError.toJSONRPCError(),
+        };
+      }
+    }
+
     // Special-case: authenticated extended card needs authResult; do not
     // route via JsonRpcRouter because that layer has no access to auth.
     if (request.method === A2A_METHODS.GET_EXTENDED_CARD) {
@@ -279,6 +295,32 @@ export class DefaultRequestHandler {
       authenticated: false,
       error: errors.join('; '),
     };
+  }
+
+  /**
+   * Parse the `X-A2A-Extensions` header (comma-separated list) and
+   * validate that every `required: true` extension declared on the
+   * AgentCard is present. Returns an `InvalidRequestError` when any
+   * required extension is missing, `null` on success.
+   *
+   * Spec a2a-x402 v0.2 §3.1 / §8: clients MUST list activated extension
+   * URIs, and agents should reject requests that omit a required one.
+   */
+  private _validateExtensionActivation(
+    context: RequestContext,
+  ): InvalidRequestError | null {
+    const required = this.a2xAgent.extensions.filter((ext) => ext.required);
+    if (required.length === 0) return null;
+
+    const activated = parseActivatedExtensions(context.headers);
+    const missing = required
+      .map((ext) => ext.uri)
+      .filter((uri) => !activated.has(uri));
+
+    if (missing.length === 0) return null;
+    return new InvalidRequestError(
+      `Required A2A extensions not activated. Include these URIs in the X-A2A-Extensions header: ${missing.join(', ')}`,
+    );
   }
 
   // ─── Private: Route Registration ───
@@ -910,4 +952,26 @@ export class DefaultRequestHandler {
       metadata: p.metadata as Record<string, unknown> | undefined,
     };
   }
+}
+
+/**
+ * Parse the `X-A2A-Extensions` header into a set of URIs. Header names
+ * are case-insensitive; values may be comma-separated or repeated. Runs
+ * against the generic `RequestContext.headers` map populated by the
+ * transport adapter (Next.js / Express / etc.).
+ */
+function parseActivatedExtensions(
+  headers: Record<string, string | string[] | undefined>,
+): Set<string> {
+  const activated = new Set<string>();
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() !== 'x-a2a-extensions') continue;
+    const raw = Array.isArray(value) ? value : value ? [value] : [];
+    for (const entry of raw) {
+      for (const uri of entry.split(',').map((s) => s.trim())) {
+        if (uri.length > 0) activated.add(uri);
+      }
+    }
+  }
+  return activated;
 }

--- a/packages/a2x/src/x402/client.ts
+++ b/packages/a2x/src/x402/client.ts
@@ -26,6 +26,7 @@ import type { SendMessageParams } from '../types/jsonrpc.js';
 import type { Task } from '../types/task.js';
 import type { Message } from '../types/common.js';
 import {
+  X402_EXTENSION_URI,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
   type X402PaymentStatus,
@@ -174,7 +175,12 @@ export class X402Client {
   constructor(
     private readonly _client: A2XClient,
     private readonly _options: X402ClientOptions,
-  ) {}
+  ) {
+    // a2a-x402 v0.2 §8: clients MUST activate the extension via the
+    // `X-A2A-Extensions` header. Register on the wrapped A2XClient so
+    // callers don't have to remember to pass `extensions` themselves.
+    this._client.registerExtension(X402_EXTENSION_URI);
+  }
 
   /**
    * Send a message, resolving payment if the merchant asks for it.

--- a/packages/a2x/src/x402/client.ts
+++ b/packages/a2x/src/x402/client.ts
@@ -1,16 +1,13 @@
 /**
  * Client-side x402 helpers.
  *
- * Two patterns are exposed:
- *
- *  1. `signX402Payment(task, { signer })` — primitive. Takes a
- *     `payment-required` task, selects one of the requirements, signs it
- *     with the caller's wallet, and returns the metadata the caller
- *     should attach to the follow-up message.
- *
- *  2. `X402Client` — wrapper around `A2XClient` that runs the full
- *     payment dance automatically: sendMessage → detect payment-required →
- *     sign → resubmit → return completed task.
+ * The high-level Standalone Flow is built into `A2XClient` itself —
+ * pass `{ x402: { signer } }` to its constructor and it transparently
+ * handles `payment-required` → sign → resubmit. The helpers here are
+ * the lower-level primitives those built-ins compose, exposed for
+ * callers that need to drive the dance manually (e.g. inspect the
+ * `payment-required` task before signing, or build their own
+ * orchestration on top).
  *
  * We accept any viem-compatible `LocalAccount` as the signer, which keeps
  * the SDK wallet-agnostic (CLI, browser wallets, HSM-backed signers etc.
@@ -21,19 +18,14 @@ import type { LocalAccount } from 'viem';
 import { createPaymentHeader as createX402PaymentHeader } from 'x402/client';
 import { safeBase64Decode } from 'x402/shared';
 import { PaymentPayloadSchema } from 'x402/types';
-import { A2XClient } from '../client/a2x-client.js';
-import type { SendMessageParams } from '../types/jsonrpc.js';
 import type { Task } from '../types/task.js';
-import type { Message } from '../types/common.js';
 import {
-  X402_EXTENSION_URI,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
   type X402PaymentStatus,
 } from './constants.js';
 import {
   X402NoSupportedRequirementError,
-  X402PaymentFailedError,
   X402PaymentRequiredError,
 } from './errors.js';
 import type {
@@ -107,7 +99,8 @@ export function getX402Status(task: Task): X402PaymentStatus | undefined {
 /**
  * Sign a payment for the given `payment-required` task. Callers
  * typically use this when they want fine-grained control of the
- * subsequent `message/send` call.
+ * subsequent `message/send` call. For a one-call API that handles the
+ * full dance, configure `A2XClient` with `{ x402: { signer } }`.
  */
 export async function signX402Payment(
   task: Task,
@@ -153,91 +146,4 @@ function defaultSelect(
   requirements: X402PaymentRequirements[],
 ): X402PaymentRequirements | undefined {
   return requirements.find((r) => r.scheme === 'exact') ?? requirements[0];
-}
-
-// ─── Convenience wrapper ────────────────────────────────────────────────
-
-export interface X402ClientOptions extends SignX402PaymentOptions {
-  /**
-   * Optional callback invoked after the merchant asks for payment and
-   * before the client signs. Useful for prompting the user to confirm.
-   * Throw from the callback to abort the payment flow.
-   */
-  onPaymentRequired?: (required: X402PaymentRequiredResponse) => void | Promise<void>;
-}
-
-/**
- * Thin wrapper around `A2XClient` that transparently handles x402
- * payment challenges. Use when the calling code doesn't need to inspect
- * the `payment-required` task itself.
- */
-export class X402Client {
-  constructor(
-    private readonly _client: A2XClient,
-    private readonly _options: X402ClientOptions,
-  ) {
-    // a2a-x402 v0.2 §8: clients MUST activate the extension via the
-    // `X-A2A-Extensions` header. Register on the wrapped A2XClient so
-    // callers don't have to remember to pass `extensions` themselves.
-    this._client.registerExtension(X402_EXTENSION_URI);
-  }
-
-  /**
-   * Send a message, resolving payment if the merchant asks for it.
-   * Returns the final completed (or failed) Task.
-   */
-  async sendMessage(params: SendMessageParams): Promise<Task> {
-    const first = await this._client.sendMessage(params);
-    if (first.status.state !== 'input-required') {
-      return first;
-    }
-    const required = getX402PaymentRequirements(first);
-    if (!required) {
-      return first;
-    }
-    if (this._options.onPaymentRequired) {
-      await this._options.onPaymentRequired(required);
-    }
-
-    const signed = await signX402Payment(first, this._options);
-    const followup: Message = {
-      ...params.message,
-      messageId: cryptoRandomId(),
-      taskId: first.id,
-      contextId: first.contextId,
-      metadata: {
-        ...(params.message.metadata ?? {}),
-        ...signed.metadata,
-      },
-    };
-
-    const second = await this._client.sendMessage({
-      ...params,
-      message: followup,
-    });
-
-    const receipts = getX402Receipts(second);
-    const failed = receipts.find((r) => !r.success);
-    if (failed) {
-      throw new X402PaymentFailedError(
-        failed.errorReason ?? 'Payment failed',
-        (second.status.message?.metadata as Record<string, unknown> | undefined)?.[
-          X402_METADATA_KEYS.ERROR
-        ] as string ?? 'UNKNOWN',
-        { transaction: failed.transaction, network: failed.network },
-      );
-    }
-
-    return second;
-  }
-
-  /** Access the underlying A2XClient for non-x402 operations. */
-  get client(): A2XClient {
-    return this._client;
-  }
-}
-
-function cryptoRandomId(): string {
-  // Node 18+ + modern browsers expose globalThis.crypto.randomUUID().
-  return globalThis.crypto.randomUUID();
 }

--- a/packages/a2x/src/x402/constants.ts
+++ b/packages/a2x/src/x402/constants.ts
@@ -40,19 +40,98 @@ export const X402_PAYMENT_STATUS = {
 export type X402PaymentStatus =
   (typeof X402_PAYMENT_STATUS)[keyof typeof X402_PAYMENT_STATUS];
 
-/** Error codes the SDK may emit via `X402_METADATA_KEYS.ERROR`. */
+/**
+ * Error codes the SDK emits via `X402_METADATA_KEYS.ERROR`.
+ *
+ * The codes from spec §9.1 "Common Error Codes" are wire-identical to the
+ * spec. Additional SDK-specific codes cover failure modes the SDK detects
+ * before or outside the facilitator's purview (payload shape problems,
+ * configuration mismatches) and are documented as proprietary extensions
+ * of §9.1's open list.
+ */
 export const X402_ERROR_CODES = {
-  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  // ─── Spec §9.1 — use these verbatim for wire compatibility ───
+  INSUFFICIENT_FUNDS: 'INSUFFICIENT_FUNDS',
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  EXPIRED_PAYMENT: 'EXPIRED_PAYMENT',
+  DUPLICATE_NONCE: 'DUPLICATE_NONCE',
   NETWORK_MISMATCH: 'NETWORK_MISMATCH',
+  INVALID_AMOUNT: 'INVALID_AMOUNT',
+  SETTLEMENT_FAILED: 'SETTLEMENT_FAILED',
+  // ─── SDK-specific (outside spec §9.1) ───
+  /** Payment payload is missing, unparseable, or structurally invalid. */
+  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  /** Authorization target address does not match the advertised `payTo`. */
   INVALID_PAY_TO: 'INVALID_PAY_TO',
-  AMOUNT_EXCEEDED: 'AMOUNT_EXCEEDED',
+  /**
+   * Fallback for verify failures whose `invalidReason` doesn't map to a
+   * more specific spec §9.1 code. Prefer the specific code when possible.
+   */
   VERIFY_FAILED: 'VERIFY_FAILED',
-  SETTLE_FAILED: 'SETTLE_FAILED',
-  NO_REQUIREMENTS: 'NO_REQUIREMENTS',
 } as const;
 
 export type X402ErrorCode =
   (typeof X402_ERROR_CODES)[keyof typeof X402_ERROR_CODES];
+
+/**
+ * Map a facilitator's `invalidReason` string to a spec §9.1 error code.
+ *
+ * Facilitator implementations (including the Coinbase reference one)
+ * return free-form reason strings that embed the actual failure cause.
+ * We do best-effort substring matching so clients can branch on the
+ * well-known spec codes instead of scraping prose. When no substring
+ * matches, returns `VERIFY_FAILED` so the caller always has something.
+ */
+export function mapVerifyFailureToCode(
+  invalidReason: string | undefined,
+): X402ErrorCode {
+  if (!invalidReason) return X402_ERROR_CODES.VERIFY_FAILED;
+  const reason = invalidReason.toLowerCase();
+  if (
+    reason.includes('insufficient_funds') ||
+    reason.includes('insufficient_balance') ||
+    reason.includes('insufficient-balance')
+  ) {
+    return X402_ERROR_CODES.INSUFFICIENT_FUNDS;
+  }
+  if (
+    reason.includes('nonce_reused') ||
+    reason.includes('duplicate_nonce') ||
+    reason.includes('nonce_used') ||
+    reason.includes('used_nonce')
+  ) {
+    return X402_ERROR_CODES.DUPLICATE_NONCE;
+  }
+  if (
+    reason.includes('expired') ||
+    reason.includes('valid_before') ||
+    reason.includes('validbefore') ||
+    reason.includes('valid_after') ||
+    reason.includes('validafter')
+  ) {
+    return X402_ERROR_CODES.EXPIRED_PAYMENT;
+  }
+  if (
+    reason.includes('invalid_signature') ||
+    reason.includes('signature_invalid') ||
+    reason.includes('bad_signature')
+  ) {
+    return X402_ERROR_CODES.INVALID_SIGNATURE;
+  }
+  if (
+    reason.includes('network_mismatch') ||
+    reason.includes('wrong_network')
+  ) {
+    return X402_ERROR_CODES.NETWORK_MISMATCH;
+  }
+  if (
+    reason.includes('invalid_amount') ||
+    reason.includes('amount_mismatch')
+  ) {
+    return X402_ERROR_CODES.INVALID_AMOUNT;
+  }
+  return X402_ERROR_CODES.VERIFY_FAILED;
+}
 
 /** Default maximum payment completion window per `PaymentRequirements.maxTimeoutSeconds`. */
 export const X402_DEFAULT_TIMEOUT_SECONDS = 300;

--- a/packages/a2x/src/x402/errors.ts
+++ b/packages/a2x/src/x402/errors.ts
@@ -1,7 +1,7 @@
 /**
- * x402-specific error types. Thrown client-side by helpers like
- * `signX402Payment` and `X402Client` when the server or the x402 flow
- * itself produces something unactionable.
+ * x402-specific error types. Thrown client-side by `A2XClient` (when
+ * its `x402` option is configured) and the `signX402Payment` primitive
+ * when the server or the x402 flow itself produces something unactionable.
  *
  * Server-side the SDK doesn't throw — it emits a `payment-failed` task
  * status with an error code under `x402.payment.error`.

--- a/packages/a2x/src/x402/executor.ts
+++ b/packages/a2x/src/x402/executor.ts
@@ -5,6 +5,8 @@
  *  - "payment-submitted" → verify + settle on-chain, then run the inner
  *    executor with the original user content, and attach the settlement
  *    receipt to the response.
+ *  - "payment-rejected" → client declined the requirements; terminate the
+ *    task without re-prompting (spec §5.4.2 + §7.1 rejection transition).
  *  - anything else → respond with a `payment-required` task state carrying
  *    the `X402PaymentRequiredResponse` in message metadata. The task is
  *    left in `input-required` so the client can resume it by resending the
@@ -29,6 +31,7 @@ import {
   X402_DEFAULT_TIMEOUT_SECONDS,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
+  mapVerifyFailureToCode,
   type X402ErrorCode,
 } from './constants.js';
 import { resolveFacilitator, type FacilitatorUrlConfig } from './facilitator.js';
@@ -60,12 +63,24 @@ export interface X402PaymentExecutorOptions {
    * through without charging. Default: always require payment.
    */
   requiresPayment?: (message: Message) => boolean;
+  /**
+   * When true, verify/settle failures re-issue `payment-required` on the
+   * same task (keeping it in `input-required`) with the failure reason
+   * carried in `X402PaymentRequiredResponse.error` per spec §5.1 / §5.3.
+   * When false (default), failures terminate the task with state `failed`.
+   *
+   * Spec §9 explicitly allows either strategy: "the agent could leave the
+   * Task state as working or request a payment requirement with
+   * input-required again."
+   */
+  retryOnFailure?: boolean;
 }
 
 interface ResolvedConfig {
   accepts: X402PaymentRequirements[];
   facilitator: X402Facilitator;
   requiresPayment: (message: Message) => boolean;
+  retryOnFailure: boolean;
 }
 
 export class X402PaymentExecutor extends AgentExecutor {
@@ -85,6 +100,11 @@ export class X402PaymentExecutor extends AgentExecutor {
 
     const status = getPaymentStatus(message);
 
+    if (status === X402_PAYMENT_STATUS.REJECTED) {
+      applyRejectedStatus(task);
+      return task;
+    }
+
     if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
       applyPaymentRequiredStatus(task, this._buildRequirements());
       return task;
@@ -93,7 +113,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const payload = getPaymentPayload(message);
     const authorization = getEvmAuthorization(payload);
     if (!payload || !authorization) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
@@ -105,7 +125,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const accepted = this._matchRequirement(payload);
     const validationErr = validatePayloadAgainstRequirement(payload, accepted);
     if (validationErr) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         validationErr.code,
         validationErr.reason,
@@ -116,22 +136,32 @@ export class X402PaymentExecutor extends AgentExecutor {
 
     const verifyResult = await this._config.facilitator.verify(payload, accepted!);
     if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.VERIFY_FAILED,
+        mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
       );
       return task;
     }
 
+    // Capture receipts on the task BEFORE the inner executor rewrites
+    // `task.status` (which happens in _inner.execute). Without this the
+    // "complete history" guarantee from spec §7 is lost across a retry.
+    const priorReceipts = getExistingReceipts(task);
+
+    // Verified — record the intermediate state per spec §7.1 even though a
+    // blocking execute() doesn't surface it to the client separately.
+    applyVerifiedStatus(task);
+
     const settleResult = await this._config.facilitator.settle(payload, accepted!);
     if (!settleResult.success) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.SETTLE_FAILED,
+        X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        priorReceipts,
       );
       return task;
     }
@@ -143,7 +173,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     };
 
     const result = await this._inner.execute(task, message);
-    attachReceipt(result, receipt);
+    attachCompletedReceipt(result, receipt, priorReceipts);
     return result;
   }
 
@@ -159,20 +189,22 @@ export class X402PaymentExecutor extends AgentExecutor {
     const contextId = task.contextId ?? task.id;
     const status = getPaymentStatus(message);
 
+    if (status === X402_PAYMENT_STATUS.REJECTED) {
+      applyRejectedStatus(task);
+      yield { taskId: task.id, contextId, status: task.status };
+      return;
+    }
+
     if (status !== X402_PAYMENT_STATUS.SUBMITTED) {
       applyPaymentRequiredStatus(task, this._buildRequirements());
-      yield {
-        taskId: task.id,
-        contextId,
-        status: task.status,
-      };
+      yield { taskId: task.id, contextId, status: task.status };
       return;
     }
 
     const payload = getPaymentPayload(message);
     const authorization = getEvmAuthorization(payload);
     if (!payload || !authorization) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
@@ -185,7 +217,7 @@ export class X402PaymentExecutor extends AgentExecutor {
     const accepted = this._matchRequirement(payload);
     const validationErr = validatePayloadAgainstRequirement(payload, accepted);
     if (validationErr) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
         validationErr.code,
         validationErr.reason,
@@ -195,25 +227,38 @@ export class X402PaymentExecutor extends AgentExecutor {
       return;
     }
 
+    // Capture receipts before verify/settle/inner-stream rewrites
+    // `task.status`. Same reason as the execute() path — preserve the
+    // "complete history" guarantee from spec §7.
+    const priorReceipts = getExistingReceipts(task);
+
     const verifyResult = await this._config.facilitator.verify(payload, accepted!);
     if (!verifyResult.isValid) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.VERIFY_FAILED,
+        mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
+        priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
     }
 
+    // Spec §7.1 lifecycle: SUBMITTED → VERIFIED → COMPLETED. Emit the
+    // intermediate VERIFIED state so streaming clients can surface
+    // "settling on-chain…" progress before the final receipt arrives.
+    applyVerifiedStatus(task);
+    yield { taskId: task.id, contextId, status: task.status };
+
     const settleResult = await this._config.facilitator.settle(payload, accepted!);
     if (!settleResult.success) {
-      applyFailedPaymentStatus(
+      this._handlePaymentFailure(
         task,
-        X402_ERROR_CODES.SETTLE_FAILED,
+        X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
@@ -234,7 +279,7 @@ export class X402PaymentExecutor extends AgentExecutor {
       yield event;
     }
 
-    attachReceipt(task, receipt);
+    attachCompletedReceipt(task, receipt, priorReceipts);
     if (lastStatusEvent) {
       yield {
         taskId: task.id,
@@ -250,11 +295,15 @@ export class X402PaymentExecutor extends AgentExecutor {
 
   // ─── Private ───
 
-  private _buildRequirements(): X402PaymentRequiredResponse {
-    return {
+  private _buildRequirements(
+    previousError?: string,
+  ): X402PaymentRequiredResponse {
+    const response: X402PaymentRequiredResponse = {
       x402Version: 1,
       accepts: this._config.accepts,
     };
+    if (previousError) response.error = previousError;
+    return response;
   }
 
   private _matchRequirement(
@@ -263,6 +312,42 @@ export class X402PaymentExecutor extends AgentExecutor {
     return this._config.accepts.find(
       (req) => req.network === payload.network && req.scheme === payload.scheme,
     );
+  }
+
+  /**
+   * Dispatch on `retryOnFailure`: either terminate the task with `failed`
+   * (default, terse) or re-issue `payment-required` with the failure
+   * reason carried in the `error` field (opt-in, allows client retry).
+   *
+   * `explicitPrior` lets the caller pass in receipts captured before a
+   * downstream step (e.g. `_inner.execute`) rewrote `task.status`. When
+   * omitted, prior receipts are read from the current `task.status`.
+   */
+  private _handlePaymentFailure(
+    task: Task,
+    code: X402ErrorCode,
+    reason: string,
+    network: string | undefined,
+    explicitPrior?: X402SettleResponse[],
+  ): void {
+    const receipt: X402SettleResponse = {
+      success: false,
+      transaction: '',
+      network: network ?? 'unknown',
+      errorReason: reason,
+    };
+    const prior = explicitPrior ?? getExistingReceipts(task);
+    if (this._config.retryOnFailure) {
+      applyRetryRequiredStatus(
+        task,
+        this._buildRequirements(reason),
+        receipt,
+        code,
+        prior,
+      );
+    } else {
+      applyFailedPaymentStatus(task, code, reason, receipt, prior);
+    }
   }
 }
 
@@ -278,6 +363,7 @@ function resolveOptions(options: X402PaymentExecutorOptions): ResolvedConfig {
     accepts: options.accepts.map(normalizeAccept),
     facilitator: resolveFacilitator(options.facilitator),
     requiresPayment: options.requiresPayment ?? (() => true),
+    retryOnFailure: options.retryOnFailure ?? false,
   };
 }
 
@@ -306,6 +392,13 @@ function getPaymentPayload(message: Message): X402PaymentPayload | undefined {
   return meta[X402_METADATA_KEYS.PAYLOAD] as X402PaymentPayload | undefined;
 }
 
+/** Read the prior receipts array off the task's status message metadata. */
+function getExistingReceipts(task: Task): X402SettleResponse[] {
+  const meta = (task.status.message?.metadata ?? {}) as Record<string, unknown>;
+  const prior = meta[X402_METADATA_KEYS.RECEIPTS];
+  return Array.isArray(prior) ? (prior as X402SettleResponse[]) : [];
+}
+
 function applyPaymentRequiredStatus(
   task: Task,
   requirements: X402PaymentRequiredResponse,
@@ -325,18 +418,55 @@ function applyPaymentRequiredStatus(
   };
 }
 
+/**
+ * Transition to a transient "verified" state between the facilitator's
+ * verify call and the subsequent settle call. Spec §7.1 state machine
+ * and x402-transport-a2a-v1.md map this to task state `working` with
+ * `x402.payment.status: payment-verified`.
+ */
+function applyVerifiedStatus(task: Task): void {
+  task.status = {
+    state: TaskState.WORKING,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [{ text: 'Payment verified. Settling on-chain…' }],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.VERIFIED,
+      },
+    },
+  };
+}
+
+/**
+ * Terminate the task after the client signalled `payment-rejected`. Spec
+ * §7.1 transition PAYMENT_REQUIRED → PAYMENT_REJECTED; we use task state
+ * `failed` to end the loop (spec doesn't mandate the exact terminal, only
+ * that the loop ends).
+ */
+function applyRejectedStatus(task: Task): void {
+  task.status = {
+    state: TaskState.FAILED,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [{ text: 'Payment was declined by the client.' }],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED,
+      },
+    },
+  };
+}
+
 function applyFailedPaymentStatus(
   task: Task,
   code: X402ErrorCode,
   reason: string,
-  network: string | undefined,
+  receipt: X402SettleResponse,
+  prior: X402SettleResponse[],
 ): void {
-  const receipt: X402SettleResponse = {
-    success: false,
-    transaction: '',
-    network: network ?? 'unknown',
-    errorReason: reason,
-  };
   task.status = {
     state: TaskState.FAILED,
     timestamp: new Date().toISOString(),
@@ -347,13 +477,51 @@ function applyFailedPaymentStatus(
       metadata: {
         [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.FAILED,
         [X402_METADATA_KEYS.ERROR]: code,
-        [X402_METADATA_KEYS.RECEIPTS]: [receipt],
+        [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
       },
     },
   };
 }
 
-function attachReceipt(task: Task, receipt: X402SettleResponse): void {
+/**
+ * Retry variant: instead of terminating, re-publish `payment-required`
+ * on the same task with the failure reason in `error`. Allows the client
+ * to fix the issue (top up wallet, resign with fresh nonce, etc.) and
+ * re-submit without creating a new task.
+ */
+function applyRetryRequiredStatus(
+  task: Task,
+  requirements: X402PaymentRequiredResponse,
+  receipt: X402SettleResponse,
+  code: X402ErrorCode,
+  prior: X402SettleResponse[],
+): void {
+  task.status = {
+    state: TaskState.INPUT_REQUIRED,
+    timestamp: new Date().toISOString(),
+    message: {
+      messageId: `x402-${Date.now()}`,
+      role: 'agent',
+      parts: [
+        {
+          text: `Payment failed: ${receipt.errorReason ?? 'unknown error'}. Please retry.`,
+        },
+      ],
+      metadata: {
+        [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+        [X402_METADATA_KEYS.REQUIRED]: requirements,
+        [X402_METADATA_KEYS.ERROR]: code,
+        [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
+      },
+    },
+  };
+}
+
+function attachCompletedReceipt(
+  task: Task,
+  receipt: X402SettleResponse,
+  explicitPrior?: X402SettleResponse[],
+): void {
   if (!task.status.message) {
     task.status.message = {
       messageId: `x402-${Date.now()}`,
@@ -363,10 +531,18 @@ function attachReceipt(task: Task, receipt: X402SettleResponse): void {
     };
   }
   const existing = (task.status.message.metadata ?? {}) as Record<string, unknown>;
+  // Prefer caller-supplied prior receipts when available (the caller
+  // captured them before an intermediate step rewrote `task.status`).
+  // Otherwise fall back to whatever is still on the task.
+  const prior =
+    explicitPrior ??
+    (Array.isArray(existing[X402_METADATA_KEYS.RECEIPTS])
+      ? (existing[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[])
+      : []);
   task.status.message.metadata = {
     ...existing,
     [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
-    [X402_METADATA_KEYS.RECEIPTS]: [receipt],
+    [X402_METADATA_KEYS.RECEIPTS]: [...prior, receipt],
   };
 }
 
@@ -420,7 +596,7 @@ function validatePayloadAgainstRequirement(
   try {
     if (BigInt(authorization.value) > BigInt(accepted.maxAmountRequired)) {
       return {
-        code: X402_ERROR_CODES.AMOUNT_EXCEEDED,
+        code: X402_ERROR_CODES.INVALID_AMOUNT,
         reason: `Amount ${authorization.value} exceeds maximum ${accepted.maxAmountRequired}.`,
       };
     }
@@ -438,6 +614,9 @@ export const __internal = {
   normalizeAccept,
   validatePayloadAgainstRequirement,
   applyPaymentRequiredStatus,
+  applyVerifiedStatus,
+  applyRejectedStatus,
   applyFailedPaymentStatus,
-  attachReceipt,
+  applyRetryRequiredStatus,
+  attachCompletedReceipt,
 };

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -48,6 +48,7 @@ export {
   X402_ERROR_CODES,
   X402_DEFAULT_TIMEOUT_SECONDS,
   X402_DEFAULT_RESOURCE,
+  mapVerifyFailureToCode,
   type X402PaymentStatus,
   type X402ErrorCode,
 } from './constants.js';

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -30,15 +30,21 @@
  *
  * ```ts
  * import { A2XClient } from '@a2x/sdk/client';
- * import { X402Client } from '@a2x/sdk/x402';
  * import { privateKeyToAccount } from 'viem/accounts';
  *
- * const x402 = new X402Client(new A2XClient(url), {
- *   signer: privateKeyToAccount(process.env.PRIVATE_KEY),
+ * const client = new A2XClient(url, {
+ *   x402: { signer: privateKeyToAccount(process.env.PRIVATE_KEY) },
  * });
  *
- * const task = await x402.sendMessage({ message: { … } });
+ * const task = await client.sendMessage({ message: { … } });
  * ```
+ *
+ * `A2XClient` runs the Standalone Flow transparently — detect
+ * `payment-required`, sign one of the merchant's `accepts[]`, resubmit
+ * with the signed payload, and return the final task. For
+ * fine-grained control (e.g. inspecting the `payment-required` task
+ * before signing) drop down to the `signX402Payment` primitive
+ * exported from this module.
  */
 
 export {
@@ -78,12 +84,10 @@ export {
   getX402PaymentRequirements,
   getX402Receipts,
   getX402Status,
-  X402Client,
 } from './client.js';
 export type {
   SignX402PaymentOptions,
   SignedX402Payment,
-  X402ClientOptions,
 } from './client.js';
 
 export {

--- a/packages/cli/src/commands/a2a/send.ts
+++ b/packages/cli/src/commands/a2a/send.ts
@@ -2,18 +2,13 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import crypto from 'node:crypto';
 import type { SendMessageParams, Task } from '@a2x/sdk';
-import {
-  X402Client,
-  getX402PaymentRequirements,
-  getX402Receipts,
-} from '@a2x/sdk';
+import { getX402PaymentRequirements, getX402Receipts } from '@a2x/sdk';
 import { printTask, printConnectionError, createClient } from '../../format.js';
 import { activeWalletAccount } from '../../wallet-store.js';
 import {
   DEFAULT_MAX_AMOUNT_ATOMIC,
   buildBudgetedX402ClientSettings,
   parseMaxAmount,
-  printPaymentRequirement,
   printX402Error,
 } from '../../x402-cli.js';
 
@@ -43,9 +38,15 @@ export const sendCommand = new Command('send')
       },
     ) => {
       const maxAmount = parseMaxAmount(opts.maxAmount);
+      const noX402 = opts.x402 === false;
+      const signer = noX402 ? undefined : activeWalletAccount();
 
       try {
-        const client = createClient(url, opts);
+        const client = createClient(url, opts, {
+          x402: signer
+            ? buildBudgetedX402ClientSettings({ signer, maxAmount })
+            : undefined,
+        });
 
         const params: SendMessageParams = {
           message: {
@@ -59,42 +60,28 @@ export const sendCommand = new Command('send')
           params.message.contextId = opts.contextId;
         }
 
-        let task: Task = await client.sendMessage(params);
+        const task: Task = await client.sendMessage(params);
 
-        // Handle x402 payment-required — unless the user opted out via --no-x402.
-        // commander maps --no-x402 to opts.x402 === false.
-        const required = getX402PaymentRequirements(task);
-        if (required && opts.x402 !== false) {
-          const signer = activeWalletAccount();
-          if (!signer) {
-            if (opts.json) {
-              console.log(JSON.stringify(task, null, 2));
-              return;
-            }
-            printTask(task);
-            console.log();
-            console.error(
-              chalk.yellow(
-                'Agent is asking for an x402 payment but no wallet is active.',
-              ),
-            );
-            console.error(
-              chalk.yellow(
-                'Run `a2x wallet create` (or `a2x wallet use <name>`) to unlock paid calls.',
-              ),
-            );
-            process.exit(2);
+        // If the agent asked for payment but we couldn't sign (no wallet
+        // and the user didn't pass --no-x402), surface a helpful error.
+        if (!noX402 && !signer && getX402PaymentRequirements(task)) {
+          if (opts.json) {
+            console.log(JSON.stringify(task, null, 2));
+            return;
           }
-
-          if (!opts.json) {
-            printPaymentRequirement(required, maxAmount);
-          }
-
-          const x402 = new X402Client(
-            client,
-            buildBudgetedX402ClientSettings({ signer, maxAmount }),
+          printTask(task);
+          console.log();
+          console.error(
+            chalk.yellow(
+              'Agent is asking for an x402 payment but no wallet is active.',
+            ),
           );
-          task = await x402.sendMessage(params);
+          console.error(
+            chalk.yellow(
+              'Run `a2x wallet create` (or `a2x wallet use <name>`) to unlock paid calls.',
+            ),
+          );
+          process.exit(2);
         }
 
         if (opts.json) {

--- a/packages/cli/src/commands/a2a/stream.ts
+++ b/packages/cli/src/commands/a2a/stream.ts
@@ -3,15 +3,8 @@ import chalk from 'chalk';
 import crypto from 'node:crypto';
 import type {
   SendMessageParams,
-  Task,
   TaskArtifactUpdateEvent,
   TaskStatusUpdateEvent,
-} from '@a2x/sdk';
-import {
-  getX402PaymentRequirements,
-  signX402Payment,
-  X402_METADATA_KEYS,
-  X402_PAYMENT_STATUS,
 } from '@a2x/sdk';
 import {
   printStatusUpdate,
@@ -22,10 +15,8 @@ import {
 import { activeWalletAccount } from '../../wallet-store.js';
 import {
   DEFAULT_MAX_AMOUNT_ATOMIC,
-  enforceBudget,
+  buildBudgetedX402ClientSettings,
   parseMaxAmount,
-  pickAffordableRequirement,
-  printPaymentRequirement,
   printX402Error,
 } from '../../x402-cli.js';
 
@@ -60,9 +51,23 @@ export const streamCommand = new Command('stream')
       },
     ) => {
       const maxAmount = parseMaxAmount(opts.maxAmount);
+      const noX402 = opts.x402 === false;
+      const signer = noX402 ? undefined : activeWalletAccount();
+
+      if (!noX402 && !signer && !opts.json) {
+        console.log(
+          chalk.gray(
+            '(no active wallet — paid agents will return payment-required without auto-signing)',
+          ),
+        );
+      }
 
       try {
-        const client = createClient(url, opts);
+        const client = createClient(url, opts, {
+          x402: signer
+            ? buildBudgetedX402ClientSettings({ signer, maxAmount })
+            : undefined,
+        });
 
         const params: SendMessageParams = {
           message: {
@@ -80,90 +85,7 @@ export const streamCommand = new Command('stream')
           console.log(chalk.gray('─'.repeat(40)));
         }
 
-        // First pass: consume the stream but pause as soon as a
-        // payment-required status-update arrives.
-        const paymentSignal = await consumeUntilPaymentRequired(
-          client.sendMessageStream(params),
-          opts,
-        );
-
-        if (!paymentSignal) {
-          // Stream finished without ever asking for payment — normal case.
-          finish(opts);
-          return;
-        }
-
-        if (opts.x402 === false) {
-          if (!opts.json) {
-            console.log();
-            console.log(
-              chalk.yellow(
-                'Stream paused for x402 payment; --no-x402 was set, exiting.',
-              ),
-            );
-          }
-          process.exit(2);
-        }
-
-        const signer = activeWalletAccount();
-        if (!signer) {
-          if (!opts.json) {
-            console.log();
-            console.error(
-              chalk.yellow(
-                'Agent is asking for an x402 payment but no wallet is active.',
-              ),
-            );
-            console.error(
-              chalk.yellow(
-                'Run `a2x wallet create` (or `a2x wallet use <name>`) to unlock paid calls.',
-              ),
-            );
-          }
-          process.exit(2);
-        }
-
-        // Budget check + display before signing.
-        enforceBudget(paymentSignal.required, maxAmount);
-        if (!opts.json) {
-          console.log();
-          printPaymentRequirement(paymentSignal.required, maxAmount);
-        }
-
-        const signed = await signX402Payment(paymentSignal.syntheticTask, {
-          signer,
-          selectRequirement: (accepts) =>
-            pickAffordableRequirement(
-              { x402Version: 1, accepts },
-              maxAmount,
-            ),
-        });
-
-        // Second pass: same content + taskId + payment metadata.
-        const followupParams: SendMessageParams = {
-          ...params,
-          message: {
-            ...params.message,
-            messageId: crypto.randomUUID(),
-            taskId: paymentSignal.taskId,
-            contextId: paymentSignal.contextId,
-            metadata: {
-              ...(params.message.metadata ?? {}),
-              ...signed.metadata,
-            },
-          },
-        };
-
-        if (!opts.json) {
-          console.log(
-            chalk.gray(
-              `  signed ${signed.requirement.maxAmountRequired} atomic → resuming stream`,
-            ),
-          );
-          console.log();
-        }
-
-        for await (const event of client.sendMessageStream(followupParams)) {
+        for await (const event of client.sendMessageStream(params)) {
           renderEvent(event, opts);
         }
 
@@ -176,59 +98,6 @@ export const streamCommand = new Command('stream')
       }
     },
   );
-
-/**
- * Iterate the first stream, printing events as they come in. As soon as
- * we see a TaskStatusUpdateEvent whose message carries the x402
- * payment-required status, we synthesize a minimal Task so the caller
- * can feed it to `signX402Payment` and stop consuming further events.
- *
- * Returns `undefined` when the stream ended naturally (no payment gate).
- */
-async function consumeUntilPaymentRequired(
-  stream: AsyncGenerator<StreamEvent>,
-  opts: { json?: boolean },
-): Promise<
-  | {
-      required: NonNullable<ReturnType<typeof getX402PaymentRequirements>>;
-      syntheticTask: Task;
-      taskId: string;
-      contextId: string;
-    }
-  | undefined
-> {
-  for await (const event of stream) {
-    if (!('status' in event)) {
-      renderEvent(event, opts);
-      continue;
-    }
-
-    const meta = (event.status.message?.metadata ?? {}) as Record<string, unknown>;
-    const x402Status = meta[X402_METADATA_KEYS.STATUS];
-    if (x402Status === X402_PAYMENT_STATUS.REQUIRED) {
-      // The SDK helpers expect a Task shape, not a status-update event.
-      const syntheticTask: Task = {
-        id: event.taskId,
-        contextId: event.contextId,
-        status: event.status,
-      };
-      const required = getX402PaymentRequirements(syntheticTask);
-      if (required) {
-        // Print the status update (so the user sees the pause) and stop.
-        renderEvent(event, opts);
-        return {
-          required,
-          syntheticTask,
-          taskId: event.taskId,
-          contextId: event.contextId,
-        };
-      }
-    }
-
-    renderEvent(event, opts);
-  }
-  return undefined;
-}
 
 /**
  * Whether the cursor is currently mid-line after a streaming artifact chunk

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -4,7 +4,13 @@
 
 import chalk from 'chalk';
 import { A2XClient } from '@a2x/sdk';
-import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from '@a2x/sdk';
+import type {
+  A2XClientX402Options,
+  Task,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  Part,
+} from '@a2x/sdk';
 import { CliAuthProvider } from './cli-auth-provider.js';
 
 // ─── Error Formatting ───
@@ -247,14 +253,21 @@ export function parseHeaders(headerArgs?: string[]): Record<string, string> | un
 /**
  * Create an A2XClient from CLI arguments.
  * Automatically wires up the interactive CLI auth provider with token persistence.
+ *
+ * Pass `x402` to enable transparent x402 payment handling — the call sites
+ * for `a2x a2a send` and `a2x a2a stream` build it via
+ * `buildBudgetedX402ClientSettings()` so the spend ceiling and the
+ * `--no-x402` opt-out are respected.
  */
 export function createClient(
   url: string,
   opts: { header?: string[] },
+  extra?: { x402?: A2XClientX402Options },
 ): A2XClient {
   const headers = parseHeaders(opts.header);
   return new A2XClient(url, {
     headers,
     authProvider: new CliAuthProvider(url),
+    x402: extra?.x402,
   });
 }

--- a/packages/cli/src/x402-cli.ts
+++ b/packages/cli/src/x402-cli.ts
@@ -1,17 +1,17 @@
 /**
  * Shared x402 helpers used by `a2x a2a send` and `a2x a2a stream`.
  *
- * The SDK exposes `X402Client.onPaymentRequired` and `selectRequirement`
- * as callbacks. The CLI wires them to a spend ceiling so an auto-signed
- * payment can never exceed `--max-amount` — if the server advertises
- * only expensive options we throw `X402BudgetExceededError` before any
- * EIP-3009 authorization gets signed.
+ * The SDK's `A2XClient` runs the x402 dance natively when given an
+ * `x402` option. This module wires the CLI's spend ceiling and friendly
+ * error messages onto that surface — so an auto-signed payment can never
+ * exceed `--max-amount` and a budget violation surfaces with a CLI-shaped
+ * message instead of the generic "no supported requirement" error.
  */
 
 import chalk from 'chalk';
 import type {
+  A2XClientX402Options,
   SignX402PaymentOptions,
-  X402ClientOptions,
   X402PaymentRequiredResponse,
   X402PaymentRequirements,
 } from '@a2x/sdk';
@@ -71,22 +71,30 @@ export function safeBigInt(raw: string): bigint {
 }
 
 /**
- * Build the `{ onPaymentRequired, selectRequirement }` pair that both
- * `X402Client` (used by send) and the manual payment dance in stream
- * should share. Takes the same `SignX402PaymentOptions.signer` shape
- * so callers can spread `{ signer, ...buildBudgetedX402ClientOptions }`
- * without repeating themselves.
+ * Build the `A2XClientX402Options` block the CLI hands to `A2XClient`.
+ *
+ * `maxAmount` is enforced twice: in the SDK's default selector (so a
+ * caller-supplied predicate also sees only affordable options) and in
+ * our `onPaymentRequired` hook, which prints the requirements and throws
+ * `X402BudgetExceededError` up-front when nothing fits — that gives a
+ * better CLI message than letting the SDK fall through to the generic
+ * "no supported requirement" error.
  */
-export function buildBudgetedX402ClientOptions(
-  maxAmount: bigint,
-): Pick<X402ClientOptions, 'onPaymentRequired' | 'selectRequirement'> {
+export function buildBudgetedX402ClientSettings(args: {
+  signer: SignX402PaymentOptions['signer'];
+  maxAmount: bigint;
+}): A2XClientX402Options {
+  const { signer, maxAmount } = args;
   return {
-    onPaymentRequired: (r) => {
-      const affordable = r.accepts.filter(
+    signer,
+    maxAmount,
+    onPaymentRequired: (required) => {
+      printPaymentRequirement(required, maxAmount);
+      const affordable = required.accepts.filter(
         (a) => safeBigInt(a.maxAmountRequired) <= maxAmount,
       );
       if (affordable.length === 0) {
-        const cheapest = r.accepts
+        const cheapest = required.accepts
           .map((a) => ({ v: safeBigInt(a.maxAmountRequired), asset: a.asset }))
           .sort((x, y) => (x.v < y.v ? -1 : 1))[0];
         throw new X402BudgetExceededError(
@@ -96,66 +104,7 @@ export function buildBudgetedX402ClientOptions(
         );
       }
     },
-    selectRequirement: (accepts) => {
-      const affordable = accepts
-        .filter((a) => safeBigInt(a.maxAmountRequired) <= maxAmount)
-        .sort((x, y) =>
-          safeBigInt(x.maxAmountRequired) < safeBigInt(y.maxAmountRequired)
-            ? -1
-            : 1,
-        );
-      return affordable.find((a) => a.scheme === 'exact') ?? affordable[0];
-    },
   };
-}
-
-/**
- * Combine `signer` + budget callbacks into a full `X402ClientOptions`
- * in one call.
- */
-export function buildBudgetedX402ClientSettings(args: {
-  signer: SignX402PaymentOptions['signer'];
-  maxAmount: bigint;
-}): X402ClientOptions {
-  return {
-    signer: args.signer,
-    ...buildBudgetedX402ClientOptions(args.maxAmount),
-  };
-}
-
-/** Enforce the budget without going through `X402Client` (stream path). */
-export function enforceBudget(
-  required: X402PaymentRequiredResponse,
-  maxAmount: bigint,
-): void {
-  const affordable = required.accepts.filter(
-    (a) => safeBigInt(a.maxAmountRequired) <= maxAmount,
-  );
-  if (affordable.length === 0) {
-    const cheapest = required.accepts
-      .map((a) => ({ v: safeBigInt(a.maxAmountRequired), asset: a.asset }))
-      .sort((x, y) => (x.v < y.v ? -1 : 1))[0];
-    throw new X402BudgetExceededError(
-      cheapest?.v ?? 0n,
-      maxAmount,
-      cheapest?.asset ?? 'unknown',
-    );
-  }
-}
-
-/** Pick the cheapest affordable "exact" requirement without X402Client. */
-export function pickAffordableRequirement(
-  required: X402PaymentRequiredResponse,
-  maxAmount: bigint,
-): X402PaymentRequirements | undefined {
-  const affordable = required.accepts
-    .filter((a) => safeBigInt(a.maxAmountRequired) <= maxAmount)
-    .sort((x, y) =>
-      safeBigInt(x.maxAmountRequired) < safeBigInt(y.maxAmountRequired)
-        ? -1
-        : 1,
-    );
-  return affordable.find((a) => a.scheme === 'exact') ?? affordable[0];
 }
 
 // ─── Display helpers ────────────────────────────────────────────────

--- a/samples/nextjs-x402/README.md
+++ b/samples/nextjs-x402/README.md
@@ -46,14 +46,13 @@ Using the SDK directly:
 
 ```ts
 import { A2XClient } from '@a2x/sdk/client';
-import { X402Client } from '@a2x/sdk/x402';
 import { privateKeyToAccount } from 'viem/accounts';
 
-const x402 = new X402Client(new A2XClient('http://localhost:3000/api/a2a'), {
-  signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+const client = new A2XClient('http://localhost:3000/api/a2a', {
+  x402: { signer: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`) },
 });
 
-const task = await x402.sendMessage({
+const task = await client.sendMessage({
   message: {
     messageId: crypto.randomUUID(),
     role: 'user',


### PR DESCRIPTION
Closes #92. Supersedes #93 (closed for redesign).

## Summary

Two-part change:

1. **Six spec-conformance fixes** from the closed PR #93 are preserved verbatim (one §8 MUST violation + five drift gaps). The first commit on this branch is ost006's audit work; the second is the redesign on top.
2. **`X402Client` is removed.** `A2XClient` itself now runs the a2a-x402 v0.2 Standalone Flow when given an `x402` option. Callers no longer have to know up front whether the target agent gates on x402 — that's a property of the AgentCard, not the caller.

## What changed (client API)

```ts
// Before — caller had to pick the right class up front
import { X402Client } from '@a2x/sdk/x402';
const x402 = new X402Client(new A2XClient(url), { signer });
await x402.sendMessage({ message });

// After — A2XClient handles x402 transparently when configured
import { A2XClient } from '@a2x/sdk/client';
const client = new A2XClient(url, { x402: { signer } });
await client.sendMessage({ message });
```

`A2XClient.sendMessage` and `A2XClient.sendMessageStream` both detect `payment-required`, sign one of the merchant's `accepts[]`, and resubmit on the same task. Streaming runs the dance in-band so consumers iterate one merged generator across both SSE connections (`payment-required → payment-verified → working → artifacts → payment-completed`).

The new `A2XClientX402Options` carries:

| Field | Default | Purpose |
|---|---|---|
| `signer` | required | viem `LocalAccount`. |
| `maxAmount` | no cap | Atomic-unit ceiling. Filters `accepts[]` before the selector runs. |
| `selectRequirement` | first `scheme === 'exact'` | Predicate over the (filtered) requirements. |
| `onPaymentRequired` | none | Hook that fires after `payment-required` and before signing. Throw to abort. |

Setting `x402` automatically registers `X402_EXTENSION_URI` so the §8 `X-A2A-Extensions` header is emitted on every request — no manual wiring.

The low-level primitives (`signX402Payment`, `getX402PaymentRequirements`, `getX402Receipts`, `getX402Status`) remain exported for callers that need manual control.

## Spec conformance fixes (carried over from #93)

These are unchanged; client surface is reshaped around them.

1. **§8 MUST — `X-A2A-Extensions` activation header.** Client emits the header when extensions are registered (auto-set when `x402` option is configured). `DefaultRequestHandler` rejects requests missing required-extension URIs with `-32600`.
2. **§9.1 — Error code names match spec.** `SETTLE_FAILED` → `SETTLEMENT_FAILED`, `AMOUNT_EXCEEDED` → `INVALID_AMOUNT`. Removed unused `NO_REQUIREMENTS`. Added `mapVerifyFailureToCode()` to dispatch facilitator `invalidReason` into `INSUFFICIENT_FUNDS` / `INVALID_SIGNATURE` / `EXPIRED_PAYMENT` / `DUPLICATE_NONCE`.
3. **§7.1 — `payment-verified` transient state.** Streaming clients now observe a `working + payment-verified` event between `payment-submitted` and `payment-completed`.
4. **§7 — `x402.payment.receipts` preserves history.** Prior receipts are merged across retries instead of overwritten.
5. **§5.4.2 / §7.1 — `payment-rejected` handling.** Executor terminates the task on rejection instead of looping back to `payment-required`.
6. **§9 — `retryOnFailure` executor option.** Opt-in to spec §9's retry branch where verify/settle failures re-publish `payment-required` with `error` populated.

## CLI

`a2x a2a send` and `a2x a2a stream` now use `A2XClient` with the new option. Stream's previous ~80-line manual payment dance is replaced by `for await (const ev of client.sendMessageStream(params))`. Verified end-to-end against `samples/nextjs-x402` with `X402_MOCK_FACILITATOR=1` — no manual `-H X-A2A-Extensions:...` flag needed (the SDK injects it).

CLI is on the changeset `ignore` list (ships via tag-driven GitHub Release), so the version doesn't bump here.

## Test coverage

434 tests pass (9 new in `a2x-client-x402.test.ts`):
- `sendMessage`: returns first task when no payment, runs full dance with header + signed metadata + same taskId, throws `X402PaymentFailedError` on settle failure, aborts on `onPaymentRequired` throw, refuses when `maxAmount` filters out everything, honours custom `selectRequirement`, skips dance entirely when `x402` is unset.
- `sendMessageStream`: yields `payment-required → payment-verified → payment-completed` across two SSE connections as a single generator, passes through unmodified when `x402` is unset.
- Plus the 8 §8 / §9.1 server tests and 17 executor tests from #93 — all green.

## Breaking changes

Pre-1.0 minor bump:

- **TypeScript**: `X402Client` class removed. Migrate by passing `{ x402: { signer } }` to `A2XClient`.
- **Wire**: `SETTLE_FAILED` → `SETTLEMENT_FAILED`, `AMOUNT_EXCEEDED` → `INVALID_AMOUNT` in `x402.payment.error` strings.

## Verification

- [x] `pnpm test` — 434/434 pass
- [x] `pnpm typecheck` — clean across all 4 typechecked packages
- [x] `pnpm lint` — 0 errors (1 pre-existing warning unrelated)
- [x] `pnpm -r build` — SDK + CLI + both samples build clean
- [x] E2E `samples/nextjs-x402` + `X402_MOCK_FACILITATOR=1` + `a2x a2a stream` — full lifecycle observed (`payment-required → payment-verified → working → artifact → payment-completed`)
- [x] Activation header gating — POST without `X-A2A-Extensions` returns `-32600`; with header accepted

## Test plan

- [x] `pnpm install && pnpm test && pnpm typecheck && pnpm lint && pnpm -r build`
- [x] Run `samples/nextjs-x402` with `X402_MOCK_FACILITATOR=1` + CLI `a2a stream` (no `-H` flag required) → task completes, `payment-verified` observable
- [x] Probe with `curl -X POST` without `X-A2A-Extensions` → `-32600`; with header → accepted
