### PR TITLE
fix(sdk): surface auth failure as auth-required TaskState per A2A spec

### DIFF
--- a/.changeset/auth-required-task-state.md
+++ b/.changeset/auth-required-task-state.md
@@ -1,0 +1,21 @@
+---
+"@a2x/sdk": minor
+---
+
+Align auth failure handling with A2A spec by surfacing failures as a `TaskState.auth-required` task instead of a non-standard `-32008` JSON-RPC error.
+
+Closes #94.
+
+**Why.** The SDK previously returned a JSON-RPC error with code `-32008 AuthenticationRequiredError` on auth failures. That code is not part of the spec — v0.3 defines RPC error codes only up to `-32007 AuthenticatedExtendedCardNotConfiguredError`, and v1.0 does not define JSON-RPC error codes at all. A2A v0.3 (`TaskState.auth-required`) and v1.0 (`TASK_STATE_AUTH_REQUIRED`) both reserve a Task lifecycle state for this exact case. The SDK's own `A2XClient` token-refresh path was gated on `response.status === 401`, an HTTP status the server never produced — so it was unreachable in practice.
+
+**Server.** `DefaultRequestHandler` now branches on the failing request method:
+
+- `message/send` returns a Task with `status.state: 'auth-required'` (HTTP `200`).
+- `message/stream` emits a single `TaskStatusUpdateEvent` carrying `auth-required` and closes the stream (HTTP `200`).
+- All other methods (`tasks/get`, `tasks/cancel`, `tasks/pushNotificationConfig/*`, `agent/getAuthenticatedExtendedCard`) have no task-shaped response, so they fall back to spec-defined `-32600 InvalidRequest` with a descriptive message.
+
+The synthesized auth-required task is ephemeral — it's not persisted to the task store, so unauthenticated callers cannot allocate task IDs.
+
+**Client.** `A2XClient` no longer inspects `response.status === 401`. Instead, after parsing a `message/send` response or buffering the first event of a `message/stream` response, it checks for `status.state === 'auth-required'`. When `AuthProvider.refresh()` is configured, the client refreshes credentials and retries once — both for blocking and streaming calls. When `refresh()` is not configured, the auth-required task / event is returned to the caller unchanged.
+
+**Breaking — removals.** `AuthenticationRequiredError` and `A2A_ERROR_CODES.AUTHENTICATION_REQUIRED` (`-32008`) are removed. Consumers that imported either symbol must migrate to inspecting the Task state. HTTP status remains `200` in all cases — no host adapter changes are required (Next.js routes, Express handlers, the built-in `to-a2x` server, etc.).

--- a/packages/a2x/docs/guides/advanced/authentication.md
+++ b/packages/a2x/docs/guides/advanced/authentication.md
@@ -139,6 +139,35 @@ a2xAgent.addSecurityScheme('mtls', new MutualTlsAuthorization({
 
 Your HTTP layer must terminate TLS with client-cert verification enabled and pass the cert through on `RequestContext.clientCertificate`.
 
+## How auth failures are surfaced
+
+A2A models authentication failure as a Task lifecycle state, not a transport-level error:
+
+- **v0.3** — `TaskState.auth-required` (`specification/a2a-v0.3.0.json:2450`).
+- **v1.0** — `TASK_STATE_AUTH_REQUIRED` (`specification/a2a-v1.0.0.proto:206-207`). Per the v1.0 `SendMessage` semantics, servers MUST wait for `AUTH_REQUIRED` (an interrupted state) before returning under `return_immediately=false`.
+
+The SDK follows this directly:
+
+| Method | Response on auth failure |
+|---|---|
+| `message/send` | `result` is a Task with `status.state === 'auth-required'`. HTTP `200`. |
+| `message/stream` | First (and only) SSE event is a `TaskStatusUpdateEvent` carrying `auth-required`, then the stream closes. HTTP `200`. |
+| `tasks/get`, `tasks/cancel`, `tasks/pushNotificationConfig/*`, `agent/getAuthenticatedExtendedCard` | These methods don't return a Task, so they fall back to JSON-RPC `-32600 InvalidRequest`. HTTP `200`. |
+
+`A2XClient` reacts to `auth-required` automatically:
+
+```ts
+const client = new A2XClient(url, { authProvider });
+
+// If the server returns auth-required and AuthProvider implements
+// refresh(), the client refreshes credentials and retries once before
+// returning. If refresh is not configured, the auth-required Task is
+// returned to the caller as-is.
+const task = await client.sendMessage({ message });
+```
+
+The streaming counterpart buffers the first event: when it observes `auth-required` and `AuthProvider.refresh()` is available, it refreshes, opens a new stream, and yields that stream's events to the caller.
+
 ## Client side: handling auth
 
 ### Static headers

--- a/packages/a2x/docs/guides/advanced/extended-agent-card.md
+++ b/packages/a2x/docs/guides/advanced/extended-agent-card.md
@@ -24,8 +24,10 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
   .setDefaultUrl('https://agent.example.com/a2a')
   .setName('acme-agent')
   .setDescription('Public description of Acme Agent.')
-  // Auth is required — the handler returns AuthenticationRequiredError
-  // on unauthenticated calls to the extended-card method.
+  // Auth is required — the handler returns -32600 InvalidRequest on
+  // unauthenticated calls to the extended-card method (this method has
+  // no task-shaped response, so it cannot use the `auth-required`
+  // TaskState path).
   .addSecurityScheme('apiKey', new ApiKeyAuthorization({
     in: 'header',
     name: 'x-api-key',
@@ -78,7 +80,7 @@ If you only want to *add* skills rather than replace them, build the merged arra
 | Situation | JSON-RPC error | Code |
 |---|---|---|
 | Provider never registered | `AuthenticatedExtendedCardNotConfiguredError` | `-32007` |
-| Call arrives without auth (no `context`, failed auth, missing required scope) | `AuthenticationRequiredError` | `-32008` |
+| Call arrives without auth (no `context`, failed auth, missing required scope) | `InvalidRequestError` | `-32600` |
 | Resolved name / description missing after merge | Internal error (your provider stripped required fields) | `-32603` |
 
 The auth check runs at the `DefaultRequestHandler` level via the normal security-scheme flow — you don't need to re-implement it inside the provider. The provider only runs **after** `AuthResult.authenticated === true`.

--- a/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
+++ b/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
@@ -116,14 +116,16 @@ describe('agent/getAuthenticatedExtendedCard', () => {
     );
   });
 
-  it('returns AuthenticationRequiredError when the call is unauthenticated', async () => {
+  it('returns InvalidRequest when the call is unauthenticated', async () => {
     const handler = createHandler({
       withAuth: true,
       withProvider: () => ({ description: 'Extended' }),
     });
 
-    // Missing API key — auth will fail and the pre-dispatch block returns
-    // AUTHENTICATION_REQUIRED before the special-case branch runs.
+    // Missing API key — auth fails. The extended-card method has no
+    // task-shaped response, so the handler falls back to InvalidRequest
+    // (-32600). Spec a2a-v0.3 / v1.0 reserve the auth-required TaskState
+    // for task-creating methods only.
     const response = await handler.handle(extendedCardRequest, {
       headers: {},
     });
@@ -132,14 +134,14 @@ describe('agent/getAuthenticatedExtendedCard', () => {
     const rpc = response as JSONRPCResponse;
     expect('error' in rpc).toBe(true);
     expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-      A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+      A2A_ERROR_CODES.INVALID_REQUEST,
     );
   });
 
-  it('returns AuthenticationRequiredError when no context is provided but provider is configured', async () => {
+  it('returns InvalidRequest when no context is provided but provider is configured', async () => {
     // Provider configured but also requires auth. Without a context, the
     // pre-dispatch auth step is skipped, so the special-case branch trips
-    // on missing authResult and raises AUTHENTICATION_REQUIRED itself.
+    // on missing authResult and raises InvalidRequest itself.
     const handler = createHandler({
       withAuth: true,
       withProvider: () => ({ description: 'Extended' }),
@@ -151,7 +153,7 @@ describe('agent/getAuthenticatedExtendedCard', () => {
     const rpc = response as JSONRPCResponse;
     expect('error' in rpc).toBe(true);
     expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-      A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
+      A2A_ERROR_CODES.INVALID_REQUEST,
     );
   });
 

--- a/packages/a2x/src/__tests__/client-auth.test.ts
+++ b/packages/a2x/src/__tests__/client-auth.test.ts
@@ -561,26 +561,26 @@ describe('A2XClient auth integration', () => {
     expect(headers['Authorization']).toBeUndefined();
   });
 
-  it('calls refresh on 401 and retries', async () => {
+  it('calls refresh and retries when first response is auth-required', async () => {
+    // Spec a2a-v0.3 / v1.0: an auth failure surfaces as a Task whose
+    // status.state === 'auth-required'. The client refreshes credentials
+    // once and re-sends the same request.
+    const authRequiredTask = {
+      id: 'task-auth',
+      contextId: 'ctx-auth',
+      status: { state: TaskState.AUTH_REQUIRED, timestamp: new Date().toISOString() },
+    };
     let callCount = 0;
     const mockFetch = vi.fn().mockImplementation(() => {
       callCount++;
-      if (callCount === 1) {
-        // First call: 401
-        return Promise.resolve({
-          ok: false,
-          status: 401,
-          statusText: 'Unauthorized',
-          json: () => Promise.resolve({}),
-          headers: new Headers(),
-        });
-      }
-      // Second call: success
+      const body = callCount === 1
+        ? createJsonRpcSuccess(authRequiredTask)
+        : createJsonRpcSuccess(TASK_RESULT);
       return Promise.resolve({
         ok: true,
         status: 200,
         statusText: 'OK',
-        json: () => Promise.resolve(createJsonRpcSuccess(TASK_RESULT)),
+        json: () => Promise.resolve(body),
         headers: new Headers({ 'content-type': 'application/json' }),
       });
     });
@@ -595,7 +595,6 @@ describe('A2XClient auth integration', () => {
         throw new Error('No supported scheme');
       },
       async refresh(schemes) {
-        // Replace with new credential
         for (const scheme of schemes) {
           if (scheme instanceof ApiKeyAuthScheme) {
             scheme.setCredential('new-key');
@@ -615,27 +614,23 @@ describe('A2XClient auth integration', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    // Second call should have the new key
     const secondCallHeaders = mockFetch.mock.calls[1][1].headers;
     expect(secondCallHeaders['x-api-key']).toBe('new-key');
   });
 
-  it('does not retry more than once on 401', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      statusText: 'Unauthorized',
-      json: () => Promise.resolve({}),
-      headers: new Headers(),
-    });
+  it('returns the auth-required task when refresh is unsupported', async () => {
+    const authRequiredTask = {
+      id: 'task-auth',
+      contextId: 'ctx-auth',
+      status: { state: TaskState.AUTH_REQUIRED, timestamp: new Date().toISOString() },
+    };
+    const mockFetch = createMockFetch(createJsonRpcSuccess(authRequiredTask));
 
     const authProvider: AuthProvider = {
       async provide(requirements) {
         return [requirements[0][0].setCredential('key')];
       },
-      async refresh(schemes) {
-        return schemes;
-      },
+      // No refresh() — caller is expected to inspect the task state.
     };
 
     const client = new A2XClient(V10_CARD_WITH_AUTH, {
@@ -643,14 +638,12 @@ describe('A2XClient auth integration', () => {
       authProvider,
     });
 
-    await expect(
-      client.sendMessage({
-        message: { role: 'user', parts: [{ text: 'Hello' }] },
-      }),
-    ).rejects.toThrow('HTTP 401');
+    const task = await client.sendMessage({
+      message: { role: 'user', parts: [{ text: 'Hello' }] },
+    });
 
-    // Once for initial, once for retry — no more
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(task.status.state).toBe(TaskState.AUTH_REQUIRED);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('propagates authProvider.provide() errors', async () => {
@@ -697,17 +690,4 @@ describe('A2XClient auth integration', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  it('maps AUTHENTICATION_REQUIRED error code correctly', async () => {
-    const mockFetch = createMockFetch(
-      { jsonrpc: '2.0', id: 1, error: { code: -32008, message: 'Auth required' } },
-    );
-
-    const client = new A2XClient(V10_CARD_WITH_AUTH, { fetch: mockFetch });
-
-    await expect(
-      client.sendMessage({
-        message: { role: 'user', parts: [{ text: 'Hello' }] },
-      }),
-    ).rejects.toThrow('Auth required');
-  });
 });

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -8,7 +8,7 @@ import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { LlmAgent } from '../agent/llm-agent.js';
 import { BaseLlmProvider } from '../provider/base.js';
 import { A2A_ERROR_CODES } from '../types/errors.js';
-import { TaskState } from '../types/task.js';
+import { TaskState, TaskStateV10 } from '../types/task.js';
 import type { JSONRPCResponse, JSONRPCErrorResponse } from '../types/jsonrpc.js';
 import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
 import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
@@ -660,7 +660,10 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect('result' in rpc).toBe(true);
     });
 
-    it('should reject with invalid API key', async () => {
+    // Per A2A spec (TaskState.auth-required in v0.3 / TASK_STATE_AUTH_REQUIRED
+    // in v1.0), an auth failure on a task-creating method surfaces as a Task
+    // in `auth-required` state, not a JSON-RPC error.
+    it('should surface auth failure as auth-required task for invalid API key', async () => {
       const handler = createAuthHandler((agent) => {
         agent
           .addSecurityScheme('apiKey', new ApiKeyAuthorization({
@@ -677,13 +680,14 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const response = await handler.handle(validRequest, context);
       expect(isAsyncGenerator(response)).toBe(false);
       const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
-      );
+      expect('result' in rpc).toBe(true);
+      const task = (rpc as { result: { status: { state: string } } }).result;
+      // createAuthHandler defaults to protocol v1.0 → wire form is the
+      // proto enum name, not the v0.3 kebab string.
+      expect(task.status.state).toBe(TaskStateV10.TASK_STATE_AUTH_REQUIRED);
     });
 
-    it('should reject with missing API key', async () => {
+    it('should surface auth failure as auth-required task for missing API key', async () => {
       const handler = createAuthHandler((agent) => {
         agent
           .addSecurityScheme('apiKey', new ApiKeyAuthorization({
@@ -698,10 +702,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const response = await handler.handle(validRequest, context);
       expect(isAsyncGenerator(response)).toBe(false);
       const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
-      );
+      expect('result' in rpc).toBe(true);
+      const task = (rpc as { result: { status: { state: string } } }).result;
+      // createAuthHandler defaults to protocol v1.0 → wire form is the
+      // proto enum name, not the v0.3 kebab string.
+      expect(task.status.state).toBe(TaskStateV10.TASK_STATE_AUTH_REQUIRED);
     });
 
     it('should support OR logic: pass if any requirement group succeeds', async () => {
@@ -766,10 +771,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const response = await handler.handle(validRequest, context);
       expect(isAsyncGenerator(response)).toBe(false);
       const rpc = response as JSONRPCResponse;
-      expect('error' in rpc).toBe(true);
-      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
-        A2A_ERROR_CODES.AUTHENTICATION_REQUIRED,
-      );
+      expect('result' in rpc).toBe(true);
+      const task = (rpc as { result: { status: { state: string } } }).result;
+      // createAuthHandler defaults to protocol v1.0 → wire form is the
+      // proto enum name, not the v0.3 kebab string.
+      expect(task.status.state).toBe(TaskStateV10.TASK_STATE_AUTH_REQUIRED);
     });
 
     it('should skip auth when no security requirements are set', async () => {
@@ -787,6 +793,62 @@ describe('Layer 4: DefaultRequestHandler', () => {
       expect(isAsyncGenerator(response)).toBe(false);
       const rpc = response as JSONRPCResponse;
       expect('result' in rpc).toBe(true);
+    });
+
+    it('should emit an auth-required status event for message/stream auth failure', async () => {
+      const handler = createAuthHandler((agent) => {
+        agent
+          .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+            in: 'header',
+            name: 'x-api-key',
+            keys: ['secret'],
+          }))
+          .addSecurityRequirement({ apiKey: [] });
+      });
+
+      const streamRequest = {
+        jsonrpc: '2.0' as const,
+        id: 2,
+        method: 'message/stream',
+        params: validRequest.params,
+      };
+      const context: RequestContext = { headers: {} };
+      const response = await handler.handle(streamRequest, context);
+      expect(isAsyncGenerator(response)).toBe(true);
+      const events: unknown[] = [];
+      for await (const ev of response as AsyncGenerator<unknown>) {
+        events.push(ev);
+      }
+      expect(events).toHaveLength(1);
+      const status = (events[0] as { status: { state: string } }).status;
+      expect(status.state).toBe(TaskStateV10.TASK_STATE_AUTH_REQUIRED);
+    });
+
+    it('should fall back to InvalidRequest for non-task-shaped methods on auth failure', async () => {
+      const handler = createAuthHandler((agent) => {
+        agent
+          .addSecurityScheme('apiKey', new ApiKeyAuthorization({
+            in: 'header',
+            name: 'x-api-key',
+            keys: ['secret'],
+          }))
+          .addSecurityRequirement({ apiKey: [] });
+      });
+
+      const getTaskRequest = {
+        jsonrpc: '2.0' as const,
+        id: 3,
+        method: 'tasks/get',
+        params: { id: 'task-id' },
+      };
+      const context: RequestContext = { headers: {} };
+      const response = await handler.handle(getTaskRequest, context);
+      expect(isAsyncGenerator(response)).toBe(false);
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.INVALID_REQUEST,
+      );
     });
   });
 

--- a/packages/a2x/src/a2x/v03-response-mapper.ts
+++ b/packages/a2x/src/a2x/v03-response-mapper.ts
@@ -59,6 +59,10 @@ export class V03ResponseMapper implements ResponseMapper {
       status: this._mapStatus(event.status),
     };
 
+    // Spec a2a-v0.3 §TaskStatusUpdateEvent.final
+    if (event.final !== undefined) {
+      mapped.final = event.final;
+    }
     if (event.metadata !== undefined) {
       mapped.metadata = event.metadata;
     }

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -29,9 +29,9 @@ import {
   ContentTypeNotSupportedError,
   InvalidAgentResponseError,
   AuthenticatedExtendedCardNotConfiguredError,
-  AuthenticationRequiredError,
   A2A_ERROR_CODES,
 } from '../types/errors.js';
+import { TaskState } from '../types/task.js';
 import type { ResolvedAgentCard } from './agent-card-resolver.js';
 import {
   resolveAgentCard,
@@ -144,7 +144,6 @@ const ERROR_CODE_MAP: Record<number, new (message?: string, data?: unknown) => A
   [A2A_ERROR_CODES.CONTENT_TYPE_NOT_SUPPORTED]: ContentTypeNotSupportedError,
   [A2A_ERROR_CODES.INVALID_AGENT_RESPONSE]: InvalidAgentResponseError,
   [A2A_ERROR_CODES.AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED]: AuthenticatedExtendedCardNotConfiguredError,
-  [A2A_ERROR_CODES.AUTHENTICATION_REQUIRED]: AuthenticationRequiredError,
 };
 
 // ─── v0.3 Request Formatting ───
@@ -362,7 +361,16 @@ export class A2XClient {
     const formatted = this._formatParams(params);
     const request = this._buildJsonRpcRequest(A2A_METHODS.SEND_MESSAGE, formatted);
     const result = await this._postJsonRpc(request);
-    return this._parser!.parseTask(result);
+    const task = this._parser!.parseTask(result);
+    // Spec a2a-v0.3 §TaskState / a2a-v1.0 §TASK_STATE_AUTH_REQUIRED:
+    // an auth failure surfaces as a Task in `auth-required` state.
+    // Refresh credentials once and retry; the same condition on the
+    // second response is propagated to the caller as-is.
+    if (task.status.state !== TaskState.AUTH_REQUIRED) return task;
+    if (!(await this._refreshAuth())) return task;
+    const retryRequest = this._buildJsonRpcRequest(A2A_METHODS.SEND_MESSAGE, formatted);
+    const retryResult = await this._postJsonRpc(retryRequest);
+    return this._parser!.parseTask(retryResult);
   }
 
   private async *_sendMessageStreamOnce(
@@ -371,6 +379,14 @@ export class A2XClient {
   ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
     await this._ensureResolved();
     await this._ensureAuthenticated();
+    yield* this._streamWithAuthRetry(params, signal, false);
+  }
+
+  private async *_streamWithAuthRetry(
+    params: SendMessageParams,
+    signal: AbortSignal | undefined,
+    isRetry: boolean,
+  ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
     const formatted = this._formatParams(params);
     const request = this._buildJsonRpcRequest(
       A2A_METHODS.STREAM_MESSAGE,
@@ -398,7 +414,7 @@ export class A2XClient {
     }
 
     // Server may return a JSON-RPC error instead of SSE
-    // (e.g., authentication failure, unsupported operation).
+    // (e.g., unsupported operation, invalid params).
     const contentType = response.headers.get('content-type') ?? '';
     if (!contentType.includes('text/event-stream')) {
       const jsonRpcResponse = (await response.json()) as JSONRPCResponse;
@@ -410,7 +426,23 @@ export class A2XClient {
       return;
     }
 
-    yield* parseSSEStream(response, this._parser!);
+    // Buffer the first event so we can inspect for auth-required without
+    // surfacing it to the caller before deciding to refresh+retry.
+    const events = parseSSEStream(response, this._parser!);
+    const firstResult = await events.next();
+    if (firstResult.done) return;
+    const firstEvent = firstResult.value;
+    if (
+      !isRetry &&
+      'status' in firstEvent &&
+      firstEvent.status?.state === TaskState.AUTH_REQUIRED &&
+      (await this._refreshAuth())
+    ) {
+      yield* this._streamWithAuthRetry(params, signal, true);
+      return;
+    }
+    yield firstEvent;
+    yield* events;
   }
 
   private async _signX402(task: Task): Promise<SignedX402Payment> {
@@ -621,10 +653,7 @@ export class A2XClient {
     };
   }
 
-  private async _postJsonRpc(
-    request: JSONRPCRequest,
-    isRetry = false,
-  ): Promise<unknown> {
+  private async _postJsonRpc(request: JSONRPCRequest): Promise<unknown> {
     const headers = this._buildHeaders();
     const url = new URL(this._endpointUrl!);
 
@@ -635,19 +664,6 @@ export class A2XClient {
       headers,
       body: JSON.stringify(request),
     });
-
-    // Token refresh on 401 (once)
-    if (
-      !isRetry &&
-      response.status === 401 &&
-      this._authProvider?.refresh &&
-      this._resolvedSchemes
-    ) {
-      this._resolvedSchemes = await this._authProvider.refresh(
-        this._resolvedSchemes,
-      );
-      return this._postJsonRpc(request, true);
-    }
 
     if (!response.ok) {
       throw new InternalError(
@@ -664,6 +680,20 @@ export class A2XClient {
     }
 
     return (jsonRpcResponse as { result: unknown }).result;
+  }
+
+  /**
+   * Per A2A spec, an auth failure on a task-creating call surfaces as a
+   * Task in `auth-required` state — not as a transport error and not as a
+   * JSON-RPC error code. When the AuthProvider supports `refresh()`, the
+   * client refreshes credentials once and retries the same call.
+   */
+  private async _refreshAuth(): Promise<boolean> {
+    if (!this._authProvider?.refresh || !this._resolvedSchemes) return false;
+    this._resolvedSchemes = await this._authProvider.refresh(
+      this._resolvedSchemes,
+    );
+    return true;
   }
 }
 

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -29,7 +29,6 @@ import type {
 import { TERMINAL_STATES } from '../types/task.js';
 import {
   AuthenticatedExtendedCardNotConfiguredError,
-  AuthenticationRequiredError,
   InternalError,
   InvalidParamsError,
   InvalidRequestError,
@@ -45,6 +44,8 @@ import { JsonRpcRouter } from './jsonrpc-router.js';
 import type { ResponseMapper } from '../a2x/response-mapper.js';
 import { ResponseMapperFactory } from '../a2x/response-mapper.js';
 import type { RequestContext, AuthResult } from '../types/auth.js';
+import type { Task } from '../types/task.js';
+import { TaskState } from '../types/task.js';
 
 /** Return type of `handle()`. */
 export type HandleResult =
@@ -124,13 +125,24 @@ export class DefaultRequestHandler {
     // Authenticate if context is provided and security requirements exist.
     // Capture authResult so special-case handlers (e.g. the authenticated
     // extended card) can consume the resolved principal/scopes.
+    //
+    // Spec a2a-v0.3 / v1.0 model auth failure as a Task lifecycle state
+    // (`TaskState.AUTH_REQUIRED`), not as a JSON-RPC error. For methods
+    // whose response shape is a Task (`message/send`, `message/stream`),
+    // emit an auth-required task. Other methods don't have a task-shaped
+    // response, so they fall back to `-32600 InvalidRequest`.
     let authResult: AuthResult | undefined;
     if (context && this.a2xAgent.securityRequirements.length > 0) {
       authResult = await this._authenticate(context);
       if (!authResult.authenticated) {
-        const error = new AuthenticationRequiredError(
-          authResult.error ?? 'Authentication required',
-        );
+        const reason = authResult.error ?? 'Authentication required';
+        if (request.method === A2A_METHODS.SEND_MESSAGE) {
+          return this._buildAuthRequiredResponse(request, reason);
+        }
+        if (request.method === A2A_METHODS.STREAM_MESSAGE) {
+          return this._buildAuthRequiredStream(request, reason);
+        }
+        const error = new InvalidRequestError(reason);
         return {
           jsonrpc: '2.0',
           id: request.id,
@@ -163,7 +175,7 @@ export class DefaultRequestHandler {
           throw new AuthenticatedExtendedCardNotConfiguredError();
         }
         if (!authResult || !authResult.authenticated) {
-          throw new AuthenticationRequiredError(
+          throw new InvalidRequestError(
             'Authentication is required for the authenticated extended card',
           );
         }
@@ -200,6 +212,75 @@ export class DefaultRequestHandler {
    */
   getAgentCard(version?: string): AgentCardV03 | AgentCardV10 {
     return this.a2xAgent.getAgentCard(version);
+  }
+
+  // ─── Private: auth-required Task synthesis ───
+
+  /**
+   * Build an ephemeral Task in `auth-required` state for a single
+   * `message/send` request that failed authentication. Per A2A spec
+   * (`TaskState.auth-required` in v0.3 / `TASK_STATE_AUTH_REQUIRED` in
+   * v1.0), this is the protocol-level signal that prompts the client to
+   * acquire credentials and retry. The task is NOT persisted to the
+   * store — unauthenticated callers must not be able to allocate task
+   * IDs at will.
+   */
+  private _buildAuthRequiredResponse(
+    request: JSONRPCRequest,
+    reason: string,
+  ): JSONRPCResponse {
+    const userMessage = (request.params as { message?: unknown } | undefined)
+      ?.message;
+    const task = this._buildAuthRequiredTask(request, reason);
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: this.responseMapper.mapTask(
+        task,
+        userMessage as Parameters<ResponseMapper['mapTask']>[1],
+      ),
+    };
+  }
+
+  /**
+   * Streaming counterpart to `_buildAuthRequiredResponse`. Emits a single
+   * `TaskStatusUpdateEvent` carrying `auth-required` and closes — clients
+   * react to the state and refresh their credentials before retrying via
+   * a fresh `message/stream`.
+   */
+  private async *_buildAuthRequiredStream(
+    request: JSONRPCRequest,
+    reason: string,
+  ): AsyncGenerator<unknown> {
+    const task = this._buildAuthRequiredTask(request, reason);
+    yield this.responseMapper.mapStatusUpdateEvent({
+      taskId: task.id,
+      contextId: task.contextId ?? '',
+      status: task.status,
+      metadata: { final: true },
+    });
+  }
+
+  private _buildAuthRequiredTask(
+    request: JSONRPCRequest,
+    reason: string,
+  ): Task {
+    const params = request.params as
+      | { message?: { contextId?: string } }
+      | undefined;
+    return {
+      id: randomUUID(),
+      contextId: params?.message?.contextId ?? randomUUID(),
+      status: {
+        state: TaskState.AUTH_REQUIRED,
+        message: {
+          messageId: randomUUID(),
+          role: 'agent',
+          parts: [{ text: reason }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    };
   }
 
   // ─── Private: Authentication ───

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -257,7 +257,10 @@ export class DefaultRequestHandler {
       taskId: task.id,
       contextId: task.contextId ?? '',
       status: task.status,
-      metadata: { final: true },
+      // Spec a2a-v0.3 §TaskStatusUpdateEvent: `final: true` marks the last
+      // event for the stream. v1.0 dropped the field — the mapper handles
+      // both cases.
+      final: true,
     });
   }
 

--- a/packages/a2x/src/types/errors.ts
+++ b/packages/a2x/src/types/errors.ts
@@ -19,7 +19,6 @@ export const A2A_ERROR_CODES = {
   CONTENT_TYPE_NOT_SUPPORTED: -32005,
   INVALID_AGENT_RESPONSE: -32006,
   AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED: -32007,
-  AUTHENTICATION_REQUIRED: -32008,
 } as const;
 
 // ─── Base A2A Error Class ───
@@ -147,10 +146,3 @@ export class AuthenticatedExtendedCardNotConfiguredError extends A2AError {
   }
 }
 
-export class AuthenticationRequiredError extends A2AError {
-  readonly code = A2A_ERROR_CODES.AUTHENTICATION_REQUIRED;
-
-  constructor(message = 'Authentication required', data?: unknown) {
-    super(message, data);
-  }
-}

--- a/packages/a2x/src/types/task.ts
+++ b/packages/a2x/src/types/task.ts
@@ -77,6 +77,13 @@ export interface TaskStatusUpdateEvent {
   taskId: string;
   contextId: string;
   status: TaskStatus;
+  /**
+   * If true, this is the last status update expected for this task in the
+   * stream. Spec a2a-v0.3 §TaskStatusUpdateEvent (top-level `final` field).
+   * v1.0 dropped this field in favor of relying on the transport's
+   * end-of-stream signal — the v1.0 response mapper omits it on the wire.
+   */
+  final?: boolean;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

- Replace the non-standard `-32008 AuthenticationRequiredError` path with the spec-defined `TaskState.auth-required` (v0.3) / `TASK_STATE_AUTH_REQUIRED` (v1.0) — A2A's first-class lifecycle state for auth failures.
- `A2XClient` now reacts to `auth-required` on the parsed task (or the first SSE event) and runs `AuthProvider.refresh()` + retry once; the previous `response.status === 401` branch was unreachable because the server never produced a 401.
- Remove `AuthenticationRequiredError` and `A2A_ERROR_CODES.AUTHENTICATION_REQUIRED` entirely.

Closes #94. See [the issue thread](https://github.com/planetarium/a2x/issues/94#issuecomment-4325140939) for the spec citations and rationale that drove the pivot away from the originally proposed HTTP 401 + `WWW-Authenticate` approach.

## Server behavior matrix

| Method | Auth failure response |
|---|---|
| `message/send` | `result` is a Task with `status.state: 'auth-required'`, HTTP `200` |
| `message/stream` | One `TaskStatusUpdateEvent` carrying `auth-required`, then stream close, HTTP `200` |
| `tasks/get` / `tasks/cancel` / `tasks/pushNotificationConfig/*` / `agent/getAuthenticatedExtendedCard` | `-32600 InvalidRequest` (no Task-shaped response available), HTTP `200` |

The synthesized `auth-required` task is ephemeral — it is *not* persisted to the task store, so unauthenticated callers cannot allocate task IDs.

## Client behavior

- `A2XClient.sendMessage` parses the task, checks `status.state === 'auth-required'`, calls `AuthProvider.refresh()` if available, re-sends once.
- `A2XClient.sendMessageStream` buffers the first event, applies the same logic, and either yields the auth-required event to the caller (no refresh available) or re-opens the stream and yields the new stream's events.
- HTTP-status-based detection (`response.status === 401`) is removed — the spec does not bind auth failures to a transport status, and the previous code was unreachable.

## Why the spec sides with this approach

- v0.3 — `TaskState.auth-required` (`specification/a2a-v0.3.0.json:2450`), `specification/a2a-v0.3.0.proto:177-180`.
- v1.0 — `TASK_STATE_AUTH_REQUIRED` (`specification/a2a-v1.0.0.json:1062` / `:1899`), `specification/a2a-v1.0.0.proto:206-207`. v1.0 `SendMessage` semantics (`a2a-v1.0.0.proto:155-160`) explicitly call out `AUTH_REQUIRED` as an interrupted state servers must wait for under `return_immediately=false`.
- `-32008` was never in the spec — v0.3 RPC error codes stop at `-32007 AuthenticatedExtendedCardNotConfiguredError`, and v1.0 doesn't define JSON-RPC error codes at all (transport-binding split).

## Breaking changes

- Removed: `AuthenticationRequiredError`, `A2A_ERROR_CODES.AUTHENTICATION_REQUIRED`. Consumers that imported either symbol must migrate to inspecting the parsed Task / SSE event for `status.state === 'auth-required'`.
- HTTP status remains `200` in all cases. The built-in `to-a2x` server, the Next.js sample routes, and any user-supplied host adapter need **zero** changes.

## Docs / changeset

- `packages/a2x/docs/guides/advanced/authentication.md` — new "How auth failures are surfaced" section with the behavior matrix.
- `packages/a2x/docs/guides/advanced/extended-agent-card.md` — updated error table (`-32008` → `-32600`).
- `.changeset/auth-required-task-state.md` — minor bump.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 435/435 pass, including new tests for `auth-required` task on `message/send`, single-event SSE on `message/stream`, and `-32600` fallback for `tasks/get`. Updated client-auth tests verify the refresh+retry path on auth-required.
- [x] `pnpm lint` — no new warnings
- [x] `pnpm -r build` — clean across all packages and samples