### PR TITLE
chore(ci): tighten dependabot config to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,39 +4,62 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
       timezone: "Asia/Seoul"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
     groups:
+      # next-stack must come before typescript-toolchain so that
+      # eslint-config-next is grouped with next/react instead of eslint.
+      next-stack:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+          - "eslint-config-next"
+          - "@types/react"
+          - "@types/react-dom"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
       typescript-toolchain:
         patterns:
           - "typescript"
           - "tsup"
           - "@typescript-eslint/*"
           - "eslint"
+          - "eslint-*"
           - "vitest"
       llm-providers:
         patterns:
           - "@anthropic-ai/sdk"
           - "openai"
           - "@google/genai"
+      build-tools:
+        patterns:
+          - "@yao-pkg/pkg"
+          - "@changesets/*"
     ignore:
       # Major bumps are handled manually to avoid surprise breakages.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Patch bumps are noise. Security advisories still fire via
+      # dependabot security-updates regardless of this filter.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # GitHub Actions used by workflows under .github/workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
       timezone: "Asia/Seoul"
@@ -45,6 +68,10 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       # Action major bumps are handled manually. A semver-valid major can
       # still be freshly released and unstable (see pnpm/action-setup v6
@@ -52,3 +79,6 @@ updates:
       # on install — pnpm/action-setup#227 and #228).
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Patch bumps for actions are noise; security advisories still fire.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Summary

Dependabot was opening per-package PRs every Monday for every minor and patch bump, producing 6+ PRs/week. This change cuts the noise to roughly one batch PR per month while preserving security coverage.

## Changes

**npm ecosystem:**
- `weekly` → `monthly` schedule
- Globally ignore `version-update:semver-patch`. Security advisories still fire via `dependabot security-updates`, which is unaffected by `ignore` rules
- Add groups so related packages bump together:
  - `next-stack`: next, react, react-dom, eslint-config-next, @types/react(-dom)
  - `tailwind`: tailwindcss, @tailwindcss/*
  - `build-tools`: @yao-pkg/pkg, @changesets/*
  - `eslint-*` added to existing `typescript-toolchain` group
- `next-stack` listed before `typescript-toolchain` so `eslint-config-next` is grouped with the React stack rather than matched by `eslint-*`
- `open-pull-requests-limit`: 10 → 5

**github-actions ecosystem:**
- `weekly` → `monthly` schedule
- Add a single `github-actions` group covering all action bumps (one PR per month max for actions)
- Globally ignore patch bumps (consistent with npm)

## Why

Past 30 days the repo had ~20 chore(deps) PRs, almost all patch bumps that just churn `pnpm-lock.yaml`. The PR list became the noise. Major bumps were already manual; patches add no signal beyond what security alerts provide.

## Test plan

- [ ] CI passes (no behavioral code change; config only)
- [ ] Verify on next monthly run (first Monday after merge) that PRs come in as grouped batches, not per-package
- [ ] Confirm security advisory test (e.g. simulate via `gh api /repos/.../vulnerability-alerts` if needed) still produces a PR despite the patch ignore rule

No changeset: per `AGENTS.md`, `.github/` tooling changes ride silently on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)