### PR TITLE
fix(sdk): make PushNotificationAuthenticationInfo conform to v1.0 spec on the wire

### DIFF
--- a/.changeset/fix-push-notification-auth-v10-spec.md
+++ b/.changeset/fix-push-notification-auth-v10-spec.md
@@ -1,0 +1,12 @@
+---
+'@a2x/sdk': patch
+---
+
+Fix `PushNotificationAuthenticationInfo` to match the v1.0 spec on the wire. The
+SDK previously emitted (and accepted) the v0.3 shape `{ schemes: string[] }` even
+on v1.0 transports, which violates `a2a-v1.0.0.json` (`{ scheme: string,
+credentials? }`, `additionalProperties: false`). The internal store still keeps
+the v0.3 shape; the v1.0 response mapper now collapses `schemes` to `scheme` on
+output, and the inbound validator on a v1.0 agent now requires the `scheme`
+field and normalizes it back to `[scheme]` for storage. v0.3 agents are
+unchanged.

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -74,3 +74,14 @@ const client = new A2XClient(url, { preferredVersion: '1.0' });
 - **Serve v1.0 as primary**, let A2X down-convert for v0.3 consumers. This is the default; you don't have to do anything.
 - **Pin your own clients to v1.0** when calling agents that support both. Future-facing.
 - **Only override defaults** when you need cross-version compatibility for a specific deployment target.
+
+## Beyond the AgentCard: push notification authentication
+
+`tasks/pushNotificationConfig/{set,get,list}` carries an optional `authentication` block whose shape diverges between specs:
+
+| Version | Shape | Notes |
+|---|---|---|
+| v0.3 | `{ schemes: string[], credentials? }` | `schemes` required and non-empty |
+| v1.0 | `{ scheme: string, credentials? }` | `scheme` required; `additionalProperties: false` |
+
+A2X stores the v0.3 shape internally and translates at the v1.0 boundary: `scheme = schemes[0]` outbound, `schemes = [scheme]` inbound. The conversion is lossy when v0.3 lists more than one scheme — only the first is preserved on a v1.0 wire. Configure your agent's `protocolVersion` to match the wire your clients speak; the SDK handles the rest.

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1154,6 +1154,64 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const stored = await pushStore.get('task-1', generatedId!);
         expect(stored?.pushNotificationConfig.id).toBe(generatedId);
       });
+
+      it('should accept v0.3 spec authentication shape with schemes array', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              authentication: { schemes: ['Bearer'], credentials: 'abc123' },
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { pushNotificationConfig: { authentication: unknown } } }).result;
+        expect(result.pushNotificationConfig.authentication).toEqual({
+          schemes: ['Bearer'],
+          credentials: 'abc123',
+        });
+
+        const stored = await pushStore.get('task-1', 'config-1');
+        expect(stored?.pushNotificationConfig.authentication).toEqual({
+          schemes: ['Bearer'],
+          credentials: 'abc123',
+        });
+      });
+
+      it('should return InvalidParams when v0.3 authentication.schemes is empty', async () => {
+        const { handler } = createHandlerWithPushNotification('0.3');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              authentication: { schemes: [] },
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
     });
 
     describe('v1.0 wire format (flattened response)', () => {
@@ -1277,7 +1335,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
         );
       });
 
-      it('should return InvalidParams when authentication.schemes is empty', async () => {
+      it('should return InvalidParams when authentication.scheme is missing', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
         const response = await handler.handle({
@@ -1289,7 +1347,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
             pushNotificationConfig: {
               id: 'config-1',
               url: 'https://example.com/webhook',
-              authentication: { schemes: [] },
+              authentication: { credentials: 'abc123' },
             },
           },
         });
@@ -1302,7 +1360,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
         );
       });
 
-      it('should accept valid authentication info', async () => {
+      it('should reject v0.3-shape authentication.schemes on a v1.0 wire', async () => {
         const { handler } = createHandlerWithPushNotification('1.0');
 
         const response = await handler.handle({
@@ -1314,7 +1372,32 @@ describe('Layer 4: DefaultRequestHandler', () => {
             pushNotificationConfig: {
               id: 'config-1',
               url: 'https://example.com/webhook',
-              authentication: { schemes: ['Bearer'], credentials: 'abc123' },
+              authentication: { schemes: ['Bearer'] },
+            },
+          },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      });
+
+      it('should accept v1.0 spec authentication shape and round-trip via internal v0.3 form', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/set',
+          params: {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'config-1',
+              url: 'https://example.com/webhook',
+              authentication: { scheme: 'Bearer', credentials: 'abc123' },
             },
           },
         });
@@ -1323,7 +1406,13 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         const result = (rpc as { result: { authentication: unknown } }).result;
-        expect(result.authentication).toEqual({ schemes: ['Bearer'], credentials: 'abc123' });
+        expect(result.authentication).toEqual({ scheme: 'Bearer', credentials: 'abc123' });
+
+        const stored = await pushStore.get('task-1', 'config-1');
+        expect(stored?.pushNotificationConfig.authentication).toEqual({
+          schemes: ['Bearer'],
+          credentials: 'abc123',
+        });
       });
     });
   });
@@ -1376,6 +1465,32 @@ describe('Layer 4: DefaultRequestHandler', () => {
           url: 'https://example.com/webhook',
           token: 'tok-1',
         });
+      });
+
+      it('should translate stored authentication to v1.0 wire shape on read', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        await pushStore.set({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+            authentication: { schemes: ['Bearer'], credentials: 'abc123' },
+          },
+        });
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/get',
+          params: { taskId: 'task-1', id: 'config-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { authentication: unknown } }).result;
+        expect(result.authentication).toEqual({ scheme: 'Bearer', credentials: 'abc123' });
       });
 
       it('should return TaskNotFound when config does not exist', async () => {
@@ -1633,6 +1748,36 @@ describe('Layer 4: DefaultRequestHandler', () => {
         const rpc = response as JSONRPCResponse;
         expect('error' in rpc).toBe(false);
         expect((rpc as { result: unknown }).result).toEqual({ configs: [], nextPageToken: '' });
+      });
+
+      it('should translate stored authentication to v1.0 wire shape on list', async () => {
+        const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+        await pushStore.set({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'config-1',
+            url: 'https://example.com/webhook',
+            authentication: { schemes: ['Bearer'], credentials: 'abc123' },
+          },
+        });
+
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/pushNotificationConfig/list',
+          params: { taskId: 'task-1' },
+        });
+
+        expect(isAsyncGenerator(response)).toBe(false);
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(false);
+        const result = (rpc as { result: { configs: { authentication?: unknown }[] } }).result;
+        expect(result.configs).toHaveLength(1);
+        expect(result.configs[0].authentication).toEqual({
+          scheme: 'Bearer',
+          credentials: 'abc123',
+        });
       });
 
       it('should accept pageSize/pageToken params and ignore them', async () => {

--- a/packages/a2x/src/a2x/v10-response-mapper.ts
+++ b/packages/a2x/src/a2x/v10-response-mapper.ts
@@ -18,7 +18,10 @@ import type { TaskState } from '../types/task.js';
 import type { Message, Part, Artifact, Role } from '../types/common.js';
 import { ROLE_TO_V10 } from '../types/common.js';
 import type { ResponseMapper } from './response-mapper.js';
-import type { TaskPushNotificationConfig } from '../types/jsonrpc.js';
+import type {
+  PushNotificationAuthenticationInfo,
+  TaskPushNotificationConfig,
+} from '../types/jsonrpc.js';
 
 export class V10ResponseMapper implements ResponseMapper {
   readonly version = '1.0';
@@ -89,7 +92,9 @@ export class V10ResponseMapper implements ResponseMapper {
       url: inner.url,
     };
     if (inner.token !== undefined) flat.token = inner.token;
-    if (inner.authentication !== undefined) flat.authentication = inner.authentication;
+    if (inner.authentication !== undefined) {
+      flat.authentication = this._mapAuthentication(inner.authentication);
+    }
     return flat;
   }
 
@@ -101,6 +106,22 @@ export class V10ResponseMapper implements ResponseMapper {
   }
 
   // ─── Private Helpers ───
+
+  // v0.3 stores `{ schemes: string[], credentials? }` but v1.0
+  // (`a2a-v1.0.0.json:466-483`, `a2a-v1.0.0.proto:325-329`) requires
+  // `{ scheme: string, credentials? }` with `additionalProperties: false`.
+  // Collapse to the first scheme on the wire — round-trip is lossy when v0.3
+  // listed more than one, and the validator rejects empty arrays so
+  // `schemes[0]` is always defined here.
+  private _mapAuthentication(
+    auth: PushNotificationAuthenticationInfo,
+  ): Record<string, unknown> {
+    const mapped: Record<string, unknown> = { scheme: auth.schemes[0] };
+    if (auth.credentials !== undefined) {
+      mapped.credentials = auth.credentials;
+    }
+    return mapped;
+  }
 
   private _mapStateToV10(state: TaskState): string {
     const v10State = TASK_STATE_TO_V10.get(state);

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -17,6 +17,7 @@ import type {
   DeletePushNotificationConfigParams,
   GetPushNotificationConfigParams,
   ListPushNotificationConfigsParams,
+  PushNotificationAuthenticationInfo,
   PushNotificationConfig,
   TaskPushNotificationConfig,
 } from '../types/jsonrpc.js';
@@ -882,13 +883,64 @@ export class DefaultRequestHandler {
         'SetPushNotificationConfig: "pushNotificationConfig.token" must be a string when provided',
       );
     }
-    if (n.authentication !== undefined) {
-      if (n.authentication === null || typeof n.authentication !== 'object') {
+    const authentication =
+      n.authentication !== undefined
+        ? this._validatePushNotificationAuthentication(n.authentication)
+        : undefined;
+
+    // Empty-string id is treated as absent (v1.0 proto-default semantic);
+    // the server assigns a UUID so the store can key the entry.
+    const clientId = typeof n.id === 'string' && n.id.length > 0 ? n.id : undefined;
+    const innerConfig: PushNotificationConfig = {
+      id: clientId ?? randomUUID(),
+      url: n.url,
+      ...(n.token !== undefined ? { token: n.token as string } : {}),
+      ...(authentication !== undefined ? { authentication } : {}),
+    };
+
+    return {
+      taskId: p.taskId,
+      pushNotificationConfig: innerConfig,
+    };
+  }
+
+  /**
+   * Validate and normalize the inbound `authentication` block of a
+   * `pushNotificationConfig` to the internal v0.3 shape
+   * `{ schemes: string[], credentials? }`.
+   *
+   * - v0.3 (`a2a-v0.3.0.json:1879-1897`): `{ schemes: string[], credentials? }`
+   *   with `schemes` required and non-empty.
+   * - v1.0 (`a2a-v1.0.0.json:466-483`, `a2a-v1.0.0.proto:325-329`):
+   *   `{ scheme: string, credentials? }` with `scheme` REQUIRED and
+   *   `additionalProperties: false`. Promote `scheme` to `[scheme]` for
+   *   storage so `tasks/pushNotificationConfig/{set,get,list}` round-trip
+   *   through the same internal shape regardless of wire version.
+   */
+  private _validatePushNotificationAuthentication(
+    raw: unknown,
+  ): PushNotificationAuthenticationInfo {
+    if (raw === null || typeof raw !== 'object') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.authentication" must be an object when provided',
+      );
+    }
+    const auth = raw as Record<string, unknown>;
+    if (auth.credentials !== undefined && typeof auth.credentials !== 'string') {
+      throw new InvalidParamsError(
+        'SetPushNotificationConfig: "pushNotificationConfig.authentication.credentials" must be a string when provided',
+      );
+    }
+
+    let schemes: string[];
+    if (this.a2xAgent.protocolVersion === '1.0') {
+      if (typeof auth.scheme !== 'string' || auth.scheme.trim() === '') {
         throw new InvalidParamsError(
-          'SetPushNotificationConfig: "pushNotificationConfig.authentication" must be an object when provided',
+          'SetPushNotificationConfig: "pushNotificationConfig.authentication.scheme" must be a non-empty string',
         );
       }
-      const auth = n.authentication as Record<string, unknown>;
+      schemes = [auth.scheme];
+    } else {
       if (!Array.isArray(auth.schemes) || auth.schemes.length === 0) {
         throw new InvalidParamsError(
           'SetPushNotificationConfig: "pushNotificationConfig.authentication.schemes" must be a non-empty array of strings',
@@ -901,28 +953,12 @@ export class DefaultRequestHandler {
           );
         }
       }
-      if (auth.credentials !== undefined && typeof auth.credentials !== 'string') {
-        throw new InvalidParamsError(
-          'SetPushNotificationConfig: "pushNotificationConfig.authentication.credentials" must be a string when provided',
-        );
-      }
+      schemes = auth.schemes as string[];
     }
 
-    // Empty-string id is treated as absent (v1.0 proto-default semantic);
-    // the server assigns a UUID so the store can key the entry.
-    const clientId = typeof n.id === 'string' && n.id.length > 0 ? n.id : undefined;
-    const innerConfig: PushNotificationConfig = {
-      id: clientId ?? randomUUID(),
-      url: n.url,
-      ...(n.token !== undefined ? { token: n.token as string } : {}),
-      ...(n.authentication !== undefined
-        ? { authentication: n.authentication as PushNotificationConfig['authentication'] }
-        : {}),
-    };
-
     return {
-      taskId: p.taskId,
-      pushNotificationConfig: innerConfig,
+      schemes,
+      ...(auth.credentials !== undefined ? { credentials: auth.credentials as string } : {}),
     };
   }
 


### PR DESCRIPTION
Closes #107.

## Summary

- v1.0 spec defines `AuthenticationInfo` as `{ scheme: string (REQUIRED), credentials? }` with `additionalProperties: false`. The SDK was emitting and accepting the v0.3 shape `{ schemes: string[], credentials? }` even on v1.0 transports, so `tasks/pushNotificationConfig/{set,get,list}` produced wire shapes the v1.0 schema doesn't allow.
- Internal store stays in the v0.3 shape (matches the default protocol). `V10ResponseMapper` now collapses `schemes[0] → scheme` outbound, and `DefaultRequestHandler._validatePushNotificationAuthentication` accepts the v1.0 wire `scheme` when `protocolVersion === '1.0'`, normalizing it back to `[scheme]` for storage.
- v0.3 agents are unchanged. Round-trip is lossy when a v0.3 store holds more than one scheme and is read back over a v1.0 wire — only the first scheme survives, which is documented in the new helper comments and in `agent-card-versioning.md`.

## Files

- `packages/a2x/src/a2x/v10-response-mapper.ts` — translate `authentication` to v1.0 wire shape on `mapPushNotificationConfig` (used by both the single-config response and the list response).
- `packages/a2x/src/transport/request-handler.ts` — protocol-version-aware inbound validator extracted into `_validatePushNotificationAuthentication`, returning the internal `{ schemes, credentials? }` shape.
- `packages/a2x/src/__tests__/request-handler.test.ts` — replaced the old assertions that locked in the broken behavior; added round-trip coverage for v1.0 set→get→list and v0.3 set inbound validation. The previous "should accept valid authentication info" test was asserting `schemes` on a v1.0 response, which is exactly what the bug produced — that expectation is now `scheme` per spec.
- `packages/a2x/docs/guides/advanced/agent-card-versioning.md` — short "Beyond the AgentCard" section documenting the wire shape divergence and the lossy collapse, since there is no dedicated push-notification guide.
- `.changeset/fix-push-notification-auth-v10-spec.md` — patch bump for `@a2x/sdk`.

## Test plan

- [x] `pnpm test` — 440 tests pass (28 files); 6 new authentication tests added.
- [x] `pnpm typecheck` — passes (one transient OOM crash on a parallel `tsc` run, clean on retry).
- [x] `pnpm -r build` — passes.
- [x] `pnpm lint` — only a pre-existing unrelated warning in `packages/cli/src/__tests__/stream-line-collision.test.ts`.
- [ ] Optional manual verification: round-trip `tasks/pushNotificationConfig/set` → `get` from a real v1.0 client; not exercised in this PR but covered by the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)