### PR TITLE
fix(cli): rename macos-only pkg outputs back to a2x-macos-{arch}

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "binaries": "pkg bin-bundle/a2x.cjs --targets node20-linux-x64,node20-linux-arm64,node20-macos-x64,node20-macos-arm64,node20-win-x64 --out-path binaries --compress Brotli --public",
-    "binaries:macos": "pkg bin-bundle/a2x.cjs --targets node20-macos-x64,node20-macos-arm64 --out-path binaries --compress Brotli --public",
+    "binaries:macos": "pkg bin-bundle/a2x.cjs --targets node20-macos-x64,node20-macos-arm64 --out-path binaries --compress Brotli --public && mv binaries/a2x-x64 binaries/a2x-macos-x64 && mv binaries/a2x-arm64 binaries/a2x-macos-arm64",
     "binaries:non-macos": "pkg bin-bundle/a2x.cjs --targets node20-linux-x64,node20-linux-arm64,node20-win-x64 --out-path binaries --compress Brotli --public"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `binaries:macos` now appends `mv binaries/a2x-x64 binaries/a2x-macos-x64 && mv binaries/a2x-arm64 binaries/a2x-macos-arm64` after the `pkg` invocation, restoring the `a2x-macos-{arch}` filenames the rest of the release pipeline expects.
- One-line script change in `packages/cli/package.json`. No workflow, source, or docs changes.

## Why

`@yao-pkg/pkg` has an undocumented filename rule: when every `--targets` entry shares the same platform, it drops the platform from the output and uses `a2x-{arch}` instead of `a2x-{platform}-{arch}`. The all-in-one `binaries` script (5 targets across linux/macos/win) sidesteps this; the new `binaries:macos` script introduced in #88 — which only has `node20-macos-x64,node20-macos-arm64` — triggers it.

Result: on the first real macOS-runner release attempt (cli-v0.2.1, kicked off by #112), `pkg` actually built and ad-hoc-signed the binaries successfully, but wrote them as `a2x-x64` / `a2x-arm64`. The `Verify macOS binaries are ad-hoc signed` step and `actions/upload-artifact` glob (`a2x-*`) both look for `a2x-macos-arm64`, so the verify step failed with `No such file or directory` and the release job was skipped. See [run 24987963491](https://github.com/planetarium/a2x/actions/runs/24987963491).

Reproduced locally on Apple Silicon (macOS 14.7.2, the same runner image as `macos-14`):

```
> pkg bin-bundle/a2x.cjs --targets node20-macos-x64,node20-macos-arm64 --out-path binaries ...
$ ls binaries
a2x-arm64        a2x-x64        # ← pkg dropped the `macos-` segment
```

The `mv` chain is the smallest fix that keeps a single `pkg` invocation (one Brotli compression pass per target). `binaries:non-macos` already spans multiple platforms, so pkg keeps the full suffix there — no change needed.

## Release impact

`packages/cli/package.json` is still at `0.2.1` and the `cli-v0.2.1` git tag was never created (the failed run skipped the `release` job). Once this PR merges, the `Release CLI` workflow will re-run on main, pick `changed=true`, build the binaries with the corrected names, and cut `cli-v0.2.1`. No version bump needed.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint` (0 errors, 1 pre-existing unrelated warning)
- [x] `pnpm typecheck`
- [x] `pnpm -r build`
- [x] `pnpm test` (440/440)
- [x] `pnpm --filter @a2x/cli binaries:macos` locally → produces `binaries/a2x-macos-x64` + `binaries/a2x-macos-arm64`, both `Format=Mach-O thin` and `Signature=adhoc`
- [ ] After merge: `Release CLI` workflow on the merge commit runs `Verify macOS binaries are ad-hoc signed` to completion and the `release` job creates `cli-v0.2.1` with all six assets (5 binaries + npm tarball)
- [ ] After release: `gh release download cli-v0.2.1 --pattern 'a2x-macos-arm64'` + `chmod +x` + run on Apple Silicon prints the version with no manual `codesign`

## Notes

- No changeset (`@a2x/cli` is in `.changeset/config.json` `ignore`).
- No docs / README updates — package surface is unchanged.
- Follow-up worth considering after this lands: the `cli-release` skill's troubleshooting note still attributes macOS download failures to quarantine/Gatekeeper, but the actual modes seen so far are (a) unsigned exec (fixed in #88) and (b) silent filename drift (this PR). Worth a doc PR.