### PR TITLE
fix(sdk): honor AgentCard.protocolVersion in detectProtocolVersion

### DIFF
--- a/.changeset/fix-detect-protocol-version-honors-declared.md
+++ b/.changeset/fix-detect-protocol-version-honors-declared.md
@@ -1,0 +1,12 @@
+---
+'@a2x/sdk': patch
+---
+
+Fix `detectProtocolVersion` (and therefore `A2XClient`) to honor the AgentCard's
+declared top-level `protocolVersion` field before falling back to shape
+heuristics. Per `a2a-v0.3.0.json`, `protocolVersion` is required on v0.3 cards;
+per `a2a-v1.0.0.json`, it does not exist at the top level. The previous
+shape-only check misclassified v0.3 agents that legally advertise
+`supportedInterfaces` for additional transports as v1.0, which skipped the v0.3
+wire transform and shipped message parts without the required `kind`
+discriminator. The server then dropped the parts and rejected the request.

--- a/packages/a2x/src/__tests__/client.test.ts
+++ b/packages/a2x/src/__tests__/client.test.ts
@@ -107,6 +107,38 @@ describe('AgentCardResolver', () => {
         supportedInterfaces: [{ url: 'http://localhost' }],
       })).toBe('1.0');
     });
+
+    it('should detect v0.3 when card declares protocolVersion 0.3.x even if supportedInterfaces is present', () => {
+      // Regression: v0.3 cards may legally advertise supportedInterfaces for extra
+      // transports. The declared protocolVersion must win over shape inference.
+      expect(detectProtocolVersion({
+        protocolVersion: '0.3.0',
+        url: 'http://localhost',
+        supportedInterfaces: [
+          { url: 'http://localhost', protocolBinding: 'JSONRPC', protocolVersion: '0.3' },
+        ],
+      })).toBe('0.3');
+    });
+
+    it('should accept short major.minor protocolVersion strings', () => {
+      expect(detectProtocolVersion({ protocolVersion: '0.3' })).toBe('0.3');
+      expect(detectProtocolVersion({ protocolVersion: '1.0' })).toBe('1.0');
+    });
+
+    it('should detect v1.0 from declared protocolVersion 1.x', () => {
+      expect(detectProtocolVersion({ protocolVersion: '1.0.0' })).toBe('1.0');
+    });
+
+    it('should fall back to shape inference when protocolVersion is unrecognized', () => {
+      expect(detectProtocolVersion({
+        protocolVersion: '2.0.0',
+        url: 'http://localhost',
+      })).toBe('0.3');
+      expect(detectProtocolVersion({
+        protocolVersion: '',
+        supportedInterfaces: [{ url: 'http://localhost' }],
+      })).toBe('1.0');
+    });
   });
 
   describe('getAgentEndpointUrl', () => {

--- a/packages/a2x/src/client/agent-card-resolver.ts
+++ b/packages/a2x/src/client/agent-card-resolver.ts
@@ -36,10 +36,20 @@ export interface ResolvedAgentCard {
 /**
  * Detect whether an AgentCard is v0.3 or v1.0.
  *
- * v0.3 cards have a top-level `url` field and `protocolVersion` string.
- * v1.0 cards have a `supportedInterfaces` array.
+ * Per spec, the card's own `protocolVersion` is authoritative:
+ *   - v0.3 (`a2a-v0.3.0.json`) requires a top-level `protocolVersion` (full semver, e.g. "0.3.0").
+ *   - v1.0 (`a2a-v1.0.0.json`) has no top-level `protocolVersion`; versions appear per-interface.
+ *
+ * Shape alone is ambiguous: a v0.3 agent may legally also expose `supportedInterfaces` to
+ * advertise additional transports, and would be misclassified as v1.0 if we ignored the
+ * declared version. Honor the declared field first, then fall back to shape heuristics.
  */
 export function detectProtocolVersion(card: Record<string, unknown>): ProtocolVersion {
+  const declared = card.protocolVersion;
+  if (typeof declared === 'string') {
+    if (declared.startsWith('0.3')) return '0.3';
+    if (declared.startsWith('1.')) return '1.0';
+  }
   if (
     Array.isArray(card.supportedInterfaces) &&
     card.supportedInterfaces.length > 0


### PR DESCRIPTION
## Summary

- `detectProtocolVersion` now consults the AgentCard's declared top-level `protocolVersion` before falling back to shape heuristics, fixing v0.3 agents that legally advertise `supportedInterfaces` being misclassified as v1.0.
- Spec-grounded mapping per `specification/a2a-v0.3.0.json` (required top-level `protocolVersion`) and `a2a-v1.0.0.json` (no top-level field; versions appear per-interface).
- Brings code in line with the already-documented client behavior in `docs/guides/advanced/agent-card-versioning.md` ("`A2XClient` reads the remote card's `protocolVersion` field").

## Why

A v0.3 agent that exposes `supportedInterfaces` (legal in v0.3 for additional transports) was being detected as v1.0. That skipped the v0.3 wire transform in `A2XClient._formatParams`, so message parts went on the wire without the required `kind: 'text' | 'data' | 'file'` discriminator. Servers then dropped the parts and replied `Agent execution error: message.parts with text is required`. Reproduced against Flex HR Suite (`protocolVersion: "0.3.0"` + `supportedInterfaces` populated).

## Changes

- `packages/a2x/src/client/agent-card-resolver.ts` — `detectProtocolVersion` honors `card.protocolVersion`: `0.3.x` → `'0.3'`, `1.x` → `'1.0'`. Existing shape heuristic kicks in only when the field is absent or unrecognized.
- `packages/a2x/src/__tests__/client.test.ts` — adds 5 cases covering the regression (v0.3 card with `supportedInterfaces`), short `0.3` / `1.0` strings, declared `1.0.0`, and unrecognized / empty values falling back to shape.
- `.changeset/fix-detect-protocol-version-honors-declared.md` — patch bump for `@a2x/sdk`.

No public-API surface change; behavior fix only. Docs already correctly describe the intended behavior, so no `docs/` update needed.

## Test plan

- [x] `pnpm test` — 444 passed (28 files), incl. the 5 new cases.
- [x] `pnpm typecheck` — clean across all 4 workspace projects.
- [x] `pnpm lint` — no new warnings (one pre-existing unrelated warning in `stream-line-collision.test.ts`).
- [x] `pnpm -r build` — green across packages and samples.

Closes #104