### PR TITLE
fix(sdk): silence per-render warn from OAuth2DeviceCodeAuthorization.toV03Schema

### DIFF
--- a/.changeset/fix-oauth2-device-code-warn-noise.md
+++ b/.changeset/fix-oauth2-device-code-warn-noise.md
@@ -1,0 +1,12 @@
+---
+'@a2x/sdk': patch
+---
+
+Stop logging a `console.warn` from
+`OAuth2DeviceCodeAuthorization.toV03Schema()`. The warning fired on every v0.3
+AgentCard render — i.e. on every `GET /.well-known/agent.json?version=0.3` and
+every `agent/getAuthenticatedExtendedCard` call — even though emitting Device
+Code as a non-standard `oauth2.flows.deviceCode` extension is the SDK's
+intentional behavior. The non-standard nature is already documented on the
+method's JSDoc and in the authentication guide; the per-render log was pure
+noise.

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { A2XAgent } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
@@ -278,8 +278,7 @@ describe('Layer 3: A2XAgent', () => {
       expect(card.skills[0].security).toEqual([{ api_key: [] }]);
     });
 
-    it('should emit DeviceCode as non-standard v0.3 extension with warning', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('should emit DeviceCode as non-standard v0.3 extension', () => {
       const a2x = createA2XAgent();
       a2x
         .setDefaultUrl('https://example.com/a2a')
@@ -304,10 +303,6 @@ describe('Layer 3: A2XAgent', () => {
           },
         },
       });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('non-standard extension'),
-      );
-      warnSpy.mockRestore();
     });
   });
 

--- a/packages/a2x/src/__tests__/security.test.ts
+++ b/packages/a2x/src/__tests__/security.test.ts
@@ -169,8 +169,7 @@ describe('Layer 1: SecurityScheme Classes', () => {
       scopes: { read: 'Read' },
     };
 
-    it('toV03Schema emits deviceCode as non-standard extension and warns', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('toV03Schema emits deviceCode as non-standard extension', () => {
       const scheme = new OAuth2DeviceCodeAuthorization({
         ...opts,
         refreshUrl: 'https://auth.example.com/refresh',
@@ -189,14 +188,9 @@ describe('Layer 1: SecurityScheme Classes', () => {
         },
         description: 'Device flow',
       });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('non-standard extension'),
-      );
-      warnSpy.mockRestore();
     });
 
     it('toV03Schema omits refreshUrl and description when not provided', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const scheme = new OAuth2DeviceCodeAuthorization(opts);
       const v03 = scheme.toV03Schema() as Extract<
         ReturnType<typeof scheme.toV03Schema>,
@@ -208,7 +202,6 @@ describe('Layer 1: SecurityScheme Classes', () => {
         scopes: opts.scopes,
       });
       expect('description' in v03).toBe(false);
-      warnSpy.mockRestore();
     });
 
     it('toV10Schema should return oauth2 with deviceCode flow', () => {

--- a/packages/a2x/src/security/oauth2-device-code.ts
+++ b/packages/a2x/src/security/oauth2-device-code.ts
@@ -65,9 +65,6 @@ export class OAuth2DeviceCodeAuthorization extends BaseSecurityScheme {
    * v0.3 parsers may ignore this flow. `@a2x/sdk` clients consume it natively.
    */
   toV03Schema(): SecuritySchemeV03 {
-    console.warn(
-      'OAuth2DeviceCodeAuthorization: Device Code flow is emitted as a non-standard extension on the v0.3 AgentCard. Strict third-party v0.3 parsers may ignore it.',
-    );
     const flow: DeviceCodeFlowV03 = {
       deviceAuthorizationUrl: this.deviceAuthorizationUrl,
       tokenUrl: this.tokenUrl,


### PR DESCRIPTION
## Summary
- `OAuth2DeviceCodeAuthorization.toV03Schema()` ran on every v0.3 AgentCard render, so the `console.warn` inside it fired on every `GET /.well-known/agent.json?version=0.3` and every `agent/getAuthenticatedExtendedCard` call.
- Emitting Device Code as a non-standard `oauth2.flows.deviceCode` extension is the SDK's intentional behavior — the v0.3 caveat is already documented on the method's JSDoc and in the authentication guide — so the per-render runtime log was pure noise.
- Drop the `console.warn` and update the two tests that asserted it. No public API change.

Closes #108.

## Notes
- No public surface change → no `packages/a2x/docs/` update needed.
- Changeset: `patch` for `@a2x/sdk`.

## Test plan
- [x] `pnpm test` — 444/444 passing
- [x] `pnpm typecheck`
- [x] `pnpm lint` (only pre-existing unrelated warning)
- [x] `pnpm -r build`