### PR TITLE
fix(sdk): add missing TaskState.UNKNOWN to match v0.3 / v1.0 spec

### DIFF
--- a/packages/a2x/src/__tests__/client.test.ts
+++ b/packages/a2x/src/__tests__/client.test.ts
@@ -325,6 +325,15 @@ describe('ResponseParser', () => {
       expect(task.status.state).toBe(TaskState.FAILED);
     });
 
+    it('should convert TASK_STATE_UNKNOWN to unknown', () => {
+      // Spec a2a-v0.3 §TaskState includes `unknown` as a first-class state.
+      // A v1.0 server emitting TASK_STATE_UNKNOWN must round-trip cleanly,
+      // not throw — see #121.
+      const raw = { id: 'task-1', status: { state: 'TASK_STATE_UNKNOWN' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.UNKNOWN);
+    });
+
     it('should pass through already lowercase states', () => {
       const raw = { id: 'task-1', status: { state: 'completed' } };
       const task = parser.parseTask(raw);

--- a/packages/a2x/src/__tests__/types.test.ts
+++ b/packages/a2x/src/__tests__/types.test.ts
@@ -19,11 +19,13 @@ describe('Layer 1: Types', () => {
       expect(TaskState.REJECTED).toBe('rejected');
       expect(TaskState.INPUT_REQUIRED).toBe('input-required');
       expect(TaskState.AUTH_REQUIRED).toBe('auth-required');
+      expect(TaskState.UNKNOWN).toBe('unknown');
     });
 
     it('should define v1.0 task state mappings', () => {
       expect(TaskStateV10.TASK_STATE_SUBMITTED).toBe('TASK_STATE_SUBMITTED');
       expect(TaskStateV10.TASK_STATE_WORKING).toBe('TASK_STATE_WORKING');
+      expect(TaskStateV10.TASK_STATE_UNKNOWN).toBe('TASK_STATE_UNKNOWN');
     });
 
     it('should define terminal states', () => {
@@ -33,6 +35,9 @@ describe('Layer 1: Types', () => {
       expect(TERMINAL_STATES.has(TaskState.REJECTED)).toBe(true);
       expect(TERMINAL_STATES.has(TaskState.WORKING)).toBe(false);
       expect(TERMINAL_STATES.has(TaskState.SUBMITTED)).toBe(false);
+      // `unknown` is non-terminal — it signals "lost track", not a
+      // finalized outcome, and the task may transition once the peer resyncs.
+      expect(TERMINAL_STATES.has(TaskState.UNKNOWN)).toBe(false);
     });
 
     it('should map internal states to v1.0 constants', () => {
@@ -41,6 +46,9 @@ describe('Layer 1: Types', () => {
       );
       expect(TASK_STATE_TO_V10.get(TaskState.WORKING)).toBe(
         TaskStateV10.TASK_STATE_WORKING,
+      );
+      expect(TASK_STATE_TO_V10.get(TaskState.UNKNOWN)).toBe(
+        TaskStateV10.TASK_STATE_UNKNOWN,
       );
     });
   });

--- a/packages/a2x/src/types/task.ts
+++ b/packages/a2x/src/types/task.ts
@@ -15,6 +15,11 @@ export enum TaskState {
   REJECTED = 'rejected',
   INPUT_REQUIRED = 'input-required',
   AUTH_REQUIRED = 'auth-required',
+  // Spec a2a-v0.3 §TaskState lists `unknown` as a first-class state for
+  // peers that have lost track of a task's true state (e.g. resubscribe
+  // after a crash, gateways that missed a transition). Non-terminal — it
+  // signals "I don't know yet", not a finalized outcome.
+  UNKNOWN = 'unknown',
 }
 
 // ─── v1.0 Protocol Constants (for output mapping) ───
@@ -28,6 +33,7 @@ export enum TaskStateV10 {
   TASK_STATE_INPUT_REQUIRED = 'TASK_STATE_INPUT_REQUIRED',
   TASK_STATE_REJECTED = 'TASK_STATE_REJECTED',
   TASK_STATE_AUTH_REQUIRED = 'TASK_STATE_AUTH_REQUIRED',
+  TASK_STATE_UNKNOWN = 'TASK_STATE_UNKNOWN',
 }
 
 // ─── Terminal States ───
@@ -50,6 +56,7 @@ export const TASK_STATE_TO_V10: ReadonlyMap<TaskState, TaskStateV10> = new Map([
   [TaskState.INPUT_REQUIRED, TaskStateV10.TASK_STATE_INPUT_REQUIRED],
   [TaskState.REJECTED, TaskStateV10.TASK_STATE_REJECTED],
   [TaskState.AUTH_REQUIRED, TaskStateV10.TASK_STATE_AUTH_REQUIRED],
+  [TaskState.UNKNOWN, TaskStateV10.TASK_STATE_UNKNOWN],
 ]);
 
 // ─── TaskStatus ───


### PR DESCRIPTION
## Summary

- Add `UNKNOWN = 'unknown'` to `TaskState` and `TASK_STATE_UNKNOWN` to `TaskStateV10`, plus the entry in `TASK_STATE_TO_V10` so the v1.0 ↔ internal round-trip works.
- Treat `unknown` as **non-terminal** (deliberately omitted from `TERMINAL_STATES`): it signals "I don't know yet", not a finalized outcome.
- Cover the new value in `types.test.ts` and add a v1.0 → internal round-trip test in `client.test.ts` (`V10ResponseParser`).

Closes #121.

## Why

Spec a2a-v0.3 \`§TaskState\` (\`specification/a2a-v0.3.0.json:2440-2453\`) defines nine states; the SDK was modeling eight. v1.0 has the same set up-shifted to \`TASK_STATE_*\`. Missing the value meant a v1.0 server emitting \`TASK_STATE_UNKNOWN\` made \`convertV10State\` throw \"Unknown task state\" on every status event for that task — see \`response-parser.ts:154-163\`.

## Test plan

- [x] \`pnpm test\` (445 pass)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (no new warnings)
- [x] \`pnpm -r build\`
- [x] New test: \`should convert TASK_STATE_UNKNOWN to unknown\` round-trips v1.0 → internal cleanly

## Changeset

Skipped per the tightened changeset policy (#116) — small bug-fix, default to no changeset; the maintainer batches into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)