### PR TITLE
fix(sdk): return HTTP 200 with JSON-RPC error body for parse / handler errors

### DIFF
--- a/packages/a2x/src/__tests__/to-a2x-http.test.ts
+++ b/packages/a2x/src/__tests__/to-a2x-http.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration tests for the toA2x() HTTP wrapper.
+ *
+ * Verifies the JSON-RPC over HTTP convention: parse and handler errors
+ * are surfaced as JSON-RPC error responses with HTTP 200, not 4xx —
+ * see issue #122.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { LlmAgent } from '../agent/llm-agent.js';
+import { BaseLlmProvider } from '../provider/base.js';
+import { toA2x, createA2xRequestListener } from '../transport/to-a2x.js';
+
+// Side-effect import to register response mappers (v0.3 / v1.0).
+import '../a2x/index.js';
+
+class NoopProvider extends BaseLlmProvider {
+  readonly name = 'noop';
+  constructor() {
+    super({ model: 'noop' });
+  }
+  async generateContent() {
+    return { content: [], finishReason: 'stop' as const };
+  }
+}
+
+describe('toA2x() HTTP wrapper — JSON-RPC over HTTP error convention', () => {
+  let baseUrl: string;
+  let stop: () => Promise<void>;
+
+  beforeAll(async () => {
+    const agent = new LlmAgent({
+      name: 'noop-agent',
+      provider: new NoopProvider(),
+      instruction: 'noop',
+    });
+    const a2x = toA2x(agent, { defaultUrl: 'http://localhost/a2a' });
+
+    // Use the exported request listener so this test exercises the same
+    // code path the production listen() does, then bind on an ephemeral
+    // port so tests can run in parallel.
+    const { createServer } = await import('node:http');
+    const server = createServer(createA2xRequestListener(a2x.handler));
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+    stop = () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+  });
+
+  afterAll(async () => {
+    await stop?.();
+  });
+
+  it('returns HTTP 200 with -32700 body for malformed JSON', async () => {
+    const res = await fetch(`${baseUrl}/a2a`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not valid json',
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      jsonrpc: string;
+      id: unknown;
+      error: { code: number; message: string };
+    };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32700);
+  });
+
+  it('returns HTTP 200 with a JSON-RPC error body for an unrecognized method', async () => {
+    // The handler returns a JSON-RPC error response (it does not throw)
+    // for an unknown method; the wrapper passes that through with HTTP
+    // 200. Belt-and-suspenders proof that we are not coercing the
+    // handler's structured error into a 4xx anywhere.
+    const res = await fetch(`${baseUrl}/a2a`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'does/not/exist',
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      jsonrpc: string;
+      id: unknown;
+      error: { code: number; message: string };
+    };
+    expect(body.id).toBe(7);
+    expect(body.error.code).toBeLessThan(0);
+  });
+});

--- a/packages/a2x/src/transport/index.ts
+++ b/packages/a2x/src/transport/index.ts
@@ -7,5 +7,5 @@ export type { HandleResult } from './request-handler.js';
 export { JsonRpcRouter } from './jsonrpc-router.js';
 export type { MethodHandler, StreamMethodHandler } from './jsonrpc-router.js';
 export { createSSEStream } from './sse-handler.js';
-export { toA2x } from './to-a2x.js';
+export { toA2x, createA2xRequestListener } from './to-a2x.js';
 export type { ToA2xOptions, ToA2xResult } from './to-a2x.js';

--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -88,131 +88,9 @@ export function toA2x(
 
       const { createServer } = await import('node:http');
 
-      const server = createServer(async (req, res) => {
-        // CORS headers
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-
-        if (req.method === 'OPTIONS') {
-          res.writeHead(204);
-          res.end();
-          return;
-        }
-
-        // GET /.well-known/agent.json
-        const parsedUrl = new URL(
-          req.url!,
-          `http://localhost:${listenPort}`,
-        );
-        if (
-          req.method === 'GET' &&
-          parsedUrl.pathname === '/.well-known/agent.json'
-        ) {
-          const version =
-            parsedUrl.searchParams.get('version') ?? undefined;
-
-          try {
-            const card = handler.getAgentCard(version);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify(card));
-          } catch (error) {
-            res.writeHead(500, { 'Content-Type': 'application/json' });
-            res.end(
-              JSON.stringify({
-                error: error instanceof Error ? error.message : 'Internal error',
-              }),
-            );
-          }
-          return;
-        }
-
-        // POST /a2a (JSON-RPC)
-        if (req.method === 'POST') {
-          let body = '';
-          for await (const chunk of req) {
-            body += chunk;
-          }
-
-          try {
-            const parsed = JSON.parse(body);
-            const context: RequestContext = {
-              headers: req.headers as Record<string, string | string[] | undefined>,
-              query: Object.fromEntries(parsedUrl.searchParams.entries()),
-            };
-            const result = await handler.handle(parsed, context);
-
-            // Streaming → AsyncGenerator → SSE
-            if (
-              result &&
-              typeof result === 'object' &&
-              Symbol.asyncIterator in result
-            ) {
-              res.writeHead(200, {
-                'Content-Type': 'text/event-stream',
-                'Cache-Control': 'no-cache',
-                Connection: 'keep-alive',
-              });
-
-              const stream = createSSEStream(
-                result as AsyncGenerator<never>,
-              );
-              const reader = stream.getReader();
-
-              // On client TCP close, cancel the reader so the source
-              // generator terminates and aborts in-flight LLM calls.
-              // Use res.on('close') — req.on('close') fires when the
-              // request body stream is consumed (before response writing),
-              // so it misses the later disconnect during streaming.
-              // res.close also fires after a normal res.end(), at which
-              // point cancel() is a harmless no-op.
-              const cancelReader = () => {
-                void reader.cancel().catch(() => {});
-              };
-              res.on('close', cancelReader);
-
-              try {
-                while (true) {
-                  const { done, value } = await reader.read();
-                  if (done) break;
-                  res.write(
-                    typeof value === 'string'
-                      ? value
-                      : new TextDecoder().decode(value),
-                  );
-                }
-              } catch (error) {
-                const errorData = JSON.stringify({
-                  error:
-                    error instanceof Error
-                      ? error.message
-                      : 'Internal error',
-                });
-                res.write(`event: error\ndata: ${errorData}\n\n`);
-              }
-              res.end();
-              return;
-            }
-
-            // Standard JSON-RPC response
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify(result));
-          } catch {
-            res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(
-              JSON.stringify({
-                jsonrpc: '2.0',
-                id: null,
-                error: { code: -32700, message: 'Parse error' },
-              }),
-            );
-          }
-          return;
-        }
-
-        res.writeHead(404);
-        res.end('Not Found');
-      });
+      const server = createServer(
+        createA2xRequestListener(handler, `http://localhost:${listenPort}`),
+      );
 
       return new Promise<void>((resolve) => {
         server.listen(listenPort, () => {
@@ -220,5 +98,170 @@ export function toA2x(
         });
       });
     },
+  };
+}
+
+/**
+ * Build a Node.js `http.RequestListener` that dispatches `/.well-known/`
+ * card lookups to `handler.getAgentCard()` and `POST /a2a` JSON-RPC
+ * requests through `handler.handle()`.
+ *
+ * Exported separately so it can be unit-tested without going through
+ * `listen(port)` (which never resolves until the server closes), and so
+ * embedders that already own an `http.Server` can install our dispatch
+ * without recreating one.
+ *
+ * `defaultOrigin` is the synthetic origin used to resolve relative
+ * `req.url` values into a `URL` object. It only affects URL parsing —
+ * the actual HTTP host comes from the request itself.
+ */
+export function createA2xRequestListener(
+  handler: DefaultRequestHandler,
+  defaultOrigin = 'http://localhost',
+): (req: import('node:http').IncomingMessage, res: import('node:http').ServerResponse) => Promise<void> {
+  return async (req, res) => {
+    // CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const parsedUrl = new URL(req.url ?? '/', defaultOrigin);
+
+    // GET /.well-known/agent.json
+    if (
+      req.method === 'GET' &&
+      parsedUrl.pathname === '/.well-known/agent.json'
+    ) {
+      const version = parsedUrl.searchParams.get('version') ?? undefined;
+      try {
+        const card = handler.getAgentCard(version);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(card));
+      } catch (error) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : 'Internal error',
+          }),
+        );
+      }
+      return;
+    }
+
+    // POST /a2a (JSON-RPC)
+    if (req.method === 'POST') {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+
+      // JSON-RPC over HTTP convention: parse and handler errors are
+      // surfaced as JSON-RPC error responses with HTTP 200, not as
+      // 4xx/5xx — clients that skip body parsing on 4xx would never
+      // see the JSON-RPC error code otherwise. Mirrors the contract
+      // already implemented in DefaultRequestHandler.handle() for
+      // string bodies (request-handler.ts:96-106).
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32700, message: 'Parse error' },
+          }),
+        );
+        return;
+      }
+
+      const context: RequestContext = {
+        headers: req.headers as Record<string, string | string[] | undefined>,
+        query: Object.fromEntries(parsedUrl.searchParams.entries()),
+      };
+
+      let result: Awaited<ReturnType<typeof handler.handle>>;
+      try {
+        result = await handler.handle(parsed, context);
+      } catch (err) {
+        const id =
+          parsed && typeof parsed === 'object' && 'id' in parsed
+            ? (parsed as { id: unknown }).id
+            : null;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id,
+            error: {
+              code: -32603,
+              message: err instanceof Error ? err.message : 'Internal error',
+            },
+          }),
+        );
+        return;
+      }
+
+      // Streaming → AsyncGenerator → SSE
+      if (
+        result &&
+        typeof result === 'object' &&
+        Symbol.asyncIterator in result
+      ) {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        });
+
+        const stream = createSSEStream(result as AsyncGenerator<never>);
+        const reader = stream.getReader();
+
+        // On client TCP close, cancel the reader so the source generator
+        // terminates and aborts in-flight LLM calls. Use res.on('close')
+        // — req.on('close') fires when the request body stream is
+        // consumed (before response writing), so it misses the later
+        // disconnect during streaming. res.close also fires after a
+        // normal res.end(), at which point cancel() is a harmless no-op.
+        const cancelReader = () => {
+          void reader.cancel().catch(() => {});
+        };
+        res.on('close', cancelReader);
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(
+              typeof value === 'string'
+                ? value
+                : new TextDecoder().decode(value),
+            );
+          }
+        } catch (error) {
+          const errorData = JSON.stringify({
+            error: error instanceof Error ? error.message : 'Internal error',
+          });
+          res.write(`event: error\ndata: ${errorData}\n\n`);
+        }
+        res.end();
+        return;
+      }
+
+      // Standard JSON-RPC response
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
   };
 }

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -100,6 +100,24 @@ const handler = new DefaultRequestHandler(a2xAgent);
 const app = express();
 app.use(express.json());
 
+// Parse-error handler: convert SyntaxError raised by express.json()
+// into a JSON-RPC -32700 response with HTTP 200, matching the
+// JSON-RPC over HTTP convention used by the SDK's own to-a2x wrapper.
+// Express invokes this with 4 args when it sees a SyntaxError.
+app.use(
+  (err: unknown, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err instanceof SyntaxError && 'body' in err) {
+      res.status(200).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      });
+      return;
+    }
+    next(err);
+  },
+);
+
 // Agent Card
 app.get('/.well-known/agent.json', (req, res) => {
   try {
@@ -120,45 +138,54 @@ app.post('/a2a', async (req, res) => {
     query: req.query as Record<string, string | string[] | undefined>,
   };
 
+  // JSON-RPC over HTTP convention: handler exceptions are surfaced as
+  // JSON-RPC error responses with HTTP 200, not as 4xx/5xx, so clients
+  // that skip body parsing on transport errors still see the code.
+  let result: Awaited<ReturnType<typeof handler.handle>>;
   try {
-    const result = await handler.handle(req.body, context);
-
-    // Streaming → SSE
-    if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
-      res.setHeader('Content-Type', 'text/event-stream');
-      res.setHeader('Cache-Control', 'no-cache');
-      res.setHeader('Connection', 'keep-alive');
-
-      const stream = createSSEStream(
-        result as AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
-      );
-      const reader = stream.getReader();
-
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
-        }
-      } catch (error) {
-        const errorData = JSON.stringify({
-          error: error instanceof Error ? error.message : 'Internal error',
-        });
-        res.write(`event: error\ndata: ${errorData}\n\n`);
-      }
-      res.end();
-      return;
-    }
-
-    // Standard JSON-RPC response
-    res.json(result);
-  } catch {
-    res.status(400).json({
+    result = await handler.handle(req.body, context);
+  } catch (err) {
+    const id = (req.body as { id?: unknown } | undefined)?.id ?? null;
+    res.status(200).json({
       jsonrpc: '2.0',
-      id: null,
-      error: { code: -32700, message: 'Parse error' },
+      id,
+      error: {
+        code: -32603,
+        message: err instanceof Error ? err.message : 'Internal error',
+      },
     });
+    return;
   }
+
+  // Streaming → SSE
+  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    const stream = createSSEStream(
+      result as AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
+    );
+    const reader = stream.getReader();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+      }
+    } catch (error) {
+      const errorData = JSON.stringify({
+        error: error instanceof Error ? error.message : 'Internal error',
+      });
+      res.write(`event: error\ndata: ${errorData}\n\n`);
+    }
+    res.end();
+    return;
+  }
+
+  // Standard JSON-RPC response
+  res.json(result);
 });
 
 // ─── 5. Start ───

--- a/samples/nextjs-skill/src/app/api/a2a/route.ts
+++ b/samples/nextjs-skill/src/app/api/a2a/route.ts
@@ -11,13 +11,16 @@ const SSE_HEADERS = {
 } as const;
 
 export async function POST(request: Request): Promise<Response> {
+  // JSON-RPC over HTTP convention: parse and handler errors become
+  // JSON-RPC error responses with HTTP 200, not 4xx/5xx — clients that
+  // skip body parsing on transport errors still see the code.
   let body: unknown;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json(
-      { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null },
-      { status: 400 },
+      { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+      { status: 200 },
     );
   }
 
@@ -26,7 +29,23 @@ export async function POST(request: Request): Promise<Response> {
     query: Object.fromEntries(new URL(request.url).searchParams.entries()),
   };
 
-  const result = await handler.handle(body, context);
+  let result: Awaited<ReturnType<typeof handler.handle>>;
+  try {
+    result = await handler.handle(body, context);
+  } catch (err) {
+    const id = (body as { id?: unknown } | undefined)?.id ?? null;
+    return NextResponse.json(
+      {
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32603,
+          message: err instanceof Error ? err.message : "Internal error",
+        },
+      },
+      { status: 200 },
+    );
+  }
 
   if (result && typeof result === "object" && Symbol.asyncIterator in result) {
     const stream = createSSEStream(result as AsyncGenerator<never>);

--- a/samples/nextjs-x402/src/app/api/a2a/route.ts
+++ b/samples/nextjs-x402/src/app/api/a2a/route.ts
@@ -25,13 +25,16 @@ function log(label: string, payload: unknown): void {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  // JSON-RPC over HTTP convention: parse and handler errors become
+  // JSON-RPC error responses with HTTP 200, not 4xx/5xx — clients that
+  // skip body parsing on transport errors still see the code.
   let body: unknown;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json(
-      { jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null },
-      { status: 400 },
+      { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+      { status: 200 },
     );
   }
 
@@ -42,7 +45,23 @@ export async function POST(request: Request): Promise<Response> {
     query: Object.fromEntries(new URL(request.url).searchParams.entries()),
   };
 
-  const result = await handler.handle(body, context);
+  let result: Awaited<ReturnType<typeof handler.handle>>;
+  try {
+    result = await handler.handle(body, context);
+  } catch (err) {
+    const id = (body as { id?: unknown } | undefined)?.id ?? null;
+    return NextResponse.json(
+      {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32603,
+          message: err instanceof Error ? err.message : 'Internal error',
+        },
+      },
+      { status: 200 },
+    );
+  }
 
   if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
     const source = result as AsyncGenerator<unknown>;

--- a/samples/nextjs/src/app/api/a2a/route.ts
+++ b/samples/nextjs/src/app/api/a2a/route.ts
@@ -11,13 +11,16 @@ const SSE_HEADERS = {
 } as const;
 
 export async function POST(request: Request): Promise<Response> {
+  // JSON-RPC over HTTP convention: parse and handler errors become
+  // JSON-RPC error responses with HTTP 200, not 4xx/5xx — clients that
+  // skip body parsing on transport errors still see the code.
   let body: unknown;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json(
-      { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null },
-      { status: 400 },
+      { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+      { status: 200 },
     );
   }
 
@@ -27,7 +30,23 @@ export async function POST(request: Request): Promise<Response> {
     query: Object.fromEntries(new URL(request.url).searchParams.entries()),
   };
 
-  const result = await handler.handle(body, context);
+  let result: Awaited<ReturnType<typeof handler.handle>>;
+  try {
+    result = await handler.handle(body, context);
+  } catch (err) {
+    const id = (body as { id?: unknown } | undefined)?.id ?? null;
+    return NextResponse.json(
+      {
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32603,
+          message: err instanceof Error ? err.message : "Internal error",
+        },
+      },
+      { status: 200 },
+    );
+  }
 
   // Streaming → AsyncGenerator → SSE response
   if (result && typeof result === "object" && Symbol.asyncIterator in result) {


### PR DESCRIPTION
## Summary

- Narrow the parse-error catch in \`to-a2x.ts\` to wrap \`JSON.parse\` only, then surface handler exceptions as a JSON-RPC \`-32603\` body — both with HTTP 200, matching JSON-RPC over HTTP convention.
- Extract the dispatch closure into the new exported \`createA2xRequestListener(handler, defaultOrigin)\` so the contract can be unit-tested directly (and embedders that already own an \`http.Server\` can install the same dispatch).
- Apply the same fix to all four bundled samples (\`express\`, \`nextjs\`, \`nextjs-skill\`, \`nextjs-x402\`). Express needed an extra \`SyntaxError\` middleware because \`express.json()\` raises before the route handler runs.
- Add \`to-a2x-http.test.ts\` to lock the contract in: malformed body returns HTTP 200 with \`-32700\`; unknown method returns HTTP 200 with the JSON-RPC error from the handler.

Closes #122.

## Why

The SDK already returns 200 + JSON-RPC error from \`DefaultRequestHandler.handle()\` for parse errors when called with a string body (\`request-handler.ts:96-106\`). The HTTP wrappers above it were doing the opposite — converting any throw inside the wrapping \`try\` into HTTP 400 with a hardcoded \`-32700 Parse error\` body, which:

- Hid the real error code (an \`-32603 InternalError\` from the handler showed up to the caller as \`-32700 Parse error\`).
- Was unparseable by clients that skip body decoding on \`4xx\`. The SDK's own client checks \`response.ok\` in some paths, so a server-side bug that should have surfaced as a recoverable JSON-RPC error read instead as a hard transport failure.

Auth-failure parity for this contract was the point of #94. This is the same bug at the HTTP-wrapper layer.

## Test plan

- [x] \`pnpm test\` (446 pass, includes 2 new integration tests)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (no new warnings)
- [x] \`pnpm -r build\`
- [x] New: \`returns HTTP 200 with -32700 body for malformed JSON\`
- [x] New: \`returns HTTP 200 with a JSON-RPC error body for an unrecognized method\`

## Notes

- \`createA2xRequestListener\` is now part of the public surface (\`packages/a2x/src/transport/index.ts\`); doc-pages with framework-agnostic embedding examples can switch to it instead of recreating the dispatch.
- No changeset per the tightened policy (#116) — bug fix; the maintainer batches into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)