### PR TITLE
fix(sdk): wrap SSE chunks in JSON-RPC envelope per spec

### DIFF
--- a/packages/a2x/docs/guides/agent/streaming.md
+++ b/packages/a2x/docs/guides/agent/streaming.md
@@ -45,6 +45,14 @@ For a `message/stream` call, the client gets an SSE stream of typed events. Each
 | `status-update` | Task state transition (`submitted` → `working` → `completed`/`failed`/`canceled`). |
 | `artifact-update` | A chunk of output (message parts, tool calls, tool results). |
 
+Per spec a2a-v0.3 §SendStreamingMessageSuccessResponse, every chunk on the wire is a full JSON-RPC success response keyed by the request id:
+
+```
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update", …}}
+```
+
+`createSSEStream()` and `DefaultRequestHandler` handle the wrapping for you — your agent code yields the raw event objects (`status-update` / `artifact-update`) as before.
+
 See [Consuming Streams](../client/streaming.md) for the client-side iteration pattern.
 
 ## Client disconnect stops the work

--- a/packages/a2x/docs/guides/client/streaming.md
+++ b/packages/a2x/docs/guides/client/streaming.md
@@ -94,7 +94,19 @@ Behavior to know:
 
 - **Forward-only.** Events that fired before the resubscribe call are not replayed — you see what the server publishes from that point on.
 - **Terminal replay.** If the task already completed, you receive a single `status-update` event with the final state, then the stream ends.
-- **Unknown task.** The server emits an SSE `error` event carrying `TaskNotFoundError` (JSON-RPC code `-32001`).
+- **Unknown task.** The server emits a single JSON-RPC error envelope (`{ jsonrpc: "2.0", id: <request id>, error: { code: -32001, ... } }`) on the same SSE stream and closes — same shape as a non-streaming error response, just delivered over `data:` SSE chunks.
+
+### SSE wire shape
+
+Every SSE chunk is a full JSON-RPC success response (per A2A spec a2a-v0.3 §SendStreamingMessageSuccessResponse), keyed by the original request id:
+
+```
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"…","status":{"state":"working"}}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"artifact-update","taskId":"…","artifact":{ … }}}
+```
+
+There is no `event:` field, no `event: done` terminator. Stream end is signalled by the server closing the connection after a terminal status (`final: true` in v0.3, or simply the last yielded event in v1.0). Servers from before this release may still emit the legacy `event: status_update`/`event: done` shape; the SDK parser keeps tolerating it for one minor and logs a one-time deprecation warning when it sees it.
 
 ## Accumulating output
 

--- a/packages/a2x/src/__tests__/client.test.ts
+++ b/packages/a2x/src/__tests__/client.test.ts
@@ -355,11 +355,12 @@ describe('ResponseParser', () => {
 describe('SSE Parser', () => {
   const parser = getResponseParser('0.3');
 
-  it('should parse status_update and artifact_update events', async () => {
+  it('parses spec-shaped JSON-RPC envelopes for status and artifact updates', async () => {
+    // Spec a2a-v0.3 §SendStreamingMessageSuccessResponse: each chunk is
+    // a full JSON-RPC success response with the event under `result`.
     const sse = [
-      'event: status_update\ndata: {"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
-      'event: artifact_update\ndata: {"kind":"artifact-update","taskId":"t1","contextId":"c1","artifact":{"artifactId":"a1","parts":[{"kind":"text","text":"hello"}]}}\n\n',
-      'event: done\ndata: {}\n\n',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}}\n\n',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"kind":"artifact-update","taskId":"t1","contextId":"c1","artifact":{"artifactId":"a1","parts":[{"kind":"text","text":"hello"}]}}}\n\n',
     ].join('');
 
     const response = createSSEResponse(sse);
@@ -373,11 +374,13 @@ describe('SSE Parser', () => {
     expect((events[1] as Record<string, unknown>).taskId).toBe('t1');
   });
 
-  it('should stop on done event', async () => {
+  it('stops at terminal status with final=true (no `event: done` terminator needed)', async () => {
+    // Spec a2a-v0.3 §TaskStatusUpdateEvent: `final: true` on a terminal
+    // state marks the last event for the stream. Connection close after
+    // it ends the SSE stream.
     const sse = [
-      'event: status_update\ndata: {"taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
-      'event: done\ndata: {}\n\n',
-      'event: artifact_update\ndata: {"taskId":"t1","contextId":"c1","artifact":{"artifactId":"a1","parts":[]}}\n\n',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}}\n\n',
+      'data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"completed"},"final":true}}\n\n',
     ].join('');
 
     const response = createSSEResponse(sse);
@@ -386,32 +389,19 @@ describe('SSE Parser', () => {
       events.push(event);
     }
 
-    // Should only get 1 event (before done)
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2);
   });
 
-  it('should throw on error event', async () => {
-    const sse = 'event: error\ndata: {"error":"Something went wrong"}\n\n';
-    const response = createSSEResponse(sse);
-
-    await expect(async () => {
-      for await (const _event of parseSSEStream(response, parser)) {
-        // should not reach here
-      }
-    }).rejects.toThrow('Something went wrong');
-  });
-
-  it('should handle chunked SSE delivery', async () => {
+  it('handles chunked SSE delivery for spec-shaped envelopes', async () => {
     const encoder = new TextEncoder();
-    const chunk1 = 'event: status_upd';
-    const chunk2 = 'ate\ndata: {"taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n';
-    const chunk3 = 'event: done\ndata: {}\n\n';
+    const chunk1 = 'data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-upda';
+    const chunk2 =
+      'te","taskId":"t1","contextId":"c1","status":{"state":"working"}}}\n\n';
 
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(encoder.encode(chunk1));
         controller.enqueue(encoder.encode(chunk2));
-        controller.enqueue(encoder.encode(chunk3));
         controller.close();
       },
     });
@@ -424,6 +414,31 @@ describe('SSE Parser', () => {
 
     expect(events).toHaveLength(1);
     expect((events[0] as Record<string, unknown>).taskId).toBe('t1');
+  });
+
+  it('still parses the legacy `event: status_update` / `event: done` format with a deprecation warning', async () => {
+    // Backward-compat: pre-#118 a2x servers emitted `event: ` framed
+    // chunks. Keep parsing them for one minor so users don't break on
+    // an old server, but log once so they notice the upgrade.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const sse = [
+        'event: status_update\ndata: {"kind":"status-update","taskId":"t1","contextId":"c1","status":{"state":"working"}}\n\n',
+        'event: done\ndata: {}\n\n',
+      ].join('');
+
+      const response = createSSEResponse(sse);
+      const events: unknown[] = [];
+      for await (const event of parseSSEStream(response, parser)) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain('legacy SSE format');
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('should throw if response body is null', async () => {

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -474,28 +474,33 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
       expect(isAsyncGenerator(result)).toBe(true);
 
-      // Consume the async generator and collect events
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
-      const events: unknown[] = [];
+      // Each chunk is a JSON-RPC success envelope
+      // ({ jsonrpc, id, result }) per spec §SendStreamingMessageSuccessResponse.
+      const generator = result as AsyncGenerator<{
+        jsonrpc: '2.0';
+        id: number;
+        result: Record<string, unknown>;
+      }>;
+      const events: Record<string, unknown>[] = [];
 
-      for await (const event of generator) {
-        events.push(event);
+      for await (const envelope of generator) {
+        expect(envelope.jsonrpc).toBe('2.0');
+        expect(envelope.id).toBe(1);
+        events.push(envelope.result);
       }
 
       // Should have received events (status_update + artifact_updates + final status)
       expect(events.length).toBeGreaterThan(0);
 
       // Default is v1.0: status state should be UPPER_SNAKE_CASE
-      const first = events[0] as Record<string, unknown>;
+      const first = events[0];
       const firstStatus = first.status as Record<string, unknown> | undefined;
       if (firstStatus) {
         expect(firstStatus.state).toBe('TASK_STATE_WORKING');
       }
 
       // Last status event should be completed
-      const statusEvents = events.filter(
-        (e) => (e as Record<string, unknown>).status !== undefined,
-      );
+      const statusEvents = events.filter((e) => e.status !== undefined);
       const lastStatus = statusEvents[statusEvents.length - 1] as { status: { state: string } };
       expect(lastStatus.status.state).toBe('TASK_STATE_COMPLETED');
     });
@@ -517,11 +522,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
       expect(isAsyncGenerator(result)).toBe(true);
 
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const generator = result as AsyncGenerator<{
+        jsonrpc: '2.0';
+        id: number;
+        result: Record<string, unknown>;
+      }>;
       const events: Record<string, unknown>[] = [];
 
-      for await (const event of generator) {
-        events.push(event as Record<string, unknown>);
+      for await (const envelope of generator) {
+        events.push(envelope.result);
       }
 
       expect(events.length).toBeGreaterThan(0);
@@ -562,11 +571,15 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
       expect(isAsyncGenerator(result)).toBe(true);
 
-      const generator = result as AsyncGenerator<Record<string, unknown>>;
+      const generator = result as AsyncGenerator<{
+        jsonrpc: '2.0';
+        id: number;
+        result: Record<string, unknown>;
+      }>;
       const events: Record<string, unknown>[] = [];
 
-      for await (const event of generator) {
-        events.push(event as Record<string, unknown>);
+      for await (const envelope of generator) {
+        events.push(envelope.result);
       }
 
       // No event should have a kind field
@@ -815,12 +828,17 @@ describe('Layer 4: DefaultRequestHandler', () => {
       const context: RequestContext = { headers: {} };
       const response = await handler.handle(streamRequest, context);
       expect(isAsyncGenerator(response)).toBe(true);
-      const events: unknown[] = [];
-      for await (const ev of response as AsyncGenerator<unknown>) {
-        events.push(ev);
+      const events: { jsonrpc: '2.0'; id: number; result: Record<string, unknown> }[] = [];
+      for await (const envelope of response as AsyncGenerator<{
+        jsonrpc: '2.0';
+        id: number;
+        result: Record<string, unknown>;
+      }>) {
+        events.push(envelope);
       }
       expect(events).toHaveLength(1);
-      const status = (events[0] as { status: { state: string } }).status;
+      expect(events[0].id).toBe(2);
+      const status = events[0].result.status as { state: string };
       expect(status.state).toBe(TaskStateV10.TASK_STATE_AUTH_REQUIRED);
     });
 

--- a/packages/a2x/src/__tests__/task-resubscribe.test.ts
+++ b/packages/a2x/src/__tests__/task-resubscribe.test.ts
@@ -9,7 +9,6 @@ import { BaseAgent } from '../agent/base-agent.js';
 import type { AgentEvent } from '../agent/base-agent.js';
 import type { InvocationContext } from '../runner/context.js';
 import { TaskState } from '../types/task.js';
-import { TaskNotFoundError } from '../types/errors.js';
 
 // Ensure mappers are registered
 import '../a2x/index.js';
@@ -51,8 +50,30 @@ function createSlowHandler(
   return { handler: new DefaultRequestHandler(a2xAgent), taskStore };
 }
 
+// Each chunk in a streaming response is a JSON-RPC success envelope per
+// spec a2a-v0.3 §SendStreamingMessageSuccessResponse. Tests pull events
+// out of `result` (or surface the error envelope as a fail).
+type StreamEnvelope = {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+};
+
+function unwrapResult(envelope: StreamEnvelope): Record<string, unknown> {
+  if (envelope.error) {
+    throw new Error(
+      `Stream yielded JSON-RPC error: ${envelope.error.code} ${envelope.error.message}`,
+    );
+  }
+  if (!envelope.result) {
+    throw new Error(`Stream envelope has neither result nor error: ${JSON.stringify(envelope)}`);
+  }
+  return envelope.result;
+}
+
 describe('tasks/resubscribe', () => {
-  it('returns TaskNotFoundError when task does not exist', async () => {
+  it('emits a JSON-RPC error envelope when the task does not exist', async () => {
     const { handler } = createSlowHandler(['hi'], 5);
 
     const result = await handler.handle({
@@ -62,8 +83,6 @@ describe('tasks/resubscribe', () => {
       params: { id: 'nonexistent' },
     });
 
-    // Stream handlers return an AsyncGenerator; the TaskNotFoundError is
-    // thrown from within the generator when iteration starts.
     expect(result).toBeDefined();
     expect(
       result !== null &&
@@ -71,12 +90,16 @@ describe('tasks/resubscribe', () => {
         Symbol.asyncIterator in (result as object),
     ).toBe(true);
 
-    const generator = result as AsyncGenerator<unknown>;
-    await expect(async () => {
-      for await (const _ of generator) {
-        // drain
-      }
-    }).rejects.toThrow(TaskNotFoundError);
+    const generator = result as AsyncGenerator<StreamEnvelope>;
+    const envelopes: StreamEnvelope[] = [];
+    for await (const envelope of generator) {
+      envelopes.push(envelope);
+    }
+
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0].id).toBe(1);
+    // TaskNotFoundError → JSON-RPC -32001 per A2A error code table.
+    expect(envelopes[0].error?.code).toBe(-32001);
   });
 
   it('replays terminal status event when task is already completed', async () => {
@@ -98,10 +121,11 @@ describe('tasks/resubscribe', () => {
       params: { id: task.id },
     });
 
-    const generator = result as AsyncGenerator<Record<string, unknown>>;
+    const generator = result as AsyncGenerator<StreamEnvelope>;
     const events: Record<string, unknown>[] = [];
-    for await (const event of generator) {
-      events.push(event);
+    for await (const envelope of generator) {
+      expect(envelope.id).toBe(1);
+      events.push(unwrapResult(envelope));
     }
 
     expect(events).toHaveLength(1);
@@ -136,10 +160,11 @@ describe('tasks/resubscribe', () => {
     const resubEvents: Record<string, unknown>[] = [];
     let taskId: string | undefined;
 
-    const originalIter = streamResult as AsyncGenerator<Record<string, unknown>>;
+    const originalIter = streamResult as AsyncGenerator<StreamEnvelope>;
 
     const originalConsumer = (async () => {
-      for await (const event of originalIter) {
+      for await (const envelope of originalIter) {
+        const event = unwrapResult(envelope);
         originalEvents.push(event);
         if (!taskId && typeof event.taskId === 'string') {
           taskId = event.taskId;
@@ -161,11 +186,13 @@ describe('tasks/resubscribe', () => {
       method: 'tasks/resubscribe',
       params: { id: taskId! },
     });
-    const resubIter = resubResult as AsyncGenerator<Record<string, unknown>>;
+    const resubIter = resubResult as AsyncGenerator<StreamEnvelope>;
 
     const resubConsumer = (async () => {
-      for await (const event of resubIter) {
-        resubEvents.push(event);
+      for await (const envelope of resubIter) {
+        // Resub stream's envelopes are correlated by the resub request id.
+        expect(envelope.id).toBe(2);
+        resubEvents.push(unwrapResult(envelope));
       }
     })();
 
@@ -200,7 +227,7 @@ describe('tasks/resubscribe', () => {
       },
     });
 
-    const originalIter = streamResult as AsyncGenerator<Record<string, unknown>>;
+    const originalIter = streamResult as AsyncGenerator<StreamEnvelope>;
     const originalEvents: Record<string, unknown>[] = [];
     let taskId: string | undefined;
 
@@ -208,9 +235,10 @@ describe('tasks/resubscribe', () => {
     // while the stream is still live.
     const first = await originalIter.next();
     if (!first.done) {
-      originalEvents.push(first.value);
-      if (typeof first.value.taskId === 'string') {
-        taskId = first.value.taskId;
+      const event = unwrapResult(first.value);
+      originalEvents.push(event);
+      if (typeof event.taskId === 'string') {
+        taskId = event.taskId;
       }
     }
 
@@ -222,20 +250,20 @@ describe('tasks/resubscribe', () => {
       method: 'tasks/resubscribe',
       params: { id: taskId! },
     });
-    const resubIter = resubResult as AsyncGenerator<Record<string, unknown>>;
+    const resubIter = resubResult as AsyncGenerator<StreamEnvelope>;
 
     // Consume both streams; after the primary stream ends, the resubscriber
     // must also end (done: true).
     const originalConsumer = (async () => {
-      for await (const event of originalIter) {
-        originalEvents.push(event);
+      for await (const envelope of originalIter) {
+        originalEvents.push(unwrapResult(envelope));
       }
     })();
 
     const resubEvents: Record<string, unknown>[] = [];
     const resubConsumer = (async () => {
-      for await (const event of resubIter) {
-        resubEvents.push(event);
+      for await (const envelope of resubIter) {
+        resubEvents.push(unwrapResult(envelope));
       }
     })();
 

--- a/packages/a2x/src/client/sse-parser.ts
+++ b/packages/a2x/src/client/sse-parser.ts
@@ -2,16 +2,19 @@
  * Client-side SSE (Server-Sent Events) stream parser.
  * Counterpart to server-side src/transport/sse-handler.ts.
  *
- * Supports two SSE formats:
+ * Spec format (a2a-v0.3 §SendStreamingMessageSuccessResponse — every
+ * chunk is a full JSON-RPC success response):
  *
- * Format A (a2x server — has event: field):
+ *   data: {"jsonrpc":"2.0","id":1,"result":<TaskStatusUpdateEvent|TaskArtifactUpdateEvent>}\n\n
+ *
+ * a2x and ADK-based servers both emit this shape today.
+ *
+ * Legacy format A (pre-#118 a2x server output, kept for one minor for
+ * upgrade compatibility — emits a one-time deprecation warning):
  *   event: status_update\ndata: {event object}\n\n
  *   event: artifact_update\ndata: {event object}\n\n
  *   event: done\ndata: {}\n\n
  *   event: error\ndata: {error message}\n\n
- *
- * Format B (ADK-based servers — data-only, JSON-RPC wrapped):
- *   data: {"jsonrpc":"2.0","id":1,"result":{event object with "kind" field}}\n\n
  */
 
 import type {
@@ -138,6 +141,7 @@ export async function* parseSSEStream(
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  let warnedLegacyFormat = false;
 
   try {
     while (true) {
@@ -150,8 +154,20 @@ export async function* parseSSEStream(
       buffer = remaining;
 
       for (const sseEvent of events) {
-        // Format A: explicit event: field from a2x server
+        // Legacy format A: explicit event: field. Emitted by pre-#118
+        // a2x servers; surface a one-time deprecation warning so users
+        // notice they're talking to an old server. Drop in next minor.
         if (sseEvent.event) {
+          if (!warnedLegacyFormat) {
+            warnedLegacyFormat = true;
+            console.warn(
+              '[@a2x/sdk] Streaming peer emitted the legacy SSE format ' +
+                "(`event: status_update` / `event: artifact_update`). The A2A spec " +
+                'requires `data:`-only chunks wrapped in a JSON-RPC envelope ' +
+                "(`{ jsonrpc, id, result }`). Upgrade the server (a2x ≥ next) " +
+                'to drop this warning. See issue #118.',
+            );
+          }
           switch (sseEvent.event) {
             case SSE_EVENT.STATUS_UPDATE: {
               const raw = JSON.parse(sseEvent.data);

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -141,7 +141,10 @@ export class DefaultRequestHandler {
           return this._buildAuthRequiredResponse(request, reason);
         }
         if (request.method === A2A_METHODS.STREAM_MESSAGE) {
-          return this._buildAuthRequiredStream(request, reason);
+          return this._wrapStreamInJsonRpc(
+            request.id,
+            this._buildAuthRequiredStream(request, reason),
+          );
         }
         const error = new InvalidRequestError(reason);
         return {
@@ -191,10 +194,14 @@ export class DefaultRequestHandler {
       }
     }
 
-    // Streaming method → return AsyncGenerator
+    // Streaming method → return AsyncGenerator. Each chunk is wrapped
+    // in a JSON-RPC success envelope keyed by `request.id`, per spec
+    // a2a-v0.3 §SendStreamingMessageSuccessResponse — every frame on
+    // the stream is a full JSONRPCResponse, not a bare event object.
     if (this.router.isStreamMethod(request.method)) {
       try {
-        return this.router.routeStream(request) as AsyncGenerator<unknown>;
+        const inner = this.router.routeStream(request) as AsyncGenerator<unknown>;
+        return this._wrapStreamInJsonRpc(request.id, inner);
       } catch (err) {
         return this._toErrorResponse(request.id, err);
       }
@@ -709,6 +716,25 @@ export class DefaultRequestHandler {
   }
 
   // ─── Private: Helpers ───
+
+  /**
+   * Wrap each chunk of an inner stream generator into a JSON-RPC success
+   * envelope (`{ jsonrpc, id, result }`). Mid-stream errors are surfaced
+   * as a single trailing JSON-RPC error envelope, then the stream closes
+   * — clients keyed on the request id can correlate the failure.
+   */
+  private async *_wrapStreamInJsonRpc(
+    id: string | number | null,
+    inner: AsyncGenerator<unknown>,
+  ): AsyncGenerator<JSONRPCResponse> {
+    try {
+      for await (const event of inner) {
+        yield { jsonrpc: '2.0', id, result: event };
+      }
+    } catch (err) {
+      yield this._toErrorResponse(id, err);
+    }
+  }
 
   private _toErrorResponse(
     id: string | number | null,

--- a/packages/a2x/src/transport/sse-handler.ts
+++ b/packages/a2x/src/transport/sse-handler.ts
@@ -1,17 +1,31 @@
 /**
  * Layer 4: SSE (Server-Sent Events) streaming handler.
+ *
+ * Per A2A spec a2a-v0.3 §SendStreamingMessageSuccessResponse, every
+ * chunk in a `message/stream` or `tasks/resubscribe` SSE response is a
+ * full JSON-RPC success response keyed by the request id:
+ *
+ *   { "jsonrpc": "2.0", "id": <correlation id>, "result": <event> }
+ *
+ * The wrapping into that envelope is done upstream — in
+ * DefaultRequestHandler's stream methods, where the request id is in
+ * scope. This file is the transport-level SSE encoder: it takes
+ * already-shaped values and emits them as data-only SSE chunks (no
+ * `event:` field, no terminator chunk). Stream end is signalled by
+ * connection close after the last event, which the spec already
+ * requires the handler to mark with `final: true` (v0.3) or by simply
+ * stopping (v1.0).
  */
-
-import type {
-  TaskStatusUpdateEvent,
-  TaskArtifactUpdateEvent,
-} from '../types/task.js';
 
 /**
- * Create a ReadableStream that emits SSE-formatted events from an async generator.
+ * Create a ReadableStream that JSON-encodes each value yielded by the
+ * generator as an SSE `data:` chunk.
+ *
+ * The caller is responsible for shaping each yielded value into a
+ * JSON-RPC frame. See the file header for why.
  */
 export function createSSEStream(
-  events: AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
+  events: AsyncGenerator<unknown>,
 ): ReadableStream {
   const encoder = new TextEncoder();
 
@@ -19,30 +33,21 @@ export function createSSEStream(
     async start(controller) {
       try {
         for await (const event of events) {
-          const eventType = isStatusEvent(event)
-            ? 'status_update'
-            : 'artifact_update';
-
           const data = JSON.stringify(event);
-          const sseMessage = `event: ${eventType}\ndata: ${data}\n\n`;
-
-          controller.enqueue(encoder.encode(sseMessage));
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
         }
-
-        // Send a final "done" event
-        controller.enqueue(
-          encoder.encode('event: done\ndata: {}\n\n'),
-        );
         controller.close();
       } catch (error) {
-        // Send error as SSE event before closing
+        // Mid-stream errors are spec-undefined for SSE A2A streaming.
+        // We emit a single transport-level error chunk (data-only, not
+        // a JSON-RPC envelope — we no longer hold the request id at
+        // this layer) and close. Handlers that want the spec-shaped
+        // {jsonrpc, id, error} body should yield it themselves before
+        // returning instead of throwing.
         const errorData = JSON.stringify({
-          error:
-            error instanceof Error ? error.message : 'Unknown error',
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
-        controller.enqueue(
-          encoder.encode(`event: error\ndata: ${errorData}\n\n`),
-        );
+        controller.enqueue(encoder.encode(`data: ${errorData}\n\n`));
         controller.close();
       }
     },
@@ -53,10 +58,4 @@ export function createSSEStream(
       void events.return(undefined).catch(() => {});
     },
   });
-}
-
-function isStatusEvent(
-  event: TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
-): event is TaskStatusUpdateEvent {
-  return 'status' in event;
 }


### PR DESCRIPTION
## Summary

- \`DefaultRequestHandler.handle()\` wraps every chunk yielded from the routed stream methods (and the auth-required stream synthesis) in a JSON-RPC success envelope keyed by the request id, per spec a2a-v0.3 §SendStreamingMessageSuccessResponse. Mid-stream errors are surfaced as a single trailing JSON-RPC error envelope instead of throwing.
- \`createSSEStream()\` is now a generic data-only encoder: it JSON-stringifies each yielded value as a \`data:\` chunk. The non-spec \`event:\` field and \`event: done\` terminator are gone. Stream end is signalled by connection close after the terminal status (\`final: true\` in v0.3).
- Client SSE parser keeps parsing the legacy \`event: status_update\` shape for one minor (upgrade compat), but logs a one-time deprecation warning so users notice they're on an old server.
- Tests and the streaming guides updated to the spec-shaped envelope.

Closes #118.

## Why

A spec-conformant A2A client wired to expect a JSON-RPC frame per chunk could not parse the SDK's stream — every chunk was a bare \`TaskStatusUpdateEvent\` / \`TaskArtifactUpdateEvent\` framed by a custom \`event:\` line, and the stream was terminated by a non-spec \`event: done\` chunk. The reverse direction worked only because the a2x client parser tolerated the SDK's private format. So the SDK was interop-broken with any non-a2x peer (Python ADK, official samples, third-party gateways) and silently locked into a private format with itself.

## Wire shape after this change

```
data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"kind\":\"status-update\",\"taskId\":\"…\",\"status\":{\"state\":\"working\"}}}

data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"kind\":\"artifact-update\",\"taskId\":\"…\",\"artifact\":{ … }}}
```

No \`event:\` field. No \`event: done\` terminator. Connection close after the terminal status ends the stream.

## Test plan

- [x] \`pnpm test\` (444 pass)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (no new warnings; 1 pre-existing CLI test warning unrelated)
- [x] \`pnpm -r build\`
- [x] Updated SSE fixtures: spec-shaped envelopes round-trip cleanly.
- [x] New legacy-format compatibility test: parser still handles \`event: status_update\` / \`event: done\` and emits a one-time \`console.warn\` deprecation message.
- [x] \`task-resubscribe\` and \`request-handler\` test suites updated to drill into \`envelope.result\` instead of bare events.

## Migration notes for users

- **Server**: nothing to do — \`createSSEStream()\` is internal plumbing called by \`DefaultRequestHandler\`. Code that yields events from \`message/stream\` continues to yield raw \`TaskStatusUpdateEvent\` / \`TaskArtifactUpdateEvent\` objects; the request handler does the envelope wrapping.
- **Client**: \`A2XClient\` is unaffected — the SSE parser handles the new shape transparently. Out-of-band SSE consumers (e.g. a custom resubscribe \`fetch\`) need to read \`data:\` lines and \`JSON.parse(chunk).result\` to get the underlying event.
- **Servers running on the old format** (a2x \< this version): the SDK client still parses them and emits a one-time deprecation warning. Plan to upgrade before the next minor — the legacy path is removed then.

## Changeset

No changeset per the tightened policy (#116) — bug fix; the maintainer batches into the next release. This is wire-format-changing, so the maintainer may want to add a \`minor\` changeset when consolidating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)