### PR TITLE
fix(sdk): align MessageSendConfiguration / TaskQueryParams with v0.3 spec

### DIFF
--- a/packages/a2x/docs/guides/client/basics.md
+++ b/packages/a2x/docs/guides/client/basics.md
@@ -43,6 +43,36 @@ const canceled = await client.cancelTask('task-abc123');
 
 `task-abc123` is the `id` from the task you previously submitted. This is how you poll long-running work or abort something the user changed their mind about.
 
+## Bounding history and registering a webhook in one call
+
+`SendMessageConfiguration` (the optional `configuration` field on `sendMessage()`) follows the v0.3 spec verbatim:
+
+```ts
+await client.sendMessage({
+  message: { role: 'user', parts: [{ text: 'Hello' }] },
+  configuration: {
+    // Wait for the task to reach a terminal state before resolving.
+    // false → return as soon as the agent picks the task up.
+    blocking: true,
+    // Cap the history slice the server returns on the response Task.
+    historyLength: 10,
+    // Register a webhook for this task in the same round-trip — no
+    // follow-up tasks/pushNotificationConfig/set call needed.
+    pushNotificationConfig: {
+      id: 'cfg-1',
+      url: 'https://my-app.example.com/a2a-webhook',
+      token: 'secret',
+    },
+  },
+});
+```
+
+`tasks/get` accepts the same `historyLength` (as a top-level param):
+
+```ts
+await client.getTask('task-abc123', { historyLength: 1 });
+```
+
 ## Message parts
 
 `parts` is an array — you can send text plus other modalities:

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -28,6 +28,13 @@ const mockProvider = new (class extends BaseLlmProvider {
 })();
 
 function createHandler(protocolVersion?: ProtocolVersion): DefaultRequestHandler {
+  return createHandlerWithStore(protocolVersion).handler;
+}
+
+function createHandlerWithStore(protocolVersion?: ProtocolVersion): {
+  handler: DefaultRequestHandler;
+  taskStore: InMemoryTaskStore;
+} {
   const agent = new LlmAgent({
     name: 'test-agent',
     provider: mockProvider,
@@ -44,7 +51,7 @@ function createHandler(protocolVersion?: ProtocolVersion): DefaultRequestHandler
   const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion });
   a2xAgent.setDefaultUrl('https://example.com/a2a');
 
-  return new DefaultRequestHandler(a2xAgent);
+  return { handler: new DefaultRequestHandler(a2xAgent), taskStore };
 }
 
 function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
@@ -394,6 +401,81 @@ describe('Layer 4: DefaultRequestHandler', () => {
       // v0.3: has kind, lowercase state
       expect(retrieved.kind).toBe('task');
       expect((retrieved.status as Record<string, unknown>).state).toBe('completed');
+    });
+
+    it('honors TaskQueryParams.historyLength on tasks/get', async () => {
+      // Spec a2a-v0.3 §TaskQueryParams: clients can bound how many history
+      // entries the server returns to avoid pulling the full transcript on
+      // every poll. See issue #120.
+      const { handler, taskStore } = createHandlerWithStore('0.3');
+
+      // Seed a task with a 3-entry history directly so we don't depend on
+      // the executor's accumulation behavior (which is out of scope here).
+      const seeded = await taskStore.createTask({});
+      await taskStore.updateTask(seeded.id, {
+        history: ['one', 'two', 'three'].map((t, i) => ({
+          messageId: `msg-${i}`,
+          role: 'user' as const,
+          parts: [{ text: t }],
+        })),
+      });
+
+      // Without historyLength: full history.
+      const fullResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tasks/get',
+        params: { id: seeded.id },
+      });
+      const fullTask = ((fullResponse as JSONRPCResponse) as {
+        result: { history: unknown[] };
+      }).result;
+      expect(fullTask.history).toHaveLength(3);
+
+      // historyLength=1: server slices to the most recent entry.
+      const slicedResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tasks/get',
+        params: { id: seeded.id, historyLength: 1 },
+      });
+      const slicedTask = ((slicedResponse as JSONRPCResponse) as {
+        result: { history: { parts: { text: string }[] }[] };
+      }).result;
+      expect(slicedTask.history).toHaveLength(1);
+      // The most recent entry survives.
+      expect(slicedTask.history[0].parts[0].text).toBe('three');
+
+      // historyLength=0: empty array, history field present.
+      const emptyResponse = await handler.handle({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tasks/get',
+        params: { id: seeded.id, historyLength: 0 },
+      });
+      const emptyTask = ((emptyResponse as JSONRPCResponse) as {
+        result: { history?: unknown[] };
+      }).result;
+      // Mapper omits empty history; either is acceptable so long as we
+      // didn't return more than 0 entries.
+      expect(emptyTask.history === undefined || emptyTask.history.length === 0).toBe(true);
+    });
+
+    it('rejects negative or non-integer historyLength on tasks/get', async () => {
+      const handler = createHandler();
+      for (const bad of [-1, 1.5, 'two']) {
+        const response = await handler.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/get',
+          params: { id: 'whatever', historyLength: bad },
+        });
+        const rpc = response as JSONRPCResponse;
+        expect('error' in rpc).toBe(true);
+        expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+          A2A_ERROR_CODES.INVALID_PARAMS,
+        );
+      }
     });
   });
 
@@ -1036,6 +1118,73 @@ describe('Layer 4: DefaultRequestHandler', () => {
           A2A_ERROR_CODES.INVALID_PARAMS,
         );
       });
+    });
+  });
+
+  describe('message/send — inline pushNotificationConfig (issue #120)', () => {
+    it('registers configuration.pushNotificationConfig in the store before execution', async () => {
+      // Spec a2a-v0.3 §MessageSendConfiguration: clients can register a
+      // webhook config in the same call that creates the task — no
+      // follow-up tasks/pushNotificationConfig/set round-trip needed.
+      const { handler, pushStore } = createHandlerWithPushNotification('1.0');
+
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+          configuration: {
+            pushNotificationConfig: {
+              id: 'inline-cfg-1',
+              url: 'https://example.com/webhook',
+              token: 't1',
+            },
+          },
+        },
+      });
+
+      const taskId = ((response as JSONRPCResponse) as { result: { id: string } }).result.id;
+      const stored = await pushStore.get(taskId, 'inline-cfg-1');
+      expect(stored).toEqual({
+        taskId,
+        pushNotificationConfig: {
+          id: 'inline-cfg-1',
+          url: 'https://example.com/webhook',
+          token: 't1',
+        },
+      });
+    });
+
+    it('errors PushNotificationNotSupported when configuration.pushNotificationConfig is sent to a no-store agent', async () => {
+      const handler = createHandler('1.0');
+      const response = await handler.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ text: 'Hello' }],
+          },
+          configuration: {
+            pushNotificationConfig: {
+              id: 'inline-cfg-1',
+              url: 'https://example.com/webhook',
+            },
+          },
+        },
+      });
+      const rpc = response as JSONRPCResponse;
+      expect('error' in rpc).toBe(true);
+      expect((rpc as JSONRPCErrorResponse).error.code).toBe(
+        A2A_ERROR_CODES.PUSH_NOTIFICATION_NOT_SUPPORTED,
+      );
     });
   });
 

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -469,13 +469,25 @@ export class A2XClient {
   /**
    * Retrieve the current state of a task.
    * Uses JSON-RPC method `tasks/get`.
+   *
+   * Spec a2a-v0.3 §TaskQueryParams: pass `historyLength` to bound the
+   * size of the `history` slice the server returns. Useful for polling
+   * long-running conversations without pulling the whole transcript.
    */
-  async getTask(taskId: string): Promise<Task> {
+  async getTask(
+    taskId: string,
+    options?: { historyLength?: number; metadata?: Record<string, unknown> },
+  ): Promise<Task> {
     await this._ensureResolved();
     await this._ensureAuthenticated();
-    const request = this._buildJsonRpcRequest(A2A_METHODS.GET_TASK, {
-      id: taskId,
-    });
+    const params: Record<string, unknown> = { id: taskId };
+    if (options?.historyLength !== undefined) {
+      params.historyLength = options.historyLength;
+    }
+    if (options?.metadata !== undefined) {
+      params.metadata = options.metadata;
+    }
+    const request = this._buildJsonRpcRequest(A2A_METHODS.GET_TASK, params);
     const result = await this._postJsonRpc(request);
     return this._parser!.parseTask(result);
   }
@@ -614,13 +626,8 @@ export class A2XClient {
       }
     }
 
-    // Format configuration: returnImmediately → blocking (inverted semantics)
-    const config = formatted.configuration as Record<string, unknown> | undefined;
-    if (config && 'returnImmediately' in config) {
-      config.blocking = !config.returnImmediately;
-      delete config.returnImmediately;
-    }
-
+    // configuration is now spec-shaped on the public API surface
+    // (`blocking`, `pushNotificationConfig`, …) — passthrough.
     return formatted;
   }
 

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -14,6 +14,7 @@ import type {
   JSONRPCResponse,
   SendMessageParams,
   TaskIdParams,
+  TaskQueryParams,
   DeletePushNotificationConfigParams,
   GetPushNotificationConfigParams,
   ListPushNotificationConfigsParams,
@@ -438,11 +439,12 @@ export class DefaultRequestHandler {
       },
     );
 
-    // tasks/get
+    // tasks/get — uses TaskQueryParams (id + optional historyLength) per
+    // spec a2a-v0.3 §GetTaskRequest, not the bare TaskIdParams.
     this.router.registerMethod(
       A2A_METHODS.GET_TASK,
       async (params) => {
-        const taskParams = this._validateTaskIdParams(params);
+        const taskParams = this._validateTaskQueryParams(params);
         return this._handleGetTask(taskParams);
       },
     );
@@ -524,12 +526,41 @@ export class DefaultRequestHandler {
   private async _handleSendMessage(params: SendMessageParams): Promise<unknown> {
     const task = await this._resolveTaskForMessage(params);
 
+    // Spec a2a-v0.3 §MessageSendConfiguration: clients can register a
+    // push notification config in the same call that creates the task.
+    // Honor it before kicking off execution so the agent's lifecycle
+    // events can find the config when delivery is wired.
+    await this._registerInlinePushConfig(task.id, params.configuration);
+
     const completedTask = await this.a2xAgent.agentExecutor.execute(
       task,
       params.message,
     );
 
-    return this.responseMapper.mapTask(completedTask, params.message);
+    const sliced = sliceHistory(
+      completedTask,
+      params.configuration?.historyLength,
+    );
+    return this.responseMapper.mapTask(sliced, params.message);
+  }
+
+  private async _registerInlinePushConfig(
+    taskId: string,
+    config: SendMessageParams['configuration'],
+  ): Promise<void> {
+    const pushConfig = config?.pushNotificationConfig;
+    if (!pushConfig) return;
+
+    const store = this.a2xAgent.pushNotificationConfigStore;
+    if (!store) {
+      throw new PushNotificationNotSupportedError();
+    }
+
+    const id = pushConfig.id ?? randomUUID();
+    await store.set({
+      taskId,
+      pushNotificationConfig: { ...pushConfig, id },
+    });
   }
 
   private async *_handleStreamMessage(
@@ -545,6 +576,11 @@ export class DefaultRequestHandler {
     }
 
     const task = await this._resolveTaskForMessage(params);
+
+    // Register the inline pushNotificationConfig (if any) before kicking
+    // off execution, mirroring `_handleSendMessage`. See spec a2a-v0.3
+    // §MessageSendConfiguration.
+    await this._registerInlinePushConfig(task.id, params.configuration);
 
     const eventStream = this.a2xAgent.agentExecutor.executeStream(
       task,
@@ -610,12 +646,13 @@ export class DefaultRequestHandler {
     }
   }
 
-  private async _handleGetTask(params: TaskIdParams): Promise<unknown> {
+  private async _handleGetTask(params: TaskQueryParams): Promise<unknown> {
     const task = await this.a2xAgent.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
     }
-    return this.responseMapper.mapTask(task);
+    const sliced = sliceHistory(task, params.historyLength);
+    return this.responseMapper.mapTask(sliced);
   }
 
   private async _handleCancelTask(params: TaskIdParams): Promise<unknown> {
@@ -769,6 +806,32 @@ export class DefaultRequestHandler {
     }
 
     return params as TaskIdParams;
+  }
+
+  /**
+   * Validate `tasks/get` params per spec a2a-v0.3 §TaskQueryParams.
+   * Same shape as `TaskIdParams` plus an optional non-negative integer
+   * `historyLength` and an optional `metadata` bag.
+   */
+  private _validateTaskQueryParams(params: unknown): TaskQueryParams {
+    const base = this._validateTaskIdParams(params);
+    const p = params as Record<string, unknown>;
+    if ('historyLength' in p && p.historyLength !== undefined) {
+      if (
+        typeof p.historyLength !== 'number' ||
+        !Number.isInteger(p.historyLength) ||
+        p.historyLength < 0
+      ) {
+        throw new InvalidParamsError(
+          'TaskQueryParams "historyLength" must be a non-negative integer',
+        );
+      }
+    }
+    return {
+      id: base.id,
+      historyLength: p.historyLength as number | undefined,
+      metadata: p.metadata as Record<string, unknown> | undefined,
+    };
   }
 
   /**
@@ -1072,6 +1135,23 @@ export class DefaultRequestHandler {
       metadata: p.metadata as Record<string, unknown> | undefined,
     };
   }
+}
+
+/**
+ * Trim a Task's `history` to the last `limit` entries without mutating
+ * the underlying store entry. Returns the same Task reference when no
+ * trimming is needed (limit is undefined or already short enough), so
+ * downstream mappers can rely on identity equality where they used to.
+ */
+function sliceHistory(task: Task, limit?: number): Task {
+  if (limit === undefined) return task;
+  const history = task.history;
+  if (!history) return task;
+  if (limit === 0) {
+    return { ...task, history: [] };
+  }
+  if (history.length <= limit) return task;
+  return { ...task, history: history.slice(-limit) };
 }
 
 /**

--- a/packages/a2x/src/types/jsonrpc.ts
+++ b/packages/a2x/src/types/jsonrpc.ts
@@ -56,16 +56,37 @@ export interface SendMessageParams {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Spec a2a-v0.3 §MessageSendConfiguration. Field names match the spec
+ * verbatim. `blocking` (true → wait for terminal state) replaces the
+ * old SDK-private `returnImmediately` (which was the inverse). The
+ * `pushNotificationConfig` field lets clients register a webhook in
+ * the same call that creates the task — no follow-up
+ * `tasks/pushNotificationConfig/set` round-trip needed.
+ */
 export interface SendMessageConfiguration {
   acceptedOutputModes?: string[];
   historyLength?: number;
-  returnImmediately?: boolean;
+  blocking?: boolean;
+  pushNotificationConfig?: PushNotificationConfig;
 }
 
 // ─── Task Query Parameters ───
 
 export interface TaskIdParams {
   id: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Spec a2a-v0.3 §TaskQueryParams — the params shape for `tasks/get`.
+ * Adds `historyLength` to bound how many history entries the server
+ * returns; clients use this to avoid pulling the full history on every
+ * poll of a long-running conversation.
+ */
+export interface TaskQueryParams {
+  id: string;
+  historyLength?: number;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

Aligns three drifted shapes with spec a2a-v0.3:

| Spec | Before | After |
|---|---|---|
| \`MessageSendConfiguration.blocking\` | \`returnImmediately\` (SDK-private, inverted) | \`blocking\` (spec name, spec semantics) |
| \`MessageSendConfiguration.pushNotificationConfig\` | missing | added — registered in the configured \`PushNotificationConfigStore\` before execution starts |
| \`tasks/get\` params | \`TaskIdParams\` (drops \`historyLength\`) | \`TaskQueryParams\` — \`historyLength\` honored, validator rejects negatives / non-integers |
| \`A2XClient.getTask()\` | \`(taskId)\` only | \`(taskId, { historyLength?, metadata? })\` |

\`A2XClient\` no longer has to translate \`returnImmediately → blocking\` on the wire — the rename collapses that to a passthrough.

\`message/send\` also slices \`task.history\` to \`configuration.historyLength\` on the response so the bound applies on the unary path too.

Closes #120.

## Why

- Users couldn't request a bounded history slice from \`tasks/get\` — long conversations forced the entire history on every poll.
- Users couldn't attach a webhook in the same call that creates the task; the spec's flow is "send + register webhook in one round-trip", but the SDK forced a follow-up \`tasks/pushNotificationConfig/set\`.
- \`returnImmediately\` was a friction point against every public A2A example, the JSON spec, and the v1.0 spec.

## Breaking change

\`SendMessageConfiguration.returnImmediately\` is removed in favor of \`blocking\`. Wire-level callers that previously used the SDK's \`returnImmediately\` field now write \`blocking: !returnImmediately\`. The semantics map directly:

| Old | New |
|---|---|
| \`returnImmediately: true\` (don't wait) | \`blocking: false\` |
| \`returnImmediately: false\` (wait) | \`blocking: true\` |

There were no callers relying on the old name inside the SDK (the only usage was the wire-translation step that this PR removes).

## Test plan

- [x] \`pnpm test\` (448 pass, 4 new)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm -r build\`
- [x] New: \`tasks/get\` honors \`historyLength\` (1, 0, default)
- [x] New: \`tasks/get\` rejects negative / non-integer / non-numeric \`historyLength\`
- [x] New: \`message/send\` registers \`configuration.pushNotificationConfig\` in the store
- [x] New: \`message/send\` returns \`PushNotificationNotSupported\` when no store is wired

## Docs

\`docs/guides/client/basics.md\` updated with the spec-shaped configuration block and the new \`getTask(id, { historyLength })\` signature.

## Changeset

No changeset per the tightened policy (#116) — bug fix; the maintainer batches into the next release. This is a breaking type rename, so the consolidated changeset should be at minimum \`minor\` (or \`major\` pre-1.0 depending on policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)