### PR TITLE
fix(sdk): map TaskState.UNKNOWN to v1.0 TASK_STATE_UNSPECIFIED

### DIFF
--- a/packages/a2x/src/__tests__/client.test.ts
+++ b/packages/a2x/src/__tests__/client.test.ts
@@ -325,6 +325,16 @@ describe('ResponseParser', () => {
       expect(task.status.state).toBe(TaskState.FAILED);
     });
 
+    it('should convert TASK_STATE_UNSPECIFIED to unknown', () => {
+      // v0.3 `unknown` ↔ v1.0 `TASK_STATE_UNSPECIFIED` (proto default,
+      // documented as "unknown or indeterminate state"). A v1.0 server
+      // emitting the default value must round-trip cleanly, not throw.
+      // See #121.
+      const raw = { id: 'task-1', status: { state: 'TASK_STATE_UNSPECIFIED' } };
+      const task = parser.parseTask(raw);
+      expect(task.status.state).toBe(TaskState.UNKNOWN);
+    });
+
     it('should pass through already lowercase states', () => {
       const raw = { id: 'task-1', status: { state: 'completed' } };
       const task = parser.parseTask(raw);

--- a/packages/a2x/src/__tests__/types.test.ts
+++ b/packages/a2x/src/__tests__/types.test.ts
@@ -19,11 +19,13 @@ describe('Layer 1: Types', () => {
       expect(TaskState.REJECTED).toBe('rejected');
       expect(TaskState.INPUT_REQUIRED).toBe('input-required');
       expect(TaskState.AUTH_REQUIRED).toBe('auth-required');
+      expect(TaskState.UNKNOWN).toBe('unknown');
     });
 
     it('should define v1.0 task state mappings', () => {
       expect(TaskStateV10.TASK_STATE_SUBMITTED).toBe('TASK_STATE_SUBMITTED');
       expect(TaskStateV10.TASK_STATE_WORKING).toBe('TASK_STATE_WORKING');
+      expect(TaskStateV10.TASK_STATE_UNSPECIFIED).toBe('TASK_STATE_UNSPECIFIED');
     });
 
     it('should define terminal states', () => {
@@ -33,6 +35,8 @@ describe('Layer 1: Types', () => {
       expect(TERMINAL_STATES.has(TaskState.REJECTED)).toBe(true);
       expect(TERMINAL_STATES.has(TaskState.WORKING)).toBe(false);
       expect(TERMINAL_STATES.has(TaskState.SUBMITTED)).toBe(false);
+      // `unknown` is non-terminal — peer may resync and transition out of it.
+      expect(TERMINAL_STATES.has(TaskState.UNKNOWN)).toBe(false);
     });
 
     it('should map internal states to v1.0 constants', () => {
@@ -41,6 +45,11 @@ describe('Layer 1: Types', () => {
       );
       expect(TASK_STATE_TO_V10.get(TaskState.WORKING)).toBe(
         TaskStateV10.TASK_STATE_WORKING,
+      );
+      // v0.3 `unknown` ↔ v1.0 `TASK_STATE_UNSPECIFIED` (proto default 0,
+      // documented in v1.0 as "unknown or indeterminate state").
+      expect(TASK_STATE_TO_V10.get(TaskState.UNKNOWN)).toBe(
+        TaskStateV10.TASK_STATE_UNSPECIFIED,
       );
     });
   });

--- a/packages/a2x/src/types/task.ts
+++ b/packages/a2x/src/types/task.ts
@@ -15,11 +15,21 @@ export enum TaskState {
   REJECTED = 'rejected',
   INPUT_REQUIRED = 'input-required',
   AUTH_REQUIRED = 'auth-required',
+  // Spec a2a-v0.3 §TaskState (specification/a2a-v0.3.0.json:2440-2453) lists
+  // `unknown` as a first-class state for peers that have lost track of a
+  // task's true state (resubscribe after a crash, gateway that missed a
+  // transition). Non-terminal — it signals "I don't know yet", not a
+  // finalized outcome. Round-trips with v1.0's TASK_STATE_UNSPECIFIED.
+  UNKNOWN = 'unknown',
 }
 
 // ─── v1.0 Protocol Constants (for output mapping) ───
 
 export enum TaskStateV10 {
+  // Proto default (value 0). v1.0 spec calls this "unknown or indeterminate
+  // state" (a2a-v1.0.0.proto:188-189, a2a-v1.0.0.json:1885-1898) — semantic
+  // match for v0.3's `unknown`, so the SDK rounds-trips them as a pair.
+  TASK_STATE_UNSPECIFIED = 'TASK_STATE_UNSPECIFIED',
   TASK_STATE_SUBMITTED = 'TASK_STATE_SUBMITTED',
   TASK_STATE_WORKING = 'TASK_STATE_WORKING',
   TASK_STATE_COMPLETED = 'TASK_STATE_COMPLETED',
@@ -50,6 +60,7 @@ export const TASK_STATE_TO_V10: ReadonlyMap<TaskState, TaskStateV10> = new Map([
   [TaskState.INPUT_REQUIRED, TaskStateV10.TASK_STATE_INPUT_REQUIRED],
   [TaskState.REJECTED, TaskStateV10.TASK_STATE_REJECTED],
   [TaskState.AUTH_REQUIRED, TaskStateV10.TASK_STATE_AUTH_REQUIRED],
+  [TaskState.UNKNOWN, TaskStateV10.TASK_STATE_UNSPECIFIED],
 ]);
 
 // ─── TaskStatus ───


### PR DESCRIPTION
## Summary

Replaces the closed #126 with a v1.0-spec-conformant mapping.

- Add `UNKNOWN = 'unknown'` to `TaskState` (matches v0.3 §TaskState).
- Add `TASK_STATE_UNSPECIFIED = 'TASK_STATE_UNSPECIFIED'` to `TaskStateV10` — this is the actual v1.0 enum member; there is no `TASK_STATE_UNKNOWN` in v1.0.
- Round-trip `TaskState.UNKNOWN ↔ TaskStateV10.TASK_STATE_UNSPECIFIED` in `TASK_STATE_TO_V10`. The reverse map (`V10_STATE_TO_INTERNAL` in `response-parser.ts:18-21`) picks this up automatically, so v1.0 inbound parsing now accepts `TASK_STATE_UNSPECIFIED` and produces `TaskState.UNKNOWN` instead of throwing.
- Treat `unknown` as **non-terminal** (deliberately omitted from `TERMINAL_STATES`): peer may resync and transition out of it.
- Cover the new value in `types.test.ts` and add a v1.0 → internal round-trip test in `client.test.ts` (`V10ResponseParser`).

Closes #121.

## Why this is the right v1.0 mapping (and #126 wasn't)

The closed #126 added `TASK_STATE_UNKNOWN` to `TaskStateV10` and mapped to it. But v1.0 does not define that enum member:

- `specification/a2a-v1.0.0.json:1885-1898` lists exactly: `TASK_STATE_UNSPECIFIED`, `TASK_STATE_SUBMITTED`, `TASK_STATE_WORKING`, `TASK_STATE_COMPLETED`, `TASK_STATE_FAILED`, `TASK_STATE_CANCELED`, `TASK_STATE_INPUT_REQUIRED`, `TASK_STATE_REJECTED`, `TASK_STATE_AUTH_REQUIRED`.
- `specification/a2a-v1.0.0.proto:186-208` confirms — `TASK_STATE_UNSPECIFIED = 0` is the proto default and is documented as "the task is in an unknown or indeterminate state".

`@a2x/sdk` supports both v0.3 and v1.0, dispatched per AgentCard interface, so emitting a non-spec value on the v1.0 wire would break interop with any spec-conformant v1.0 peer. `TASK_STATE_UNSPECIFIED` is both the actual enum member and the semantic match (proto comment matches v0.3's "lost track" description).

This follows the AGENTS.md spec-conformance rule: implement v0.3 faithfully, treat v1.0 divergences as the SDK's problem to bridge — bridge to the value v1.0 actually defines, not an invented one.

## Wire behavior

| Direction | Before (#126) | This PR |
|---|---|---|
| v0.3 inbound `unknown` | accepted | accepted |
| v1.0 inbound `TASK_STATE_UNSPECIFIED` | throws "Unknown task state" | parsed → `TaskState.UNKNOWN` |
| v1.0 inbound `TASK_STATE_UNKNOWN` | parsed (non-spec) | throws (correct — not a v1.0 value) |
| Internal `UNKNOWN` → v0.3 outbound | `'unknown'` | `'unknown'` |
| Internal `UNKNOWN` → v1.0 outbound | `'TASK_STATE_UNKNOWN'` (non-spec) | `'TASK_STATE_UNSPECIFIED'` |

## Test plan

- [x] `pnpm test` (445 pass, 1 new round-trip test in `V10ResponseParser`)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings; pre-existing `vi`-unused warning in CLI tests is unrelated)
- [x] `pnpm -r build`

## Docs

No doc update needed — `packages/a2x/docs/` does not enumerate `TaskState` values; the only references are to `auth-required` in authentication.md and a passing mention in extended-agent-card.md, neither of which lists the full enum. `TaskState.UNKNOWN` is a non-terminal state with no surface area beyond the type itself.

## Changeset

Skipped per the tightened changeset policy (#116) — bug fix; the maintainer batches into the next release. The v1.0 wire change is observable, so the consolidated changeset should be at minimum `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)