### PR TITLE
fix(sdk): always render AgentCard in the agent's configured protocolVersion

### DIFF
--- a/.changeset/fix-agent-card-version-mismatch.md
+++ b/.changeset/fix-agent-card-version-mismatch.md
@@ -1,0 +1,44 @@
+---
+'@a2x/sdk': minor
+---
+
+Remove the `version` parameter from `A2XAgent.getAgentCard()` and
+`DefaultRequestHandler.getAgentCard()`. The card is now always rendered in the
+agent's configured `protocolVersion` — the same wire format the server actually
+speaks.
+
+Closes [#133](https://github.com/planetarium/a2x/issues/133).
+
+**Why.** The server's wire format is fixed at construction time (the
+`protocolVersion` chosen on `new A2XAgent({...})` selects a single
+`responseMapper`). Letting `getAgentCard(version)` render a card in a different
+version published a contract the server could not honor: response shapes
+(`TASK_STATE_COMPLETED` vs `'completed'`), role/part encoding (`ROLE_USER` vs
+`'user'`, `kind` discriminator presence), and `pushNotificationConfig/{set,delete}`
+param shape are all bound to the configured version. A v1.0 agent serving a
+v0.3 card silently broke every call from a conforming v0.3 client, because
+`A2XClient.detectProtocolVersion()` honors the card's declared version
+absolutely.
+
+**Breaking — removals.**
+- `A2XAgent.getAgentCard(version?)` — the `version` parameter is removed.
+- `DefaultRequestHandler.getAgentCard(version?)` — the `version` parameter is
+  removed.
+- The `?version=` query string on `GET /.well-known/agent.json` (built-in
+  `to-a2x` HTTP server) is no longer honored.
+
+In-tree callers that already passed no argument (`samples/express`,
+`samples/nextjs`, `samples/nextjs-skill`, `samples/nextjs-x402`) are
+unaffected. Callers that previously did `getAgentCard('0.3')` against a v1.0
+agent (or vice versa) were creating the foot-gun this fix removes — the
+correct migration is to construct a separate `A2XAgent` with the desired
+`protocolVersion`:
+
+```ts
+// Before — silently broken: card said v0.3, wire still spoke v1.0
+const card03 = a2xAgent.getAgentCard('0.3');
+
+// After — one agent per wire format
+const a2xAgentV03 = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+const card03 = a2xAgentV03.getAgentCard();
+```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install @a2x/sdk
 ## Key Features
 
 - **Auto-extraction** — `A2XAgent` infers AgentCard fields (`name`, `description`, `capabilities.streaming`) from your runtime objects. No manual duplication.
-- **Multi-version AgentCard** — Generate v0.3 and v1.0 AgentCards from the same `A2XAgent` instance with `getAgentCard('0.3')` / `getAgentCard('1.0')`.
+- **Multi-version AgentCard** — Speak A2A v0.3 or v1.0 by constructing `new A2XAgent({ ..., protocolVersion: '0.3' | '1.0' })`. Card and wire stay consistent for the chosen version.
 - **Builder pattern** — Override any auto-extracted value with chainable methods (`setName()`, `addSkill()`, `addSecurityScheme()`, etc.).
 - **ADK-compatible patterns** — Familiar `LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, `FunctionTool`, `AgentTool`, `Runner`, and `Session` APIs.
 - **Client SDK** — `A2XClient` for interacting with any A2A-compliant agent, with built-in auth scheme support.
@@ -83,9 +83,9 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
 // 4. Wire up the request handler
 const handler = new DefaultRequestHandler(a2xAgent);
 
-// 5. Get AgentCards for any protocol version
-const cardV10 = a2xAgent.getAgentCard();        // v1.0 (default)
-const cardV03 = a2xAgent.getAgentCard('0.3');    // v0.3
+// 5. Render the AgentCard in the configured wire format
+const card = a2xAgent.getAgentCard();
+//   To serve v0.3 instead, construct with `protocolVersion: '0.3'`.
 ```
 
 ## How It Works
@@ -101,9 +101,8 @@ A2XAgent
     └── runConfig
         └── streamingMode    → capabilities.streaming (auto-extracted)
 
-getAgentCard(version?)
-├── "0.3" → v0.3 Mapper → AgentCard (v0.3 JSON)
-└── "1.0" → v1.0 Mapper → AgentCard (v1.0 JSON)
+getAgentCard()
+└── A2XAgent.protocolVersion → matching mapper → AgentCard JSON
 ```
 
 **Value resolution priority:**

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -350,11 +350,14 @@ Full guide: [docs/guides/advanced/x402-payments.md](./docs/guides/advanced/x402-
 
 ## AgentCard Versions
 
-a2x handles the structural differences between A2A protocol versions transparently:
+a2x handles the structural differences between A2A protocol versions transparently. Each agent is bound to one wire format at construction:
 
 ```typescript
-const cardV10 = a2xAgent.getAgentCard();       // v1.0 (default)
-const cardV03 = a2xAgent.getAgentCard('0.3');   // v0.3
+const a2xAgentV10 = new A2XAgent({ taskStore, executor });                          // v1.0 (default)
+const a2xAgentV03 = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });  // v0.3
+
+a2xAgentV10.getAgentCard(); // v1.0 card
+a2xAgentV03.getAgentCard(); // v0.3 card
 ```
 
 | Field | v0.3 | v1.0 |

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -1,8 +1,8 @@
 # AgentCard v0.3 vs v1.0
 
-A2A has two spec versions in active use. The **AgentCard** — the JSON your agent serves at `/.well-known/agent.json` — differs in shape between them. A2X hides most of the difference behind a single `A2XAgent` instance that can emit either version.
+A2A has two spec versions in active use. The **AgentCard** — the JSON your agent serves at `/.well-known/agent.json` — differs in shape between them. Each `A2XAgent` instance is bound to one wire format, chosen at construction time via `protocolVersion` (default `'1.0'`).
 
-You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` default to **v1.0**. If a client specifically asks for v0.3 (via `Accept` header or protocol negotiation), A2X transparently emits the v0.3 shape from the same underlying state.
+You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` render whatever `protocolVersion` was configured. The card shape, the JSON-RPC response shape, and the `pushNotificationConfig` param shape always match — so clients reading the card get a faithful contract for the wire underneath.
 
 ## The key differences
 
@@ -13,20 +13,25 @@ You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` def
 | Security declarations | `security` array + `securitySchemes` map | `securityRequirements` array + `securitySchemes` map |
 | Multiple transports on one agent | not supported | supported via multiple `supportedInterfaces` |
 
-A2X models everything internally in the v1.0 shape and down-converts to v0.3 on demand. This means:
+A2X models everything internally in a version-neutral shape and renders it through the configured wire format. This means:
 
 - Every declaration you make on `A2XAgent` (skills, security, default URL) works for both versions.
-- Consumers on either spec see a valid card.
+- The card and the wire are always consistent — the SDK never publishes a card whose `protocolVersion` disagrees with what the server actually emits.
 - You don't write version branches in your own code.
 
-## Emitting a specific version
+## Picking the wire format
+
+Pass `protocolVersion` to the constructor. The choice is fixed for the life of the agent:
 
 ```ts
-const v10 = a2xAgent.getAgentCard();          // v1.0 (default)
-const v03 = a2xAgent.getAgentCard('0.3');      // v0.3 explicit
+const a2xAgentV10 = new A2XAgent({ taskStore, executor }); // v1.0 (default)
+const a2xAgentV03 = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+
+a2xAgentV10.getAgentCard(); // → v1.0 card
+a2xAgentV03.getAgentCard(); // → v0.3 card
 ```
 
-Both paths are pre-wired when you use `toA2x()` or `DefaultRequestHandler` — callers negotiating over HTTP get the version they asked for.
+To serve both versions from one deployment, run two `A2XAgent` instances behind separate URLs and advertise each in the other's `additionalInterfaces`. One instance cannot lie about its wire format.
 
 ## When this matters to you
 
@@ -34,7 +39,7 @@ Three scenarios where you actually need to care:
 
 ### 1. Deploying alongside legacy v0.3 clients
 
-If you have CLI tools or third-party agents still pinned to v0.3, they read `url` and `preferredTransport` — not `supportedInterfaces`. A2X's v0.3 emission handles this automatically.
+If you have CLI tools or third-party agents still pinned to v0.3, they read `url` and `preferredTransport` — not `supportedInterfaces`. Construct the agent with `protocolVersion: '0.3'` and the SDK will speak v0.3 end-to-end (card + wire). For deployments that need to serve both at once, see [Multi-transport agents](#3-multi-transport-agents) below.
 
 ### 2. Emitting a non-standard scheme on v0.3
 
@@ -71,9 +76,9 @@ const client = new A2XClient(url, { preferredVersion: '1.0' });
 
 ## Recommendation
 
-- **Serve v1.0 as primary**, let A2X down-convert for v0.3 consumers. This is the default; you don't have to do anything.
+- **Serve v1.0 as primary** — the constructor default. New clients should target v1.0.
 - **Pin your own clients to v1.0** when calling agents that support both. Future-facing.
-- **Only override defaults** when you need cross-version compatibility for a specific deployment target.
+- **Spin up a dedicated v0.3 instance** only when a deployment target needs it. Configure it with `protocolVersion: '0.3'` rather than trying to coax a v1.0 agent into pretending.
 
 ## Beyond the AgentCard: push notification authentication
 

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -25,6 +25,7 @@ const mockProvider = new (class extends BaseLlmProvider {
 function createA2XAgent(
   agentOpts?: { name?: string; description?: string; instruction?: string },
   streamingMode: StreamingMode = StreamingMode.SSE,
+  protocolVersion?: '0.3' | '1.0',
 ) {
   const agent = new LlmAgent({
     name: agentOpts?.name ?? 'my-agent',
@@ -40,7 +41,7 @@ function createA2XAgent(
   });
   const taskStore = new InMemoryTaskStore();
 
-  return new A2XAgent({ taskStore, executor });
+  return new A2XAgent({ taskStore, executor, protocolVersion });
 }
 
 describe('Layer 3: A2XAgent', () => {
@@ -154,7 +155,7 @@ describe('Layer 3: A2XAgent', () => {
       const a2x = createA2XAgent({ name: 'auto-name' });
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.name).toBe('auto-name');
     });
 
@@ -162,7 +163,7 @@ describe('Layer 3: A2XAgent', () => {
       const a2x = createA2XAgent({ description: 'Auto description' });
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.description).toBe('Auto description');
     });
 
@@ -170,7 +171,7 @@ describe('Layer 3: A2XAgent', () => {
       const a2x = createA2XAgent(undefined, StreamingMode.SSE);
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.streaming).toBe(true);
     });
 
@@ -181,7 +182,7 @@ describe('Layer 3: A2XAgent', () => {
         .setDescription('Override desc')
         .setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.name).toBe('override');
       expect(card.description).toBe('Override desc');
     });
@@ -200,7 +201,7 @@ describe('Layer 3: A2XAgent', () => {
           tags: ['code'],
         });
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
 
       expect(card.name).toBe('my-agent');
       expect(card.description).toBe('A test agent');
@@ -225,7 +226,7 @@ describe('Layer 3: A2XAgent', () => {
           protocolVersion: '1.0',
         });
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.supportedInterfaces).toHaveLength(2);
       expect(card.supportedInterfaces[1].protocolBinding).toBe('GRPC');
     });
@@ -240,7 +241,7 @@ describe('Layer 3: A2XAgent', () => {
         )
         .addSecurityRequirement({ bearer: [] });
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.securitySchemes).toBeDefined();
       expect(card.securitySchemes!['bearer']).toEqual({
         httpAuthSecurityScheme: { scheme: 'bearer' },
@@ -253,7 +254,7 @@ describe('Layer 3: A2XAgent', () => {
 
   describe('getAgentCard - v0.3', () => {
     it('should generate v0.3 AgentCard', () => {
-      const a2x = createA2XAgent();
+      const a2x = createA2XAgent(undefined, undefined, '0.3');
       a2x
         .setDefaultUrl('https://example.com/a2a')
         .addSkill({
@@ -268,7 +269,7 @@ describe('Layer 3: A2XAgent', () => {
           new ApiKeyAuthorization({ in: 'header', name: 'X-API-Key' }),
         );
 
-      const card = a2x.getAgentCard('0.3') as AgentCardV03;
+      const card = a2x.getAgentCard() as AgentCardV03;
 
       expect(card.name).toBe('my-agent');
       expect(card.url).toBe('https://example.com/a2a');
@@ -279,7 +280,7 @@ describe('Layer 3: A2XAgent', () => {
     });
 
     it('should emit DeviceCode as non-standard v0.3 extension', () => {
-      const a2x = createA2XAgent();
+      const a2x = createA2XAgent(undefined, undefined, '0.3');
       a2x
         .setDefaultUrl('https://example.com/a2a')
         .addSecurityScheme(
@@ -291,7 +292,7 @@ describe('Layer 3: A2XAgent', () => {
           }),
         );
 
-      const card = a2x.getAgentCard('0.3') as AgentCardV03;
+      const card = a2x.getAgentCard() as AgentCardV03;
       expect(card.securitySchemes).toBeDefined();
       expect(card.securitySchemes!['device']).toEqual({
         type: 'oauth2',
@@ -306,8 +307,8 @@ describe('Layer 3: A2XAgent', () => {
     });
   });
 
-  describe('getAgentCard - default version from config', () => {
-    it('should use configured protocolVersion when no argument is given', () => {
+  describe('getAgentCard - version is fixed at construction', () => {
+    it('renders the configured v0.3 wire format', () => {
       const agent = new LlmAgent({
         name: 'test',
         provider: mockProvider,
@@ -328,7 +329,7 @@ describe('Layer 3: A2XAgent', () => {
       expect(card.protocolVersion).toBe('0.3.0');
     });
 
-    it('should allow explicit version to override configured protocolVersion', () => {
+    it('renders the configured v1.0 wire format', () => {
       const agent = new LlmAgent({
         name: 'test',
         provider: mockProvider,
@@ -342,10 +343,10 @@ describe('Layer 3: A2XAgent', () => {
       });
       const taskStore = new InMemoryTaskStore();
 
-      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' });
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.supportedInterfaces).toBeDefined();
     });
   });
@@ -405,7 +406,7 @@ describe('Layer 3: A2XAgent', () => {
         .addExtension({ uri: 'https://example.com/ext/a', required: true })
         .addExtension('https://example.com/ext/b', { description: 'B' });
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.extensions).toEqual([
         { uri: 'https://example.com/ext/a', required: true },
         { uri: 'https://example.com/ext/b', description: 'B' },
@@ -419,7 +420,7 @@ describe('Layer 3: A2XAgent', () => {
         .setCapabilities({ extensions: [{ uri: 'ext-a' }] })
         .setCapabilities({ extensions: [{ uri: 'ext-b' }] });
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.extensions).toEqual([
         { uri: 'ext-a' },
         { uri: 'ext-b' },
@@ -434,7 +435,7 @@ describe('Layer 3: A2XAgent', () => {
         .setCapabilities({ extensions: [{ uri: 'ext-b' }] })
         .addExtension('ext-c');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.extensions).toEqual([
         { uri: 'ext-a' },
         { uri: 'ext-b' },
@@ -460,7 +461,7 @@ describe('Layer 3: A2XAgent', () => {
         pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
       }).setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.pushNotifications).toBe(true);
     });
 
@@ -468,7 +469,7 @@ describe('Layer 3: A2XAgent', () => {
       const a2x = createA2XAgent();
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.pushNotifications).toBe(false);
     });
 
@@ -492,7 +493,7 @@ describe('Layer 3: A2XAgent', () => {
         .setDefaultUrl('https://example.com/a2a')
         .setPushNotifications(false);
 
-      const card = a2x.getAgentCard('1.0') as AgentCardV10;
+      const card = a2x.getAgentCard() as AgentCardV10;
       expect(card.capabilities.pushNotifications).toBe(false);
     });
 
@@ -516,7 +517,7 @@ describe('Layer 3: A2XAgent', () => {
         .setDefaultUrl('https://example.com/a2a')
         .setStateTransitionHistory(true);
 
-      const card = a2x.getAgentCard('0.3') as AgentCardV03;
+      const card = a2x.getAgentCard() as AgentCardV03;
       expect(card.capabilities.stateTransitionHistory).toBe(true);
     });
   });
@@ -526,12 +527,12 @@ describe('Layer 3: A2XAgent', () => {
       const a2x = createA2XAgent();
       a2x.setDefaultUrl('https://example.com/a2a');
 
-      const card1 = a2x.getAgentCard('1.0');
-      const card2 = a2x.getAgentCard('1.0');
+      const card1 = a2x.getAgentCard();
+      const card2 = a2x.getAgentCard();
       expect(card1).toBe(card2); // Same reference (cached)
 
       a2x.setVersion('2.0.0');
-      const card3 = a2x.getAgentCard('1.0');
+      const card3 = a2x.getAgentCard();
       expect(card3).not.toBe(card1); // New object (cache invalidated)
       expect((card3 as AgentCardV10).version).toBe('2.0.0');
     });

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -579,7 +579,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
   describe('getAgentCard', () => {
     it('should return agent card', () => {
       const handler = createHandler();
-      const card = handler.getAgentCard('1.0');
+      const card = handler.getAgentCard();
       expect(card).toBeDefined();
       expect((card as { name: string }).name).toBe('test-agent');
     });

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -68,7 +68,11 @@ export class A2XAgent {
   ) => Partial<A2XAgentState> | Promise<Partial<A2XAgentState>>;
 
   // ─── AgentCard cache ───
-  private _cardCache = new Map<string, AgentCardV03 | AgentCardV10>();
+  // Single slot: the agent's wire format is fixed at construction time, so
+  // there is only ever one card to render. Rendering any other version
+  // would publish a card that lies about what the server actually speaks
+  // (see issue #133).
+  private _cachedCard?: AgentCardV03 | AgentCardV10;
 
   constructor(options: A2XAgentOptions) {
     if (!options.taskStore) {
@@ -303,13 +307,19 @@ export class A2XAgent {
 
   // ─── Core Method ───
 
-  getAgentCard(version?: string): AgentCardV03 | AgentCardV10 {
-    const resolvedVersion = version ?? this._protocolVersion;
-
-    // Check cache
-    const cached = this._cardCache.get(resolvedVersion);
-    if (cached) {
-      return cached;
+  /**
+   * Render the AgentCard for this agent.
+   *
+   * The card is always rendered in `this._protocolVersion` — the same wire
+   * format the server speaks. Publishing a card in any other version would
+   * give clients a false contract: the response shapes, role/part encoding,
+   * and `pushNotificationConfig` param shape are all bound to the
+   * configured protocol version. To serve a different version, construct a
+   * separate `A2XAgent` with that `protocolVersion`.
+   */
+  getAgentCard(): AgentCardV03 | AgentCardV10 {
+    if (this._cachedCard) {
+      return this._cachedCard;
     }
 
     // Build the internal normalized state
@@ -353,14 +363,12 @@ export class A2XAgent {
       }
     }
 
-    // Map to the requested version
-    const mapper = AgentCardMapperFactory.getMapper(resolvedVersion);
-    const card = mapper.map(state);
+    const mapper = AgentCardMapperFactory.getMapper(this._protocolVersion);
+    const card = mapper.map(state) as AgentCardV03 | AgentCardV10;
 
-    // Cache the result
-    this._cardCache.set(resolvedVersion, card as AgentCardV03 | AgentCardV10);
+    this._cachedCard = card;
 
-    return card as AgentCardV03 | AgentCardV10;
+    return card;
   }
 
   // ─── Accessors ───
@@ -460,7 +468,7 @@ export class A2XAgent {
   // ─── Private Methods ───
 
   private _invalidateCache(): void {
-    this._cardCache.clear();
+    this._cachedCard = undefined;
   }
 
   /**

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -209,10 +209,11 @@ export class DefaultRequestHandler {
   }
 
   /**
-   * Get the AgentCard for a specific protocol version.
+   * Get the AgentCard. Always rendered in the agent's configured
+   * `protocolVersion` to match the wire format the server actually speaks.
    */
-  getAgentCard(version?: string): AgentCardV03 | AgentCardV10 {
-    return this.a2xAgent.getAgentCard(version);
+  getAgentCard(): AgentCardV03 | AgentCardV10 {
+    return this.a2xAgent.getAgentCard();
   }
 
   // ─── Private: auth-required Task synthesis ───

--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -109,11 +109,8 @@ export function toA2x(
           req.method === 'GET' &&
           parsedUrl.pathname === '/.well-known/agent.json'
         ) {
-          const version =
-            parsedUrl.searchParams.get('version') ?? undefined;
-
           try {
-            const card = handler.getAgentCard(version);
+            const card = handler.getAgentCard();
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify(card));
           } catch (error) {


### PR DESCRIPTION
## Summary

- Remove the `version` parameter from `A2XAgent.getAgentCard()` and `DefaultRequestHandler.getAgentCard()` so the card always matches the agent's configured `protocolVersion` — the same wire format the server actually speaks.
- Drop the `?version=` query handling on `GET /.well-known/agent.json` in the built-in `to-a2x` HTTP server.
- Simplify the per-version `_cardCache` `Map` to a single `_cachedCard` slot since there is only ever one card to render.

Closes #133.

## Why

The server's wire format is fixed at construction (`this._protocolVersion` selects a single `responseMapper` in `DefaultRequestHandler`). Letting the public `getAgentCard(version)` API render a card in a different version published a contract the server could not honor:

- Response shapes (`TASK_STATE_COMPLETED` vs `'completed'`),
- Role/part encoding (`ROLE_USER` vs `'user'`, `kind` discriminator presence),
- `pushNotificationConfig/{set,delete}` param shape — all bound to the configured version.

`A2XClient.detectProtocolVersion()` honors the card's declared version absolutely, so a v1.0 agent serving a v0.3 card silently broke every call from a conforming v0.3 client.

External callers that previously did `getAgentCard('0.3')` against a v1.0 agent (or vice versa) were creating exactly this foot-gun. The correct migration is to construct a separate `A2XAgent` with the desired `protocolVersion` — documented in the updated guide.

## Test plan

- [x] `pnpm typecheck` clean across the workspace
- [x] `pnpm test` — all 444 tests pass (28 files)
- [x] `pnpm lint` — no new errors (only pre-existing `vi unused` warning in CLI test)
- [x] `pnpm -r build` — packages and samples build green
- [x] In-tree callers (`samples/express`, `samples/nextjs`, `samples/nextjs-skill`, `samples/nextjs-x402`) already passed no argument to `getAgentCard()`, so they're unaffected
- [x] Updated `agent-card-versioning.md`, root `README.md`, and `packages/a2x/README.md` to document the constructor-only path
- [x] Added `minor` changeset (per project convention for breaking changes pre-1.0)

## Notes for reviewers

- The optional follow-up flagged in the issue (`addInterface()` advertising mismatched `protocolVersion` on `additionalInterfaces`) is **not** addressed here — it's a separate surface and belongs in its own PR.
- `A2XAgent.getAuthenticatedExtendedCard(authResult, version?)` carries the same shape of argument; I left it alone in this PR because the issue did not call it out and the only in-tree caller (`request-handler.ts:183`) already passes no version. Happy to fold a fix in as a separate commit if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)