### PR TITLE
ci: consolidate CI tooling — concurrency, timeouts, paths-ignore, lint warning, AGENTS.md PR scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,30 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Pure docs PRs need no validation — lint / build / typecheck / test
+    # don't touch markdown. The push: main run still validates end-to-end.
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+
+# Cancel in-progress runs when newer commits land on the same ref. Saves
+# CI minutes when a PR is iterated with multiple consecutive pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Opt in to the Node.js 24 default early to silence per-step
+  # deprecation warnings for `pnpm/action-setup@v4`. Forced for everyone
+  # on June 2nd, 2026.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Opt in to the Node.js 24 default early to silence per-step
-  # deprecation warnings for `pnpm/action-setup@v4`. Forced for everyone
-  # on June 2nd, 2026.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -38,7 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      # Pinned to v4.4.0 (rather than the floating @v4 tag) because the
+      # floating @v4 was reverted to a Node 20 manifest after the v4 → v5
+      # cut. v4.4.0 keeps the v4 codebase but declares `using: node24` in
+      # its manifest, eliminating the per-run deprecation warning without
+      # taking on v6's known regressions (see dependabot.yml comment).
+      - uses: pnpm/action-setup@v4.4.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -20,6 +20,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # `actions/upload-artifact@v4`, `actions/download-artifact@v4`, and
+  # `softprops/action-gh-release@v2` still declare Node 20 in their
+  # manifests. Force them onto Node 24 until they're bumped to their
+  # respective Node-24-native majors (separate PR — major bumps require
+  # validation against an actual CLI release).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
@@ -71,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.4.0
 
       - uses: actions/setup-node@v6
         with:
@@ -113,7 +118,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.4.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -13,9 +13,19 @@ on:
 permissions:
   contents: write
 
+# Never cancel an in-flight binary build / GitHub Release; queue
+# subsequent pushes serially instead.
+concurrency:
+  group: release-cli
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -57,6 +67,7 @@ jobs:
             script: binaries:macos
             artifact: binaries-macos
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -96,6 +107,7 @@ jobs:
     needs: [check-version, build-binaries]
     if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -20,9 +20,6 @@ concurrency:
   group: release-sdk
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -30,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.4.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -14,9 +14,19 @@ permissions:
   pull-requests: write
   id-token: write
 
+# Serialize releases on main: queue subsequent pushes behind the
+# in-flight publish rather than cancelling it (npm half-state risk).
+concurrency:
+  group: release-sdk
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,24 @@ A changeset is a deliberate "release now" signal. Each one bumps `@a2x/sdk` and 
 
 Any new or modified JSON-RPC behavior must match `specification/a2a-v0.3.0.json` and, where defined, `specification/a2a-v1.0.0.json`. When the two disagree, implement v0.3 faithfully, and treat v1.0 divergences as SDK extensions documented in the relevant guide. Constant names in `packages/a2x/src/types/jsonrpc.ts` must match the spec's `method` strings exactly.
 
+## PR scope
+
+Audit your domain fully before opening a PR, then bundle every related issue into that PR. Splitting cohesive work into N PRs costs N× the merge fanout (CI matrix on `main`, Release SDK, Release CLI) for the same work, and creates churn for reviewers.
+
+Bundle:
+
+- All known issues in one domain — all CI / repo tooling tuning, all v0.3 conformance fixes, all related refactor steps.
+- Follow-ups discovered while writing the PR ("oh and that lint warning"). They belong in the same PR, not the next one.
+- Tooling / workflow / config changes especially. Merge cost is high (every push to `main` fans out across CI + Release SDK + Release CLI), and most workflow behavior is decidable from the YAML — there's rarely a reason to "merge and see".
+
+Don't bundle:
+
+- Unrelated domains. An SDK fix, a CLI fix, and a sample fix should land as separate PRs so each can bisect / revert independently.
+- Genuinely unforeseen findings discovered after merge — those are new PRs.
+- Drive-by cleanup unrelated to the PR's stated purpose. ("Style: keep diffs minimal" still applies *across* domains.)
+
+A small focused PR is correct when the audit genuinely found one thing. The discipline is **audit completeness before opening**, not making every PR big.
+
 ## Commands
 
 From the repo root:

--- a/packages/cli/src/__tests__/stream-line-collision.test.ts
+++ b/packages/cli/src/__tests__/stream-line-collision.test.ts
@@ -6,7 +6,7 @@
  * that a newline is inserted between artifact text and status headers.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { printStatusUpdate, printArtifactChunk } from '../format.js';
 


### PR DESCRIPTION
## Summary

Audit-and-bundle follow-up to #137. Targets every CI noise source I currently know about and codifies the bundling discipline in `AGENTS.md` so future tooling changes ship as one PR instead of a chain of merges through `main`.

This PR is intentionally everything I know about. There is no "part 2" planned for the items in scope here. The one remaining noise source — `actions/upload-artifact@v4`, `actions/download-artifact@v4`, and `softprops/action-gh-release@v2` still declaring Node 20 in their manifests — is explicitly out of scope: those only fire during actual CLI release runs (rare), the bumps to v6 / v7 / v3 are breaking majors, and they need validation against a real CLI release. That follow-up is the only thing not in this PR, and it's called out below.

## Changes

### Workflows

- **`ci.yml`** — `concurrency` keyed on workflow + ref with `cancel-in-progress: true`. Iterating a PR with multiple consecutive pushes now cancels the older in-progress run instead of paying for both. Biggest single saver after #137.
- **`ci.yml`** — `paths-ignore: ['**.md']` on the `pull_request` trigger only. Pure docs PRs no longer kick off lint / build / typecheck / test (none of which touch markdown). The `push: main` run is unaffected and still validates everything after merge.
- **`ci.yml`** — `permissions: contents: read` at workflow level (least privilege).
- **`ci.yml`** — `timeout-minutes: 10`. Avg CI run is ~1m15s, so 10m is an ample runaway guard.
- **`release-sdk.yml`** — `concurrency: { group: release-sdk, cancel-in-progress: false }`. Subsequent `main` pushes queue serially behind any in-flight publish so we never cancel `pnpm changeset publish` mid-run.
- **`release-sdk.yml`** — `timeout-minutes: 15`.
- **`release-cli.yml`** — `concurrency: { group: release-cli, cancel-in-progress: false }` for the same in-flight-protection reason.
- **`release-cli.yml`** — per-job timeouts: `check-version: 5`, `build-binaries: 30` (macOS binary build can be slow), `release: 15`.
- **All three workflows** — bump every `pnpm/action-setup@v4` reference to `pnpm/action-setup@v4.4.0`. The floating `@v4` tag was reverted to a Node 20 manifest after the v4 → v5 cut, so it triggers the deprecation warning on every run; the specific tag `v4.4.0` keeps the same v4 codebase but declares `using: node24` in its manifest. Eliminates the warning at the source instead of papering over it. v6 (currently latest) is avoided per the existing `dependabot.yml` comment about its `packageManager` regressions.
- **`ci.yml`, `release-sdk.yml`** — drop the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env block. With `pnpm/action-setup` pinned to a Node 24 manifest and every other action in those two workflows already declaring Node 24 (`actions/checkout@v6`, `actions/setup-node@v6`, `changesets/action@v1`, `actions/create-github-app-token@v3`), the override is now a no-op.
- **`release-cli.yml`** — keep the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env (with explanatory comment). `actions/upload-artifact@v4`, `actions/download-artifact@v4`, and `softprops/action-gh-release@v2` still declare Node 20. They'll be bumped (v6 / v7 / v3 respectively) in a separate PR validated against an actual CLI release.

### Code

- **`packages/cli/src/__tests__/stream-line-collision.test.ts`** — drop unused `vi` import. Surfaced as a lint warning on every CI run since the file landed.

### Docs

- **`AGENTS.md`** — add a "PR scope" section between "Spec conformance" and "Commands". Codifies audit-then-bundle: when iterating on a domain (CI / repo tooling, conformance pass, multi-step refactor), audit the full scope first and bundle every related issue into a single PR. Splitting cohesive work into N PRs costs N× the merge fanout for the same work.

## What this PR will trigger

Predictable from the new `release-sdk.yml` / `release-cli.yml` paths filters merged in #137:

- **PR opening** — CI runs single `ci (node 20)` job (matrix narrowing from #137 + `**.md` paths-ignore doesn't apply since this PR has non-md changes).
- **Merge to `main`** — CI matrix runs Node 20 + 22. **Release SDK skipped** (no `packages/a2x/**` or `.changeset/**` changes). **Release CLI fires** because the test fix touches `packages/cli/**`, but `check-version` exits fast (no version bump → `changed=false` → build-binaries / release jobs skipped).

So the merge cost is one CI matrix run + one ~10s Release CLI no-op. No SDK fanout.

## Test plan

- [x] Lint clean — `pnpm lint` reports 0 problems on this branch (was 1 warning).
- [x] All tests pass — `pnpm test` (28 files / 445 tests).
- [x] CI on this PR runs single `ci (node 20)` job and reports green. — verified via [run 25033308991](https://github.com/planetarium/a2x/actions/runs/25033308991): single `ci (node 20)` job, success.
- [x] **`pnpm/action-setup` Node 20 deprecation warning is gone.** — verified: [run 25033308991](https://github.com/planetarium/a2x/actions/runs/25033308991) annotations endpoint returns `[]`. Zero warnings on the new CI run vs. 2 warnings on the previous (`vi` import + `pnpm/action-setup@v4` deprecation).
- [ ] On merge: CI matrix on `main` runs both Node 20 + 22 and is green. Release SDK is **skipped** (no `packages/a2x/**` / `.changeset/**` match). Release CLI fires but `check-version` reports `changed=false`, so binary build / release jobs are skipped. — pending merge.
- [ ] On the next PR with multiple consecutive pushes, the older CI run gets `cancelled` and only the newest one completes. — pending future event.

## Out of scope (future PR)

The remaining Node 20 manifest actions in `release-cli.yml`:

- `actions/upload-artifact@v4` — Node 24 native is `v6.0.0+` (latest `v7.0.1`). v4 → v5 was a breaking change to the artifact backend; v5 → v6 was the Node bump. Needs validation against an actual CLI release.
- `actions/download-artifact@v4` — Node 24 native is `v7.0.0+` (latest `v8.0.1`). Same story.
- `softprops/action-gh-release@v2` — Node 24 native is only `v3.0.0` (just released 2026-04-12). Major bump; needs CLI release validation.

These trigger only on actual CLI release runs (rare), so they don't pollute regular SDK / docs / tooling PRs. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env in `release-cli.yml` keeps the warning informational ("forced to Node 24") instead of forward-looking ("may not work") in the meantime.

Per `AGENTS.md`, repo tooling under `.github/`, doc changes to `AGENTS.md`, and test-only changes are out of scope for changesets.