### PR TITLE
ci(release-cli): bump artifact / gh-release actions to Node 24 majors and drop FORCE_JAVASCRIPT env

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -19,14 +19,6 @@ concurrency:
   group: release-cli
   cancel-in-progress: false
 
-env:
-  # `actions/upload-artifact@v4`, `actions/download-artifact@v4`, and
-  # `softprops/action-gh-release@v2` still declare Node 20 in their
-  # manifests. Force them onto Node 24 until they're bumped to their
-  # respective Node-24-native majors (separate PR — major bumps require
-  # validation against an actual CLI release).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -101,7 +93,7 @@ jobs:
             fi
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: packages/cli/binaries/a2x-*
@@ -132,15 +124,18 @@ jobs:
       - name: Pack CLI tarball
         run: pnpm --filter @a2x/cli pack --pack-destination packages/cli
 
+      # Pinned to v7 (not v8) — v8 changes `digest-mismatch` default to
+      # `error` (was warn-only). v7 is Node 24 native with no behavior
+      # break for our `path` / `pattern` / `merge-multiple` usage.
       - name: Download binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: packages/cli/binaries
           pattern: binaries-*
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-version.outputs.tag }}
           name: CLI ${{ needs.check-version.outputs.version }}


### PR DESCRIPTION
## Summary

Closes the residual of #139's audit that I incorrectly framed as "out of scope (future PR)". With this PR, every action across every workflow file is Node 24 native and no `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` override remains anywhere in the repo.

The previous "future PR" framing was rationalization, not a real scope reason — bundling these bumps with the rest of the audit was the right call. Splitting cohesive tooling work into N PRs costs N× the merge fanout for the same work (codified in the `AGENTS.md` "PR scope" section added in #139). This PR completes that audit so the rule isn't immediately violated by my own work.

## Changes

`.github/workflows/release-cli.yml` only:

- **`actions/upload-artifact@v4` → `@v7`** — v5 (lib bump), v6 (Node 24 runtime), v7 (opt-in `archive: false`, ESM) are all backwards compatible with our `name` / `path` / `if-no-files-found` / `retention-days` inputs.
- **`actions/download-artifact@v4` → `@v7` (NOT `@v8`)** — v8 flips `digest-mismatch` default from warn to error, which would surface transient storage hash flakes as CLI release failures. v7 is Node 24 native with zero behavior change for our `path` / `pattern` / `merge-multiple` usage. Inline comment in the YAML documents why we don't take v8.
- **`softprops/action-gh-release@v2` → `@v3`** — pure runtime bump per upstream release notes. `tag_name`, `name`, `generate_release_notes`, `files`, `GITHUB_TOKEN` all unchanged.
- **Remove `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` block** — with all three actions above on Node 24 manifests (and `pnpm/action-setup@v4.4.0`, `actions/checkout@v6`, `actions/setup-node@v6` already Node 24 from #139), the override is a no-op.

## What this PR will trigger

- **PR opening** — CI runs single `ci (node 20)` job. Lint / build / typecheck / test all pass locally.
- **Merge to `main`** — CI matrix on `main` runs Node 20 + 22. Release SDK skipped (no `packages/a2x/**` / `.changeset/**` match). Release CLI fires (`packages/cli/**` matches), but `check-version` exits fast (no version bump) — `build-binaries` and `release` jobs are skipped, so the bumped actions don't execute.
- **Next actual CLI release** — the bumped actions execute end-to-end for the first time. Risk is bounded: download-artifact pinned to v7 (no behavior change), upload-artifact and gh-release majors are runtime-only bumps.

## Test plan

- [x] `pnpm lint` clean — verified locally (0 problems).
- [x] `pnpm typecheck` clean — verified locally (all packages pass).
- [x] `pnpm test` clean — verified locally (30 files / 458 tests pass).
- [x] CI on this PR runs single `ci (node 20)` job and reports green. — verified via [run 25035996665](https://github.com/planetarium/a2x/actions/runs/25035996665): single `ci (node 20)` job, success, 0 annotations.
- [ ] On merge: CI matrix on `main` runs both Node 20 + 22 and is green. Release SDK is **skipped**. Release CLI fires but `check-version` reports `changed=false`, so binary build / release jobs are skipped — the bumped actions don't execute on this merge.
- [ ] On the next actual CLI release (next `chore/cli-release-X.Y.Z` PR merge): `actions/upload-artifact@v7` uploads binaries successfully on both ubuntu-latest and macos-14 runners. `actions/download-artifact@v7` retrieves them without `digest-mismatch` errors. `softprops/action-gh-release@v3` creates the GitHub Release with the tarball and binaries attached.
- [ ] After this PR merges, no workflow file in the repo contains `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` and no Node 20 deprecation warning appears in any subsequent CI / Release SDK / Release CLI run annotation set.

Per `AGENTS.md`, repo tooling under `.github/` is out of scope for changesets.