### PR TITLE
fix(sdk): bundle-safe x402 imports + a2a-x402 v0.2 client conformance (#134, #143)

### DIFF
--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -10,7 +10,7 @@ The flow: the merchant agent responds to an unpaid request with `input-required`
 pnpm add @a2x/sdk x402 viem
 ```
 
-`x402` and `viem` are **optional peer dependencies** — only install them if you actually enable x402 on your agent or client.
+`x402` and `viem` are **optional peer dependencies** — only install them if you actually enable x402 on your agent or client. The SDK lazy-loads the `x402` runtime helpers on the first call to `signX402Payment` (or the first time `A2XClient.sendMessage` enters the dance), so non-x402 consumers can omit the dep without breaking bundlers.
 
 ## Server
 
@@ -108,10 +108,17 @@ On a successful payment, the completed task's status message carries:
 {
   "x402.payment.status": "payment-completed",
   "x402.payment.receipts": [
-    { "success": true, "transaction": "0x…", "network": "base-sepolia" }
+    {
+      "success": true,
+      "transaction": "0x…",
+      "network": "base-sepolia",
+      "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+    }
   ]
 }
 ```
+
+Every receipt — success or failure — carries a `payer` field per x402-v1 §5.3.2. Multi-wallet auditing and post-settlement bookkeeping branch on this; the SDK propagates the address the facilitator returned, falling back to the EVM authorization's `from` for shape-failure receipts where verify never ran.
 
 Failures surface under `x402.payment.error` with one of the codes below. The seven names listed first come straight from spec §9.1; the remaining three are SDK-specific codes covering failure modes the SDK detects outside the facilitator's purview.
 
@@ -124,6 +131,7 @@ Failures surface under `x402.payment.error` with one of the codes below. The sev
 | `NETWORK_MISMATCH` | spec §9.1 | Payload's network doesn't match any advertised `accepts`. |
 | `INVALID_AMOUNT` | spec §9.1 | Authorization value doesn't match the required amount. |
 | `SETTLEMENT_FAILED` | spec §9.1 | On-chain settle call failed. |
+| `invalid_x402_version` | x402-v1 §6 / §9 | Merchant published a non-1 `x402Version`; the SDK only speaks x402 v1. Surfaced client-side as `X402InvalidVersionError` before any authorization is signed. Wire value stays lowercase because a2a-x402 v0.2 §9.1 doesn't redefine it — x402-v1 §9 is the source of truth for this code. |
 | `INVALID_PAYLOAD` | SDK | Payment payload is missing or structurally invalid. |
 | `INVALID_PAY_TO` | SDK | Authorization target address doesn't match `payTo`. |
 | `VERIFY_FAILED` | SDK | Facilitator rejected the signature, but the reason string didn't match any of the spec codes above. |
@@ -160,6 +168,8 @@ new X402PaymentExecutor(inner, {
 ### Rejection handling
 
 When a client decides not to pay it can respond with `x402.payment.status: payment-rejected` (spec §5.4.2). The executor terminates the task with state `failed` and status `payment-rejected` — no further challenges are published, the loop ends.
+
+On the client side, return `false` from `onPaymentRequired` to send `payment-rejected` cleanly; throwing aborts locally and leaves the merchant's task stranded in `input-required`. `rejectX402Payment(task)` is the lower-level primitive that produces the metadata block if you drive the dance manually.
 
 ## Client
 
@@ -200,7 +210,7 @@ for await (const event of client.sendMessageStream({ message: { … } })) {
 }
 ```
 
-If the merchant rejects the payment (verify or settle failed), the call throws `X402PaymentFailedError` with the on-chain reason attached. If every requirement in `accepts[]` exceeds `maxAmount`, signing throws `X402NoSupportedRequirementError` before any authorization is created.
+If the merchant's terminal task records a payment failure (verify or settle failed and the most recent receipt is unsuccessful), the call throws `X402PaymentFailedError` with the on-chain reason attached. The decision uses the *latest* receipt — resuming a task that has historical failure receipts but completed successfully (e.g. server-side retry) returns the task without throwing. If every requirement in `accepts[]` exceeds `maxAmount`, signing throws `X402NoSupportedRequirementError` before any authorization is created. If the merchant publishes an unsupported `x402Version`, signing throws `X402InvalidVersionError` (wire code `invalid_x402_version`, per x402-v1 §9).
 
 The full option surface:
 
@@ -209,7 +219,8 @@ The full option surface:
 | `signer` | required | viem `LocalAccount` used to produce the EIP-3009 authorization. |
 | `maxAmount` | no cap | Atomic-unit ceiling. Filters `accepts[]` before the selector runs, so a custom `selectRequirement` only sees the affordable subset. |
 | `selectRequirement` | first `scheme === 'exact'` | Predicate over the (already filtered) requirements. Return `undefined` to abort. |
-| `onPaymentRequired` | none | Hook that fires after `payment-required` and before signing. Throw to abort the dance — the caller observes the unmodified `payment-required` task (blocking) or a stream that closes after the `payment-required` event (streaming). |
+| `onPaymentRequired` | none | Hook that fires after `payment-required` and before signing. Return `false` to send `payment-rejected` cleanly so the merchant's task terminates per spec §5.4.2; return `void`/`true` (or omit) to proceed; throw to abort *locally* without telling the merchant (the caller observes the unmodified `payment-required` task). |
+| `maxRetries` | `0` | Maximum *additional* sign+resubmit attempts when the merchant runs `retryOnFailure: true` and re-issues `payment-required` on the same task. Set to `1` or more to opt into automatic retries; the dance bails on any non-`payment-required` terminal or when the budget is exhausted. |
 
 ### Extension activation header
 
@@ -266,6 +277,23 @@ const signed = await signX402Payment(first, {
   signer,
   selectRequirement: (accepts) =>
     accepts.find((r) => r.network === 'base-sepolia'),
+});
+```
+
+Declining a payment manually — produces the metadata block to attach to a follow-up `message/send` call so the merchant terminates the task per spec §5.4.2 instead of leaving it stranded in `input-required`:
+
+```ts
+import { rejectX402Payment } from '@a2x/sdk/x402';
+
+const rejection = rejectX402Payment(first);
+await client.sendMessage({
+  message: {
+    messageId: crypto.randomUUID(),
+    role: 'user',
+    taskId: first.id,
+    parts: [{ text: '' }],
+    metadata: rejection.metadata,
+  },
 });
 ```
 

--- a/packages/a2x/src/__tests__/a2x-client-x402.test.ts
+++ b/packages/a2x/src/__tests__/a2x-client-x402.test.ts
@@ -111,6 +111,7 @@ function completedTaskWithReceipt(): unknown {
               success: true,
               transaction: '0xabc',
               network: 'base-sepolia',
+              payer: '0x9999999999999999999999999999999999999999',
             },
           ],
         },
@@ -141,6 +142,7 @@ function failedTaskWithReceipt(reason: string, code: string): unknown {
               success: false,
               transaction: '',
               network: 'base-sepolia',
+              payer: '0x9999999999999999999999999999999999999999',
               errorReason: reason,
             },
           ],
@@ -324,6 +326,213 @@ describe('A2XClient.sendMessage — native x402 dance', () => {
     expect(rpcRequests).toHaveLength(1);
     expect(rpcRequests[0]!.headers['x-a2a-extensions']).toBeUndefined();
   });
+
+  it('sends payment-rejected when onPaymentRequired returns false (spec §5.4.2)', async () => {
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () =>
+        jsonRpcOk({
+          kind: 'task',
+          id: 't1',
+          contextId: 'c1',
+          status: {
+            state: 'failed',
+            timestamp: new Date().toISOString(),
+            message: {
+              messageId: 'rj',
+              role: 'agent',
+              parts: [{ kind: 'text', text: 'declined' }],
+              metadata: {
+                [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED,
+              },
+            },
+          },
+          artifacts: [],
+          history: [],
+        }),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT, onPaymentRequired: () => false },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('failed');
+    expect(rpcRequests).toHaveLength(2);
+    const followup = (rpcRequests[1]!.body as { params: { message: { metadata: Record<string, unknown> } } }).params;
+    expect(followup.message.metadata[X402_METADATA_KEYS.STATUS]).toBe(
+      X402_PAYMENT_STATUS.REJECTED,
+    );
+    // Reject path must NOT send a signed payload — the merchant only
+    // gets the rejection marker on the same task.
+    expect(followup.message.metadata[X402_METADATA_KEYS.PAYLOAD]).toBeUndefined();
+  });
+
+  it('does not throw when the latest receipt is success despite historical failures (issue #143.4)', async () => {
+    // Caller resumes a task that previously had a failed attempt. The
+    // receipts array carries the complete history per spec §7. A
+    // `find(!r.success)` scan would falsely throw on the stale failure
+    // even though the most recent receipt is success.
+    const { fetch } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () =>
+        jsonRpcOk({
+          kind: 'task',
+          id: 't1',
+          contextId: 'c1',
+          status: {
+            state: 'completed',
+            timestamp: new Date().toISOString(),
+            message: {
+              messageId: 'final',
+              role: 'agent',
+              parts: [{ kind: 'text', text: 'ok' }],
+              metadata: {
+                [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
+                [X402_METADATA_KEYS.RECEIPTS]: [
+                  { success: false, transaction: '', network: 'base-sepolia', payer: '0xpayer', errorReason: 'old' },
+                  { success: true, transaction: '0xabc', network: 'base-sepolia', payer: '0xpayer' },
+                ],
+              },
+            },
+          },
+          artifacts: [],
+          history: [],
+        }),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('completed');
+  });
+
+  it('surfaces a server-side retry signal (input-required + payment-required) without throwing', async () => {
+    // `retryOnFailure: true` on the executor re-issues `payment-required`
+    // after a failed verify/settle. The default client (maxRetries: 0)
+    // signs once, sees the retry prompt, and surfaces the task — does
+    // not throw on the failure receipt that came along for the ride.
+    const retryTask = {
+      kind: 'task',
+      id: 't1',
+      contextId: 'c1',
+      status: {
+        state: 'input-required',
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: 'retry',
+          role: 'agent',
+          parts: [{ kind: 'text', text: 'try again' }],
+          metadata: {
+            [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+            [X402_METADATA_KEYS.REQUIRED]: {
+              x402Version: 1,
+              accepts: [
+                {
+                  scheme: 'exact',
+                  network: 'base-sepolia',
+                  maxAmountRequired: '1000',
+                  resource: 'https://example.com/protected',
+                  description: 'Per-call',
+                  mimeType: 'application/json',
+                  payTo: '0x000000000000000000000000000000000000dEaD',
+                  maxTimeoutSeconds: 300,
+                  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+                  extra: { name: 'USDC', version: '2' },
+                },
+              ],
+              error: 'insufficient_balance',
+            },
+            [X402_METADATA_KEYS.ERROR]: 'INSUFFICIENT_FUNDS',
+            [X402_METADATA_KEYS.RECEIPTS]: [
+              { success: false, transaction: '', network: 'base-sepolia', payer: '0xpayer', errorReason: 'insufficient_balance' },
+            ],
+          },
+        },
+      },
+      artifacts: [],
+      history: [],
+    };
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () => jsonRpcOk(retryTask),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('input-required');
+    expect(rpcRequests).toHaveLength(2);
+  });
+
+  it('auto-retries up to maxRetries times when the server keeps re-issuing payment-required', async () => {
+    const retryTask = (): unknown => ({
+      kind: 'task',
+      id: 't1',
+      contextId: 'c1',
+      status: {
+        state: 'input-required',
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: 'retry',
+          role: 'agent',
+          parts: [{ kind: 'text', text: 'try again' }],
+          metadata: {
+            [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REQUIRED,
+            [X402_METADATA_KEYS.REQUIRED]: {
+              x402Version: 1,
+              accepts: [
+                {
+                  scheme: 'exact',
+                  network: 'base-sepolia',
+                  maxAmountRequired: '1000',
+                  resource: 'https://example.com/protected',
+                  description: 'Per-call',
+                  mimeType: 'application/json',
+                  payTo: '0x000000000000000000000000000000000000dEaD',
+                  maxTimeoutSeconds: 300,
+                  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+                  extra: { name: 'USDC', version: '2' },
+                },
+              ],
+              error: 'transient',
+            },
+          },
+        },
+      },
+      artifacts: [],
+      history: [],
+    });
+    // initial → first sign → retry-required → second sign → completed
+    const { fetch, rpcRequests } = scriptedFetch([
+      () => jsonRpcOk(paymentRequiredTask()),
+      () => jsonRpcOk(retryTask()),
+      () => jsonRpcOk(completedTaskWithReceipt()),
+    ]);
+    const client = new A2XClient(AGENT_URL, {
+      fetch,
+      x402: { signer: TEST_ACCOUNT, maxRetries: 1 },
+    });
+    const task = await client.sendMessage({
+      message: { messageId: 'm1', role: 'user', parts: [{ text: 'hi' }] },
+    });
+    expect(task.status.state).toBe('completed');
+    expect(rpcRequests).toHaveLength(3);
+    // Both follow-ups must carry signed payload metadata, not the same
+    // signature reused — fresh nonce per attempt is the whole point of
+    // retry-on-failure.
+    const followup1 = (rpcRequests[1]!.body as { params: { message: { metadata: Record<string, unknown> } } }).params.message.metadata;
+    const followup2 = (rpcRequests[2]!.body as { params: { message: { metadata: Record<string, unknown> } } }).params.message.metadata;
+    expect(followup1[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.SUBMITTED);
+    expect(followup2[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.SUBMITTED);
+  });
 });
 
 describe('A2XClient.sendMessageStream — native x402 dance', () => {
@@ -412,7 +621,7 @@ describe('A2XClient.sendMessageStream — native x402 dance', () => {
         {
           [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.COMPLETED,
           [X402_METADATA_KEYS.RECEIPTS]: [
-            { success: true, transaction: '0xabc', network: 'base-sepolia' },
+            { success: true, transaction: '0xabc', network: 'base-sepolia', payer: '0x9999999999999999999999999999999999999999' },
           ],
         },
         true,

--- a/packages/a2x/src/__tests__/x402-client.test.ts
+++ b/packages/a2x/src/__tests__/x402-client.test.ts
@@ -6,6 +6,7 @@ import {
   X402_PAYMENT_STATUS,
 } from '../x402/constants.js';
 import {
+  X402InvalidVersionError,
   X402NoSupportedRequirementError,
   X402PaymentRequiredError,
 } from '../x402/errors.js';
@@ -13,6 +14,7 @@ import {
   getX402PaymentRequirements,
   getX402Receipts,
   getX402Status,
+  rejectX402Payment,
   signX402Payment,
 } from '../x402/client.js';
 import type {
@@ -89,6 +91,7 @@ describe('getX402Status / getX402Receipts', () => {
       success: true,
       transaction: '0xabc',
       network: 'base-sepolia',
+      payer: '0x9999999999999999999999999999999999999999',
     };
     const task: Task = {
       id: 't1',
@@ -171,5 +174,36 @@ describe('signX402Payment', () => {
         selectRequirement: () => undefined,
       }),
     ).rejects.toBeInstanceOf(X402NoSupportedRequirementError);
+  });
+
+  it('throws X402InvalidVersionError when the merchant claims a non-1 x402Version (spec §6/§9)', async () => {
+    // x402-v1 §9 lists `invalid_x402_version`; the x402 npm package
+    // pins `x402Versions: [1]`, so signing a non-1 requirement would
+    // crash deep inside `createPaymentHeader`. We reject early so callers
+    // see the spec error code.
+    const task = paymentRequiredTask([BASE_ACCEPT]);
+    const meta = task.status.message!.metadata as Record<string, unknown>;
+    (meta[X402_METADATA_KEYS.REQUIRED] as { x402Version: number }).x402Version = 999;
+    await expect(
+      signX402Payment(task, { signer: TEST_ACCOUNT }),
+    ).rejects.toBeInstanceOf(X402InvalidVersionError);
+  });
+});
+
+describe('rejectX402Payment', () => {
+  it('produces a payment-rejected metadata block from a payment-required task', () => {
+    const task = paymentRequiredTask([BASE_ACCEPT]);
+    const rejection = rejectX402Payment(task);
+    expect(rejection.metadata[X402_METADATA_KEYS.STATUS]).toBe(
+      X402_PAYMENT_STATUS.REJECTED,
+    );
+  });
+
+  it('throws X402PaymentRequiredError when the task is not asking for payment', () => {
+    const task: Task = {
+      id: 't1',
+      status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+    };
+    expect(() => rejectX402Payment(task)).toThrowError(X402PaymentRequiredError);
   });
 });

--- a/packages/a2x/src/__tests__/x402-executor.test.ts
+++ b/packages/a2x/src/__tests__/x402-executor.test.ts
@@ -343,6 +343,59 @@ describe('X402PaymentExecutor — request/submit flow', () => {
     expect(meta[X402_METADATA_KEYS.STATUS]).toBe(X402_PAYMENT_STATUS.REJECTED);
   });
 
+  it('populates payer on success receipts (x402-v1 §5.3.2)', async () => {
+    const FACILITATOR_PAYER = '0x9999999999999999999999999999999999999999';
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({ isValid: true, invalidReason: undefined, payer: FACILITATOR_PAYER }),
+        settle: async () => ({
+          success: true,
+          transaction: '0xdeadbeef',
+          network: 'base-sepolia',
+          payer: FACILITATOR_PAYER,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const completed = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const receipts = (
+      completed.status.message?.metadata as Record<string, unknown>
+    )[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
+    expect(receipts[0]).toMatchObject({
+      success: true,
+      payer: FACILITATOR_PAYER,
+    });
+  });
+
+  it('populates payer on failure receipts even when the facilitator omits it', async () => {
+    // Some facilitator implementations drop `payer` on failure; spec
+    // §5.3.2 still requires the field, so the SDK must fall back to
+    // the EVM authorization's `from` (or `'unknown'` for SVM/non-EVM).
+    const executor = makeExecutor(
+      mockFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_signature',
+          payer: undefined as unknown as string,
+        }),
+      }),
+    );
+    const first = await executor.execute(newTask(), newMessage());
+    const { metadata } = await signAgainst(first);
+    const result = await executor.execute(
+      newTask(),
+      newMessage({ messageId: 'm2', metadata }),
+    );
+    const receipts = (
+      result.status.message?.metadata as Record<string, unknown>
+    )[X402_METADATA_KEYS.RECEIPTS] as X402SettleResponse[];
+    expect(receipts[0]?.payer).toBe(TEST_ACCOUNT.address);
+  });
+
   it('preserves prior receipts when payment completes after a previous failure (spec §7 history)', async () => {
     const executor = makeExecutor(mockFacilitator());
 

--- a/packages/a2x/src/client/a2x-client.ts
+++ b/packages/a2x/src/client/a2x-client.ts
@@ -51,6 +51,7 @@ import {
 } from '../x402/constants.js';
 import {
   signX402Payment,
+  rejectX402Payment,
   getX402PaymentRequirements,
   getX402Receipts,
   type SignedX402Payment,
@@ -95,14 +96,44 @@ export interface A2XClientX402Options {
   ) => X402PaymentRequirements | undefined;
   /**
    * Hook invoked after the merchant publishes `payment-required` and
-   * before the client signs. Useful for prompting the user to confirm.
-   * Throw to abort the flow — the caller observes the merchant's
-   * unmodified `payment-required` task (blocking) or a stream that
-   * closes after the `payment-required` event (streaming).
+   * before the client signs. Useful for prompting the user to confirm,
+   * declining the challenge, or recording the prompt for audit.
+   *
+   * Return value semantics:
+   *  - `void` / `undefined` / `true` — proceed: sign and resubmit (default).
+   *  - `false` — decline: send `x402.payment.status: payment-rejected`
+   *    on the same task per a2a-x402 v0.2 §5.4.2 / §7.1, then return
+   *    the merchant's terminal task to the caller. The merchant sees the
+   *    decline; the caller does not have to construct the rejection
+   *    message itself.
+   *
+   * Throw to abort *locally* without telling the merchant — the caller
+   * observes the unmodified `payment-required` task (blocking) or a
+   * stream that closes after the `payment-required` event (streaming).
+   * Use `false` instead when you want the merchant's task to terminate
+   * cleanly rather than be left stranded in `input-required`.
    */
   onPaymentRequired?: (
     required: X402PaymentRequiredResponse,
-  ) => void | Promise<void>;
+  ) => void | boolean | Promise<void | boolean>;
+  /**
+   * Maximum number of *additional* sign+resubmit attempts after the
+   * first one when the merchant runs `retryOnFailure: true` and re-issues
+   * `payment-required` on the same task (a2a-x402 v0.2 §9; see also the
+   * server-side `retryOnFailure` in `X402PaymentExecutor`).
+   *
+   * Default `0` — the SDK signs once and surfaces whatever comes back.
+   * Set to `1` or more to opt into automatic retries; the dance bails
+   * out when the merchant returns a terminal state (`completed` /
+   * `failed`) or when the budget is exhausted (in which case the most
+   * recent retry-required task is returned to the caller).
+   *
+   * Each retry signs a fresh authorization with a fresh nonce, so this
+   * is the right knob for failures the wallet can recover from on its
+   * own (network blip, transient nonce reuse) — anything that needs
+   * user interaction (top-up, wallet switch) should still surface.
+   */
+  maxRetries?: number;
 }
 
 export interface A2XClientOptions {
@@ -247,47 +278,41 @@ export class A2XClient {
     const first = await this._sendMessageOnce(params);
     if (!this._x402) return first;
     if (first.status.state !== 'input-required') return first;
+    if (!getX402PaymentRequirements(first)) return first;
 
-    const required = getX402PaymentRequirements(first);
-    if (!required) return first;
+    const maxRetries = this._x402.maxRetries ?? 0;
+    let task = first;
 
-    if (this._x402.onPaymentRequired) {
-      await this._x402.onPaymentRequired(required);
-    }
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const required = getX402PaymentRequirements(task);
+      if (!required) break;
 
-    const signed = await this._signX402(first);
+      const decision = await this._x402.onPaymentRequired?.(required);
 
-    const followup: SendMessageParams = {
-      ...params,
-      message: {
-        ...params.message,
-        messageId: globalThis.crypto.randomUUID(),
-        taskId: first.id,
-        contextId: first.contextId,
-        metadata: {
-          ...(params.message.metadata ?? {}),
-          ...signed.metadata,
-        },
-      },
-    };
+      if (decision === false) {
+        return this._sendMessageOnce(this._buildRejectFollowup(params, task));
+      }
 
-    const second = await this._sendMessageOnce(followup);
-
-    const receipts = getX402Receipts(second);
-    const failed = receipts.find((r) => !r.success);
-    if (failed) {
-      const errorCode =
-        ((second.status.message?.metadata as Record<string, unknown> | undefined)?.[
-          X402_METADATA_KEYS.ERROR
-        ] as string | undefined) ?? 'UNKNOWN';
-      throw new X402PaymentFailedError(
-        failed.errorReason ?? 'Payment failed',
-        errorCode,
-        { transaction: failed.transaction, network: failed.network },
+      const signed = await this._signX402(task);
+      task = await this._sendMessageOnce(
+        this._buildSubmitFollowup(params, task, signed.metadata),
       );
+
+      // Server may re-issue payment-required when running with
+      // retryOnFailure (a2a-x402 v0.2 §9). Loop within the budget; once
+      // exhausted (or on any non-payment-required terminal), fall through
+      // to the receipt-scan decision.
+      if (
+        task.status.state === 'input-required' &&
+        getX402PaymentRequirements(task)
+      ) {
+        continue;
+      }
+      break;
     }
 
-    return second;
+    this._throwIfX402Failure(task);
+    return task;
   }
 
   /**
@@ -309,15 +334,24 @@ export class A2XClient {
       return;
     }
 
-    let firstTask: Task | undefined;
-    for await (const event of this._sendMessageStreamOnce(params, signal)) {
-      yield event;
-      if ('status' in event && event.status?.state === 'input-required') {
-        const meta = event.status.message?.metadata as
-          | Record<string, unknown>
-          | undefined;
-        if (meta?.[X402_METADATA_KEYS.STATUS] === X402_PAYMENT_STATUS.REQUIRED) {
-          firstTask = {
+    let currentParams = params;
+    // First sign attempt + N additional retries on `retryOnFailure`
+    // re-prompts (a2a-x402 v0.2 §9). Default 0 retries → exactly one
+    // sign+resubmit, matching the long-standing client behavior.
+    let signsRemaining = (this._x402.maxRetries ?? 0) + 1;
+
+    while (true) {
+      let pendingTask: Task | undefined;
+      for await (const event of this._sendMessageStreamOnce(currentParams, signal)) {
+        yield event;
+        if (
+          'status' in event &&
+          event.status?.state === 'input-required' &&
+          (event.status.message?.metadata as Record<string, unknown> | undefined)?.[
+            X402_METADATA_KEYS.STATUS
+          ] === X402_PAYMENT_STATUS.REQUIRED
+        ) {
+          pendingTask = {
             id: event.taskId,
             contextId: event.contextId,
             status: event.status,
@@ -325,34 +359,34 @@ export class A2XClient {
           break;
         }
       }
+
+      if (!pendingTask) return;
+
+      const required = getX402PaymentRequirements(pendingTask);
+      if (!required) return;
+
+      const decision = await this._x402.onPaymentRequired?.(required);
+      if (decision === false) {
+        // Decline cleanly: surface the rejection follow-up's events to
+        // the caller (typically a single `failed` + payment-rejected
+        // status update from the merchant).
+        yield* this._sendMessageStreamOnce(
+          this._buildRejectFollowup(params, pendingTask),
+          signal,
+        );
+        return;
+      }
+
+      if (signsRemaining <= 0) return;
+      signsRemaining -= 1;
+
+      const signed = await this._signX402(pendingTask);
+      currentParams = this._buildSubmitFollowup(
+        params,
+        pendingTask,
+        signed.metadata,
+      );
     }
-
-    if (!firstTask) return;
-
-    const required = getX402PaymentRequirements(firstTask);
-    if (!required) return;
-
-    if (this._x402.onPaymentRequired) {
-      await this._x402.onPaymentRequired(required);
-    }
-
-    const signed = await this._signX402(firstTask);
-
-    const followup: SendMessageParams = {
-      ...params,
-      message: {
-        ...params.message,
-        messageId: globalThis.crypto.randomUUID(),
-        taskId: firstTask.id,
-        contextId: firstTask.contextId,
-        metadata: {
-          ...(params.message.metadata ?? {}),
-          ...signed.metadata,
-        },
-      },
-    };
-
-    yield* this._sendMessageStreamOnce(followup, signal);
   }
 
   private async _sendMessageOnce(params: SendMessageParams): Promise<Task> {
@@ -443,6 +477,62 @@ export class A2XClient {
     }
     yield firstEvent;
     yield* events;
+  }
+
+  /**
+   * Construct a follow-up `message/send` payload that resubmits the
+   * caller's original message on the same task with the supplied x402
+   * metadata block (signed payload or rejection marker).
+   */
+  private _buildSubmitFollowup(
+    original: SendMessageParams,
+    task: Task,
+    x402Metadata: Record<string, unknown>,
+  ): SendMessageParams {
+    return {
+      ...original,
+      message: {
+        ...original.message,
+        messageId: globalThis.crypto.randomUUID(),
+        taskId: task.id,
+        contextId: task.contextId,
+        metadata: {
+          ...(original.message.metadata ?? {}),
+          ...x402Metadata,
+        },
+      },
+    };
+  }
+
+  private _buildRejectFollowup(
+    original: SendMessageParams,
+    task: Task,
+  ): SendMessageParams {
+    return this._buildSubmitFollowup(original, task, rejectX402Payment(task).metadata);
+  }
+
+  /**
+   * Decide on the *latest* receipt + final task state, not "any historical
+   * failure". The receipts array is the complete history per spec §7, so
+   * a successful retry on a task that previously failed must still be
+   * surfaced as success (issue #143). Conversely, a task that ends in
+   * `failed` with the most recent receipt unsuccessful is a terminal
+   * payment failure and should throw.
+   */
+  private _throwIfX402Failure(task: Task): void {
+    if (task.status.state !== 'failed') return;
+    const receipts = getX402Receipts(task);
+    const latest = receipts[receipts.length - 1];
+    if (!latest || latest.success) return;
+    const errorCode =
+      ((task.status.message?.metadata as Record<string, unknown> | undefined)?.[
+        X402_METADATA_KEYS.ERROR
+      ] as string | undefined) ?? 'UNKNOWN';
+    throw new X402PaymentFailedError(
+      latest.errorReason ?? 'Payment failed',
+      errorCode,
+      { transaction: latest.transaction, network: latest.network },
+    );
   }
 
   private async _signX402(task: Task): Promise<SignedX402Payment> {

--- a/packages/a2x/src/x402/client.ts
+++ b/packages/a2x/src/x402/client.ts
@@ -15,9 +15,6 @@
  */
 
 import type { LocalAccount } from 'viem';
-import { createPaymentHeader as createX402PaymentHeader } from 'x402/client';
-import { safeBase64Decode } from 'x402/shared';
-import { PaymentPayloadSchema } from 'x402/types';
 import type { Task } from '../types/task.js';
 import {
   X402_METADATA_KEYS,
@@ -25,6 +22,7 @@ import {
   type X402PaymentStatus,
 } from './constants.js';
 import {
+  X402InvalidVersionError,
   X402NoSupportedRequirementError,
   X402PaymentRequiredError,
 } from './errors.js';
@@ -34,6 +32,33 @@ import type {
   X402PaymentRequiredResponse,
   X402SettleResponse,
 } from './types.js';
+
+// x402 is declared as an `optional` peer dep. Importing its runtime
+// helpers at the top level pulls them into the `@a2x/sdk/client` chunk
+// even on code paths that never touch x402, which breaks bundlers when
+// users haven't installed it (issue #134). Lazy-import inside the only
+// function that needs them so non-x402 consumers stay unaffected.
+let _x402Runtime:
+  | Promise<{
+      createPaymentHeader: typeof import('x402/client').createPaymentHeader;
+      safeBase64Decode: typeof import('x402/shared').safeBase64Decode;
+      PaymentPayloadSchema: typeof import('x402/types').PaymentPayloadSchema;
+    }>
+  | undefined;
+async function _loadX402Runtime() {
+  if (!_x402Runtime) {
+    _x402Runtime = (async () => {
+      const [{ createPaymentHeader }, { safeBase64Decode }, { PaymentPayloadSchema }] =
+        await Promise.all([
+          import('x402/client'),
+          import('x402/shared'),
+          import('x402/types'),
+        ]);
+      return { createPaymentHeader, safeBase64Decode, PaymentPayloadSchema };
+    })();
+  }
+  return _x402Runtime;
+}
 
 export interface SignX402PaymentOptions {
   /** viem LocalAccount (or any compatible signer with a `privateKey` + `address`). */
@@ -113,16 +138,28 @@ export async function signX402Payment(
     );
   }
 
+  // x402-v1 §6/§9: only x402Version 1 is defined. The x402 npm package
+  // pins `x402Versions: [1]`; signing a non-1 requirement would let a
+  // malformed/forward-versioned payload reach the wire (or crash deep
+  // inside `createPaymentHeader`). Reject early so callers see the spec
+  // error code (`invalid_x402_version`) instead of an opaque exception.
+  if (required.x402Version !== 1) {
+    throw new X402InvalidVersionError(required.x402Version as unknown as number);
+  }
+
   const select = options.selectRequirement ?? defaultSelect;
   const requirement = select(required.accepts);
   if (!requirement) {
     throw new X402NoSupportedRequirementError();
   }
 
-  const header = await createX402PaymentHeader(
-    options.signer as unknown as Parameters<typeof createX402PaymentHeader>[0],
+  const { createPaymentHeader, safeBase64Decode, PaymentPayloadSchema } =
+    await _loadX402Runtime();
+
+  const header = await createPaymentHeader(
+    options.signer as unknown as Parameters<typeof createPaymentHeader>[0],
     required.x402Version,
-    requirement as unknown as Parameters<typeof createX402PaymentHeader>[2],
+    requirement as unknown as Parameters<typeof createPaymentHeader>[2],
   );
 
   // `createPaymentHeader` returns a base64-encoded PaymentPayload for HTTP
@@ -138,6 +175,36 @@ export async function signX402Payment(
     metadata: {
       [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.SUBMITTED,
       [X402_METADATA_KEYS.PAYLOAD]: payload,
+    },
+  };
+}
+
+/**
+ * Build the `payment-rejected` follow-up metadata for a task the merchant
+ * left in `payment-required`. Resending the original message with this
+ * metadata block (and the same `taskId` / `contextId`) tells the merchant
+ * the client declined the challenge — the server-side `X402PaymentExecutor`
+ * terminates the task on receipt, closing the `payment-required` round
+ * trip per a2a-x402 v0.2 §5.4.2 / §7.1.
+ *
+ * `signX402Payment` is the "yes, here's a signed payload" half of the
+ * dance; `rejectX402Payment` is the "no, not at this price" half. Throwing
+ * from `onPaymentRequired` in `A2XClient` aborts locally without telling
+ * the merchant — use this primitive (or return `false` from
+ * `onPaymentRequired`) when you want the merchant to know.
+ */
+export function rejectX402Payment(task: Task): {
+  metadata: Record<string, unknown>;
+} {
+  const required = getX402PaymentRequirements(task);
+  if (!required) {
+    throw new X402PaymentRequiredError(
+      'Task is not in a payment-required state.',
+    );
+  }
+  return {
+    metadata: {
+      [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.REJECTED,
     },
   };
 }

--- a/packages/a2x/src/x402/constants.ts
+++ b/packages/a2x/src/x402/constants.ts
@@ -58,6 +58,20 @@ export const X402_ERROR_CODES = {
   NETWORK_MISMATCH: 'NETWORK_MISMATCH',
   INVALID_AMOUNT: 'INVALID_AMOUNT',
   SETTLEMENT_FAILED: 'SETTLEMENT_FAILED',
+  /**
+   * x402-v1 §9 `invalid_x402_version`: protocol version is not supported.
+   * Emitted client-side when the merchant publishes `x402Version` ≠ 1;
+   * the x402 npm package pins `x402Versions: [1]`, so anything else is
+   * unsigned-and-rejected before we hand the requirement to
+   * `createPaymentHeader()`.
+   *
+   * The wire value is intentionally lowercase: a2a-x402 v0.2 §9.1 only
+   * defines seven UPPERCASE codes (INSUFFICIENT_FUNDS, …, SETTLEMENT_FAILED)
+   * — `invalid_x402_version` isn't one of them. Following x402-v1 §9
+   * verbatim is more correct than coining an upper-cased a2a-x402
+   * variant that no spec defines.
+   */
+  INVALID_X402_VERSION: 'invalid_x402_version',
   // ─── SDK-specific (outside spec §9.1) ───
   /** Payment payload is missing, unparseable, or structurally invalid. */
   INVALID_PAYLOAD: 'INVALID_PAYLOAD',

--- a/packages/a2x/src/x402/errors.ts
+++ b/packages/a2x/src/x402/errors.ts
@@ -47,3 +47,24 @@ export class X402NoSupportedRequirementError extends X402Error {
     this.name = 'X402NoSupportedRequirementError';
   }
 }
+
+/**
+ * Thrown when the merchant claims an `x402Version` the SDK can't speak.
+ * x402-v1 §6 / §9: only `x402Version: 1` is defined. The wire `code`
+ * matches the spec's `invalid_x402_version` token verbatim — a2a-x402
+ * v0.2 §9.1 doesn't redefine this code (it only enumerates seven
+ * UPPERCASE codes none of which apply here), so x402-v1's lowercase
+ * spelling is the authoritative wire form.
+ */
+export class X402InvalidVersionError extends X402Error {
+  readonly version: number;
+  readonly code = 'invalid_x402_version';
+
+  constructor(version: number) {
+    super(
+      `Unsupported x402Version ${version}; this SDK only speaks x402Version 1.`,
+    );
+    this.name = 'X402InvalidVersionError';
+    this.version = version;
+  }
+}

--- a/packages/a2x/src/x402/executor.ts
+++ b/packages/a2x/src/x402/executor.ts
@@ -117,6 +117,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
         payload?.network,
+        resolvePayer(payload, undefined, undefined),
       );
       return task;
     }
@@ -129,6 +130,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         validationErr.code,
         validationErr.reason,
         payload.network,
+        resolvePayer(payload, undefined, undefined),
       );
       return task;
     }
@@ -140,6 +142,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
+        resolvePayer(payload, verifyResult, undefined),
       );
       return task;
     }
@@ -160,6 +163,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        resolvePayer(payload, verifyResult, settleResult),
         priorReceipts,
       );
       return task;
@@ -169,6 +173,7 @@ export class X402PaymentExecutor extends AgentExecutor {
       success: true,
       transaction: settleResult.transaction ?? '',
       network: payload.network,
+      payer: resolvePayer(payload, verifyResult, settleResult),
     };
 
     const result = await this._inner.execute(task, message);
@@ -208,6 +213,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         X402_ERROR_CODES.INVALID_PAYLOAD,
         'Payment payload is missing or malformed.',
         payload?.network,
+        resolvePayer(payload, undefined, undefined),
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
@@ -221,6 +227,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         validationErr.code,
         validationErr.reason,
         payload.network,
+        resolvePayer(payload, undefined, undefined),
       );
       yield { taskId: task.id, contextId, status: task.status };
       return;
@@ -238,6 +245,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         mapVerifyFailureToCode(verifyResult.invalidReason),
         verifyResult.invalidReason ?? 'Payment verification failed.',
         payload.network,
+        resolvePayer(payload, verifyResult, undefined),
         priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
@@ -257,6 +265,7 @@ export class X402PaymentExecutor extends AgentExecutor {
         X402_ERROR_CODES.SETTLEMENT_FAILED,
         settleResult.errorReason ?? 'Payment settlement failed.',
         payload.network,
+        resolvePayer(payload, verifyResult, settleResult),
         priorReceipts,
       );
       yield { taskId: task.id, contextId, status: task.status };
@@ -267,6 +276,7 @@ export class X402PaymentExecutor extends AgentExecutor {
       success: true,
       transaction: settleResult.transaction ?? '',
       network: payload.network,
+      payer: resolvePayer(payload, verifyResult, settleResult),
     };
 
     let lastStatusEvent: TaskStatusUpdateEvent | undefined;
@@ -321,18 +331,26 @@ export class X402PaymentExecutor extends AgentExecutor {
    * `explicitPrior` lets the caller pass in receipts captured before a
    * downstream step (e.g. `_inner.execute`) rewrote `task.status`. When
    * omitted, prior receipts are read from the current `task.status`.
+   *
+   * `payer` is the caller-resolved payer wallet address — required by
+   * x402-v1 §5.3.2 on every receipt, including failure rows. Pass the
+   * facilitator-supplied address when available, falling back to the
+   * EVM authorization's `from` for shape-failure cases where verify
+   * never ran.
    */
   private _handlePaymentFailure(
     task: Task,
     code: X402ErrorCode,
     reason: string,
     network: string | undefined,
+    payer: string,
     explicitPrior?: X402SettleResponse[],
   ): void {
     const receipt: X402SettleResponse = {
       success: false,
       transaction: '',
       network: network ?? 'unknown',
+      payer,
       errorReason: reason,
     };
     const prior = explicitPrior ?? getExistingReceipts(task);
@@ -571,6 +589,24 @@ function getEvmAuthorization(
   return inner && typeof inner === 'object' && 'authorization' in inner
     ? inner.authorization
     : undefined;
+}
+
+/**
+ * Pick the payer wallet address for a receipt. Spec §5.3.2 requires this
+ * on every settlement response, including failure rows, so we always
+ * have to produce a string — fall back through facilitator → payload →
+ * `'unknown'` rather than dropping the field.
+ */
+function resolvePayer(
+  payload: X402PaymentPayload | undefined,
+  verifyResult: { payer?: string } | undefined,
+  settleResult: { payer?: string } | undefined,
+): string {
+  if (settleResult?.payer) return settleResult.payer;
+  if (verifyResult?.payer) return verifyResult.payer;
+  const authorization = getEvmAuthorization(payload);
+  if (authorization?.from) return authorization.from;
+  return 'unknown';
 }
 
 function validatePayloadAgainstRequirement(

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -80,6 +80,7 @@ export type { FacilitatorUrlConfig } from './facilitator.js';
 
 export {
   signX402Payment,
+  rejectX402Payment,
   getX402PaymentRequirements,
   getX402Receipts,
   getX402Status,
@@ -94,4 +95,5 @@ export {
   X402PaymentRequiredError,
   X402PaymentFailedError,
   X402NoSupportedRequirementError,
+  X402InvalidVersionError,
 } from './errors.js';

--- a/packages/a2x/src/x402/types.ts
+++ b/packages/a2x/src/x402/types.ts
@@ -46,7 +46,8 @@ export interface X402PaymentRequiredResponse {
 
 /**
  * Settlement receipt attached to `message.metadata['x402.payment.receipts']`
- * on the task's final message. Matches spec section 5.5.
+ * on the task's final message. Matches x402-v1 §5.3 (SettlementResponse) +
+ * a2a-x402 v0.2 §5.5 (the trimmed wire shape attached to A2A tasks).
  */
 export interface X402SettleResponse {
   success: boolean;
@@ -54,6 +55,14 @@ export interface X402SettleResponse {
   transaction: string;
   /** Network the settlement occurred on. */
   network: string;
+  /**
+   * Address of the payer's wallet. Required by x402-v1 §5.3.2 on every
+   * SettlementResponse — including failure rows, since post-settlement
+   * audits / multi-wallet bookkeeping branch on this field. The SDK
+   * propagates whatever the facilitator returns; for EVM "exact" payloads
+   * it falls back to `authorization.from` if the facilitator omits it.
+   */
+  payer: string;
   /** Short error code (e.g. `VERIFY_FAILED`) when `success` is false. */
   errorReason?: string;
 }


### PR DESCRIPTION
Closes #134.
Closes #143.

## Summary

Two related x402 issues bundled into one PR — both touch the same files
(`packages/a2x/src/x402/*` + `packages/a2x/src/client/a2x-client.ts`)
and the same docs page, so splitting them would be churn.

## #134 — x402 imports break bundlers

`@a2x/sdk` declares \`x402\` as an *optional* peer dep but the built
\`@a2x/sdk/client\` chunk imported its runtime helpers via top-level
static imports. Bundlers (Next.js / Turbopack reproduction in the issue)
had to resolve \`x402\` even on code paths that never touched it.

**Fix:** lazy-load the x402 runtime inside \`signX402Payment\` (option 2
from the issue). Consumers who never trigger the dance never load
\`x402/*\`. Verified in \`dist/client/index.js\` — zero static \`x402/*\`
imports remain; the only references are the dynamic \`import(\"x402/...\")\`
calls in the lazy-loader.

The package.json contract (peer / optional / required) is **unchanged**.

## #143 — four spec-conformance gaps

All four live on the payer side. One PR per AGENTS.md "Bundle every
related issue".

1. **payment-rejected (a2a-x402 §5.4.2 / §7.1).** New
   \`rejectX402Payment(task)\` primitive; \`onPaymentRequired\` can now
   return \`false\` to send the rejection on the same task. Throwing
   still aborts locally — \`false\` ends the merchant's task cleanly
   instead of stranding it in \`input-required\` forever.
2. **\`payer\` field on every \`X402SettleResponse\` (x402-v1 §5.3.2).**
   Required by the spec on success **and** failure rows. Threaded
   through both \`execute()\` and \`executeStream()\`; falls back to
   \`authorization.from\` for shape-failure receipts where the
   facilitator never ran.
3. **\`x402Version\` validation (x402-v1 §6/§9 → \`invalid_x402_version\`).**
   The x402 npm package pins \`x402Versions: [1]\`. Reject non-1 early
   with \`X402InvalidVersionError\` so callers get the spec error code
   instead of an opaque \`createPaymentHeader\` crash.
4. **Retry-aware receipt scan.** Decide on the *latest* receipt + task
   state, not "any historical failure". Recognize \`retryOnFailure\`
   re-prompts (input-required + payment-required) without throwing on
   the failure receipt that came along for the ride. New \`maxRetries\`
   option opts into automatic re-sign-and-resubmit on the same task
   (default 0 — no behavior change for existing consumers).

## Docs

\`packages/a2x/docs/guides/advanced/x402-payments.md\` updated for the
four new behaviors per AGENTS.md docs-sync policy: \`payer\` field,
client-side \`payment-rejected\` flow, \`invalid_x402_version\` error
code, retry-aware client semantics, lazy-load note in Installation.

## Notes

- **No changeset / no SDK version bump** in this PR per author intent;
  release prep can be added on top before the maintainer cuts the next
  release.
- 467 vitest tests pass (was 458 — 9 new tests covering the new paths).
- typecheck + lint clean. Build clean for \`@a2x/sdk\` and \`@a2x/cli\`;
  the two Next.js sample builds fail on this machine due to a Node
  22.18 V8 turbofan crash that needs the \`--jitless\` workaround,
  which Next.js's WebAssembly path can't tolerate. Unrelated to this
  diff — packages build fine and the local Node mismatches \`.nvmrc\`.

## Test plan

- [x] \`pnpm test\` — 467/467 pass.
- [x] \`pnpm typecheck\` (under \`--jitless\`) — clean.
- [x] \`pnpm lint\` — clean.
- [x] \`pnpm --filter '@a2x/*' build\` — clean.
- [x] Verified \`dist/client/index.js\` has zero static \`x402/*\` imports
      (the #134 reproduction case).
- [ ] Reviewer: spot-check \`onPaymentRequired\` return-value contract
      vs. existing \`throw\`-to-abort callers; both are still supported.