### PR TITLE
feat(sdk): add file/data variants to AgentEvent for multi-modal agents

### DIFF
--- a/.changeset/feat-agent-event-multimodal.md
+++ b/.changeset/feat-agent-event-multimodal.md
@@ -1,0 +1,46 @@
+---
+'@a2x/sdk': minor
+---
+
+`AgentEvent` now supports `file` and `data` variants alongside `text`, so
+multi-modal agents (image generation, structured output, document creation,
+…) can stay on the `BaseAgent` path without dropping to a custom
+`AgentExecutor`.
+
+Closes [#148](https://github.com/planetarium/a2x/issues/148).
+
+**Why.** A2A v0.3 already defines first-class non-text part shapes
+(`FilePart`, `DataPart`) and the SDK's internal `Part` union has matched
+that since day one. But `AgentEvent` — the contract between agent code
+and the runner/executor — only had a `text` data variant, so non-text
+output had no expression on the `BaseAgent` path: the default
+`AgentExecutor.executeStream` translated `text` into artifact text-parts
+and silently dropped everything else. The only workaround was to abandon
+`BaseAgent` and emit raw `TaskArtifactUpdateEvent`s from a custom
+`AgentExecutor`, which leaks A2A protocol details into agent code.
+
+**What's new.**
+
+- `AgentEvent` adds `{ type: 'file', file: {...} }` and
+  `{ type: 'data', data, mediaType? }` variants. The `text` variant gains
+  an optional `mediaType` field for distinguishing `text/markdown`,
+  `application/json`, etc.
+- The default `AgentExecutor` (both `execute()` and `executeStream()`)
+  maps each non-text event to a fresh artifact: `file` → `FilePart`
+  artifact, `data` → `DataPart` artifact, each with a unique
+  `artifactId`. Text events keep their existing accumulation behavior
+  (single text artifact per task, append-mode chunks during streaming).
+- `LlmAgent.run()` no longer filters non-text parts out of the LLM
+  response — they are yielded as `file` / `data` events. (The bundled
+  Anthropic / OpenAI / Google provider converters today only emit text
+  blocks from chat-completion responses; non-text output mostly applies
+  to custom `BaseAgent` implementations.)
+
+**Compatibility.** Additive on the wire: clients receive standard A2A
+v0.3 `FilePart` / `DataPart` artifacts, which `A2XClient` and its
+response parser already supported. Existing text-only agents and
+clients continue to work unchanged.
+
+`switch (event.type) { … }` blocks over `AgentEvent` without a
+`default:` branch will need new `case 'file'` / `case 'data'` arms (or
+a `default:`) under TypeScript's strict-exhaustiveness checks.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm install @a2x/sdk
 - **Device Flow auth** — Built-in OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI and browserless environments.
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class support for `message/stream` via Server-Sent Events.
+- **Multi-modal artifacts** — Agents can yield `text`, `file`, and `data` `AgentEvent`s; the default executor maps each to a `TextPart` / `FilePart` / `DataPart` artifact on the wire.
 - **x402 payments** — Optional `@a2x/sdk/x402` subpath gates agent calls behind on-chain cryptocurrency payments using the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension.
 - **Zero runtime dependencies** — Core module uses only Node.js built-in APIs.
 - **TypeScript-first** — Full type safety with types derived directly from A2A JSON Schema and proto definitions.

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -12,6 +12,7 @@ A self-contained TypeScript SDK for building [A2A (Agent-to-Agent)](https://a2a-
 - **Multi-provider** — Anthropic Claude, OpenAI GPT, and Google Gemini out of the box.
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class `message/stream` support via Server-Sent Events.
+- **Multi-modal artifacts** — Agents can yield `text`, `file`, and `data` events; the default executor maps each into A2A `TextPart` / `FilePart` / `DataPart` artifacts.
 - **Built-in auth** — API Key, Bearer, OAuth 2.0 (Authorization Code, Client Credentials, Device Code), OpenID Connect, and Mutual TLS.
 - **x402 payments** — Charge per call via the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension. On-chain verify + settle through any x402 facilitator.
 - **Zero runtime dependencies** — Core module uses only Node.js built-in APIs.

--- a/packages/a2x/docs/guides/agent/streaming.md
+++ b/packages/a2x/docs/guides/agent/streaming.md
@@ -72,6 +72,53 @@ res.on('close', () => {
 
 See [Framework Integration](./framework-integration.md) for the full per-framework recipe.
 
+## Multi-modal output: file and data artifacts
+
+A2A's wire format already supports non-text parts (`FilePart`, `DataPart`) alongside the familiar `TextPart`. A2X surfaces this on the agent side via three `AgentEvent` data variants — agents that extend `BaseAgent` (or are wrapped by `LlmAgent`) can yield any of them and the executor takes care of the artifact mapping.
+
+```ts
+import { BaseAgent } from '@a2x/sdk';
+import type { AgentEvent } from '@a2x/sdk';
+
+class ImageAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'image_agent' });
+  }
+
+  async *run(): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'Here is your image:', role: 'agent' };
+    yield {
+      type: 'file',
+      file: {
+        url: 'https://cdn.example.com/out.png',
+        mediaType: 'image/png',
+        filename: 'out.png',
+      },
+    };
+    yield {
+      type: 'data',
+      data: { score: 0.92, label: 'cat' },
+      mediaType: 'application/json',
+    };
+    yield { type: 'done' };
+  }
+}
+```
+
+How the default `AgentExecutor` maps each event to a `TaskArtifactUpdateEvent`:
+
+| Event | Mapping |
+|---|---|
+| `text` | Appended to a single text artifact (`artifact-${taskId}-text`). Emitted incrementally with `append: true`, finalized with `lastChunk: true` on `done`. |
+| `file` | A new artifact (`artifact-${taskId}-file-${n}`) carrying a single `FilePart`. Emitted inline with `append: false`, `lastChunk: true`. |
+| `data` | A new artifact (`artifact-${taskId}-data-${n}`) carrying a single `DataPart`. Emitted inline with `append: false`, `lastChunk: true`. |
+
+The "one logical output = one artifact" mapping matches A2A's intuition and lets clients render each non-text result independently. Mixed runs work as expected: text accumulates into a single artifact, while each `file` / `data` event spawns its own.
+
+If you need progressive streaming for a single non-text artifact (e.g. chunked image generation), drop down to a custom `AgentExecutor` and emit `TaskArtifactUpdateEvent`s directly with `append: true`. The `AgentEvent` abstraction intentionally stays simple — one event = one artifact.
+
+> **Note on LLM provider responses.** `LlmAgent` propagates whatever `Part` shapes the configured `LlmProvider` returns. The bundled providers (Anthropic, OpenAI, Google) currently only emit text parts from chat-completion responses; non-text parts are most useful today when you implement a custom `BaseAgent` that calls an image-generation or structured-output API directly.
+
 ## Resuming a dropped SSE stream
 
 If a client loses connection mid-task, it can re-attach via the A2A `tasks/resubscribe` method without restarting the agent. A2X keeps an in-memory **task event bus** that fans events from the original `message/stream` to every live subscriber; a resubscriber catches the tail of the same execution.

--- a/packages/a2x/src/__tests__/agent-event-multimodal.test.ts
+++ b/packages/a2x/src/__tests__/agent-event-multimodal.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent } from '../agent/base-agent.js';
+import type { AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+import { TaskState } from '../types/task.js';
+import type {
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskStatusUpdateEvent,
+} from '../types/task.js';
+import { isFilePart, isDataPart, isTextPart } from '../types/common.js';
+
+// ─── Test agents that yield non-text AgentEvents ───
+
+class FileEmittingAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'file-agent' });
+  }
+
+  async *run(_ctx: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield {
+      type: 'file',
+      file: {
+        url: 'https://example.com/cat.png',
+        mediaType: 'image/png',
+        filename: 'cat.png',
+      },
+    };
+    yield { type: 'done' };
+  }
+}
+
+class DataEmittingAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'data-agent' });
+  }
+
+  async *run(_ctx: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield {
+      type: 'data',
+      data: { score: 0.92, label: 'cat' },
+      mediaType: 'application/json',
+    };
+    yield { type: 'done' };
+  }
+}
+
+class MixedAgent extends BaseAgent {
+  constructor() {
+    super({ name: 'mixed-agent' });
+  }
+
+  async *run(_ctx: InvocationContext): AsyncGenerator<AgentEvent> {
+    yield { type: 'text', text: 'Here is your image:', role: 'agent' };
+    yield {
+      type: 'file',
+      file: { raw: 'base64-bytes-here', mediaType: 'image/png' },
+    };
+    yield { type: 'text', text: ' and structured data:', role: 'agent' };
+    yield { type: 'data', data: { ok: true } };
+    yield { type: 'done' };
+  }
+}
+
+function makeTask(id = 'task-1'): Task {
+  return {
+    id,
+    contextId: `ctx-${id}`,
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  };
+}
+
+function makeExecutor(agent: BaseAgent): AgentExecutor {
+  const runner = new InMemoryRunner({ agent, appName: 'test' });
+  return new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+}
+
+const message = {
+  messageId: 'm-1',
+  role: 'user' as const,
+  parts: [{ text: 'go' }],
+};
+
+// ─── execute() (non-streaming) path ───
+
+describe('AgentExecutor.execute — non-text AgentEvents', () => {
+  it('maps a file event to a FilePart artifact', async () => {
+    const task = await makeExecutor(new FileEmittingAgent()).execute(
+      makeTask(),
+      message,
+    );
+
+    expect(task.status.state).toBe(TaskState.COMPLETED);
+    expect(task.artifacts).toBeDefined();
+    expect(task.artifacts).toHaveLength(1);
+
+    const [part] = task.artifacts![0].parts;
+    expect(isFilePart(part)).toBe(true);
+    if (isFilePart(part)) {
+      expect(part.url).toBe('https://example.com/cat.png');
+      expect(part.mediaType).toBe('image/png');
+      expect(part.filename).toBe('cat.png');
+    }
+  });
+
+  it('maps a data event to a DataPart artifact', async () => {
+    const task = await makeExecutor(new DataEmittingAgent()).execute(
+      makeTask(),
+      message,
+    );
+
+    expect(task.artifacts).toHaveLength(1);
+    const [part] = task.artifacts![0].parts;
+    expect(isDataPart(part)).toBe(true);
+    if (isDataPart(part)) {
+      expect(part.data).toEqual({ score: 0.92, label: 'cat' });
+      expect(part.mediaType).toBe('application/json');
+    }
+  });
+
+  it('produces a separate artifact per non-text event and keeps text accumulated', async () => {
+    const task = await makeExecutor(new MixedAgent()).execute(
+      makeTask(),
+      message,
+    );
+
+    // 1 file + 1 data + 1 accumulated-text = 3 artifacts, each a single part.
+    expect(task.artifacts).toHaveLength(3);
+    expect(task.artifacts!.every((a) => a.parts.length === 1)).toBe(true);
+
+    const partKinds = task.artifacts!.map((a) =>
+      isTextPart(a.parts[0])
+        ? 'text'
+        : isFilePart(a.parts[0])
+          ? 'file'
+          : isDataPart(a.parts[0])
+            ? 'data'
+            : 'unknown',
+    );
+    expect(partKinds.sort()).toEqual(['data', 'file', 'text']);
+
+    // Text artifact concatenates both text events.
+    const textArtifact = task.artifacts!.find(
+      (a) => isTextPart(a.parts[0]),
+    )!;
+    const textPart = textArtifact.parts[0];
+    if (isTextPart(textPart)) {
+      expect(textPart.text).toBe('Here is your image: and structured data:');
+    }
+  });
+});
+
+// ─── executeStream() (SSE) path ───
+
+describe('AgentExecutor.executeStream — non-text AgentEvents', () => {
+  async function collect(
+    stream: AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
+  ): Promise<(TaskStatusUpdateEvent | TaskArtifactUpdateEvent)[]> {
+    const events: (TaskStatusUpdateEvent | TaskArtifactUpdateEvent)[] = [];
+    for await (const e of stream) events.push(e);
+    return events;
+  }
+
+  function isArtifactEvent(
+    e: TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
+  ): e is TaskArtifactUpdateEvent {
+    return 'artifact' in e;
+  }
+
+  it('emits a FilePart artifact update inline (lastChunk=true, append=false)', async () => {
+    const task = makeTask();
+    const events = await collect(
+      makeExecutor(new FileEmittingAgent()).executeStream(task, message),
+    );
+
+    const artifactEvents = events.filter(isArtifactEvent);
+    expect(artifactEvents).toHaveLength(1);
+    const fileEvent = artifactEvents[0];
+    expect(fileEvent.append).toBe(false);
+    expect(fileEvent.lastChunk).toBe(true);
+
+    const [part] = fileEvent.artifact.parts;
+    expect(isFilePart(part)).toBe(true);
+
+    // Final task object should reflect the artifact too.
+    expect(task.artifacts).toHaveLength(1);
+  });
+
+  it('emits a DataPart artifact update inline', async () => {
+    const task = makeTask();
+    const events = await collect(
+      makeExecutor(new DataEmittingAgent()).executeStream(task, message),
+    );
+
+    const artifactEvents = events.filter(isArtifactEvent);
+    expect(artifactEvents).toHaveLength(1);
+    const part = artifactEvents[0].artifact.parts[0];
+    expect(isDataPart(part)).toBe(true);
+    if (isDataPart(part)) {
+      expect(part.data).toEqual({ score: 0.92, label: 'cat' });
+    }
+  });
+
+  it('streams text incrementally and file/data as their own artifacts', async () => {
+    const task = makeTask();
+    const events = await collect(
+      makeExecutor(new MixedAgent()).executeStream(task, message),
+    );
+
+    const artifactEvents = events.filter(isArtifactEvent);
+
+    // 2 text chunk updates (append=true) + 1 file + 1 data + 1 final text (append=false)
+    expect(artifactEvents).toHaveLength(5);
+
+    const appendUpdates = artifactEvents.filter((e) => e.append === true);
+    expect(appendUpdates).toHaveLength(2);
+    expect(appendUpdates.every((e) => isTextPart(e.artifact.parts[0]))).toBe(
+      true,
+    );
+
+    const finalUpdates = artifactEvents.filter((e) => e.append === false);
+    expect(finalUpdates).toHaveLength(3);
+
+    // Final artifact set on task: 1 file + 1 data + 1 text = 3 artifacts.
+    expect(task.artifacts).toHaveLength(3);
+  });
+
+  it('uses distinct artifactIds for multiple non-text events in a single run', async () => {
+    class MultiFileAgent extends BaseAgent {
+      constructor() {
+        super({ name: 'multi-file' });
+      }
+      async *run(): AsyncGenerator<AgentEvent> {
+        yield { type: 'file', file: { url: 'a.png' } };
+        yield { type: 'file', file: { url: 'b.png' } };
+        yield { type: 'done' };
+      }
+    }
+
+    const task = makeTask();
+    const events = await collect(
+      makeExecutor(new MultiFileAgent()).executeStream(task, message),
+    );
+
+    const artifactIds = events
+      .filter(isArtifactEvent)
+      .map((e) => e.artifact.artifactId);
+    expect(new Set(artifactIds).size).toBe(artifactIds.length);
+  });
+});

--- a/packages/a2x/src/a2x/agent-executor.ts
+++ b/packages/a2x/src/a2x/agent-executor.ts
@@ -60,6 +60,7 @@ export class AgentExecutor {
 
     const artifacts: Artifact[] = [];
     const textParts: string[] = [];
+    let nonTextSeq = 0;
     let completedNormally = false;
 
     try {
@@ -68,11 +69,28 @@ export class AgentExecutor {
           case 'text':
             textParts.push(event.text);
             break;
+          case 'file':
+            artifacts.push({
+              artifactId: `artifact-${task.id}-file-${++nonTextSeq}`,
+              parts: [{ ...event.file }],
+            });
+            break;
+          case 'data':
+            artifacts.push({
+              artifactId: `artifact-${task.id}-data-${++nonTextSeq}`,
+              parts: [
+                {
+                  data: event.data,
+                  ...(event.mediaType ? { mediaType: event.mediaType } : {}),
+                },
+              ],
+            });
+            break;
           case 'done':
-            // Collect text parts into an artifact
+            // Collect accumulated text into an artifact (if any).
             if (textParts.length > 0) {
               artifacts.push({
-                artifactId: `artifact-${Date.now()}`,
+                artifactId: `artifact-${task.id}-text`,
                 parts: [{ text: textParts.join('') }],
               });
             }
@@ -163,6 +181,8 @@ export class AgentExecutor {
 
     try {
       const textParts: string[] = [];
+      const nonTextArtifacts: Artifact[] = [];
+      let nonTextSeq = 0;
 
       for await (const event of this.runner.runAsync(session, message, abortController.signal)) {
         switch (event.type) {
@@ -173,7 +193,7 @@ export class AgentExecutor {
               taskId: task.id,
               contextId,
               artifact: {
-                artifactId: `artifact-${task.id}`,
+                artifactId: `artifact-${task.id}-text`,
                 parts: [{ text: event.text }],
               },
               append: true,
@@ -181,14 +201,53 @@ export class AgentExecutor {
             } satisfies TaskArtifactUpdateEvent;
             break;
 
+          case 'file': {
+            const artifact: Artifact = {
+              artifactId: `artifact-${task.id}-file-${++nonTextSeq}`,
+              parts: [{ ...event.file }],
+            };
+            nonTextArtifacts.push(artifact);
+            yield {
+              taskId: task.id,
+              contextId,
+              artifact,
+              append: false,
+              lastChunk: true,
+            } satisfies TaskArtifactUpdateEvent;
+            break;
+          }
+
+          case 'data': {
+            const artifact: Artifact = {
+              artifactId: `artifact-${task.id}-data-${++nonTextSeq}`,
+              parts: [
+                {
+                  data: event.data,
+                  ...(event.mediaType ? { mediaType: event.mediaType } : {}),
+                },
+              ],
+            };
+            nonTextArtifacts.push(artifact);
+            yield {
+              taskId: task.id,
+              contextId,
+              artifact,
+              append: false,
+              lastChunk: true,
+            } satisfies TaskArtifactUpdateEvent;
+            break;
+          }
+
           case 'done': {
-            // Emit final artifact chunk if there was text
+            const finalArtifacts: Artifact[] = [...nonTextArtifacts];
+
+            // Emit final text artifact chunk if there was text
             if (textParts.length > 0) {
               const artifact: Artifact = {
-                artifactId: `artifact-${task.id}`,
+                artifactId: `artifact-${task.id}-text`,
                 parts: [{ text: textParts.join('') }],
               };
-              task.artifacts = [artifact];
+              finalArtifacts.push(artifact);
               yield {
                 taskId: task.id,
                 contextId,
@@ -196,6 +255,10 @@ export class AgentExecutor {
                 append: false,
                 lastChunk: true,
               } satisfies TaskArtifactUpdateEvent;
+            }
+
+            if (finalArtifacts.length > 0) {
+              task.artifacts = finalArtifacts;
             }
 
             // Emit completed status

--- a/packages/a2x/src/agent/base-agent.ts
+++ b/packages/a2x/src/agent/base-agent.ts
@@ -7,7 +7,12 @@ import type { InvocationContext } from '../runner/context.js';
 // ─── AgentEvent (events yielded by agents to the Runner) ───
 
 export type AgentEvent =
-  | { type: 'text'; text: string; role?: 'user' | 'agent' }
+  | { type: 'text'; text: string; role?: 'user' | 'agent'; mediaType?: string }
+  | {
+    type: 'file';
+    file: { raw?: string; url?: string; mediaType?: string; filename?: string };
+  }
+  | { type: 'data'; data: unknown; mediaType?: string }
   | { type: 'toolCall'; toolName: string; args: Record<string, unknown>; toolCallId?: string }
   | { type: 'toolResult'; toolName: string; result: unknown; toolCallId?: string }
   | { type: 'done'; output?: unknown }

--- a/packages/a2x/src/agent/llm-agent.ts
+++ b/packages/a2x/src/agent/llm-agent.ts
@@ -11,8 +11,8 @@ import type {
   ModelResponse,
   ToolDeclaration,
 } from './llm-provider.js';
-import type { Part, Message } from '../types/common.js';
-import { isTextPart } from '../types/common.js';
+import type { Part, Message, FilePart, DataPart } from '../types/common.js';
+import { isTextPart, isFilePart, isDataPart } from '../types/common.js';
 import { BaseAgent } from './base-agent.js';
 import type { AgentEvent } from './base-agent.js';
 import { eventsToContents } from '../runner/event-history.js';
@@ -278,11 +278,43 @@ export class LlmAgent extends BaseAgent {
         return;
       }
 
-      // 5. Yield text content
+      // 5. Yield content parts. Text/file/data are emitted as discrete
+      // AgentEvents so multi-modal LLMs (image gen, structured output, …)
+      // can stay on the BaseAgent path. Non-text parts are still kept out of
+      // the LLM conversation history below — that history remains text-only.
       const textParts = response.content.filter(isTextPart);
-      for (const part of textParts) {
-        if (part.text) {
-          yield { type: 'text', text: part.text, role: 'agent' };
+      for (const part of response.content) {
+        if (isTextPart(part)) {
+          if (part.text) {
+            yield {
+              type: 'text',
+              text: part.text,
+              role: 'agent',
+              ...(part.mediaType ? { mediaType: part.mediaType } : {}),
+            };
+          }
+        } else if (isFilePart(part)) {
+          const filePart = part as FilePart;
+          yield {
+            type: 'file',
+            file: {
+              ...(filePart.raw !== undefined ? { raw: filePart.raw } : {}),
+              ...(filePart.url !== undefined ? { url: filePart.url } : {}),
+              ...(filePart.mediaType !== undefined
+                ? { mediaType: filePart.mediaType }
+                : {}),
+              ...(filePart.filename !== undefined
+                ? { filename: filePart.filename }
+                : {}),
+            },
+          };
+        } else if (isDataPart(part)) {
+          const dataPart = part as DataPart;
+          yield {
+            type: 'data',
+            data: dataPart.data,
+            ...(dataPart.mediaType ? { mediaType: dataPart.mediaType } : {}),
+          };
         }
       }
 


### PR DESCRIPTION
Closes #148.

## Summary

- Add `{ type: 'file', file: {...} }` and `{ type: 'data', data, mediaType? }` variants to `AgentEvent`. `text` gains an optional `mediaType` field.
- The default `AgentExecutor` (`execute()` + `executeStream()`) maps each non-text event to its own artifact with a unique `artifactId`. Text events keep their existing accumulation behavior (single text artifact per task, append-mode chunks during streaming).
- `LlmAgent.run()` no longer filters non-text parts out of the LLM response — they're yielded as `file` / `data` events.

## Why

A2A v0.3 already defines `FilePart` and `DataPart` on the wire, and the SDK's internal `Part` union has matched that since day one. The bottleneck was `AgentEvent`: it only had a `text` data variant, so the default executor silently dropped everything else and multi-modal agents (image generation, structured output, document creation, …) had to abandon the `BaseAgent` path and emit raw `TaskArtifactUpdateEvent`s from a custom `AgentExecutor` — leaking A2A protocol details into agent code and defeating one of a2x's stated value props.

This PR widens that bottleneck. Input (LLM provider boundary) and output (wire) were already multi-modal; only the middle abstraction needed to grow.

## Design choices

These map to the open questions in the issue:

1. **One artifact per non-text event.** Each `file` / `data` event creates a fresh artifact (`artifact-${taskId}-file-${n}` / `artifact-${taskId}-data-${n}`) rather than accumulating into a single multi-part artifact. Matches A2A's "artifact = one logical output" intuition and keeps incremental client rendering simple. Text accumulation behavior is unchanged.
2. **No `lastChunk` / `asNewArtifact` flags on `AgentEvent` yet.** Progressive streaming for a single non-text artifact is left as a `AgentExecutor` subclassing concern. Keeping the abstraction small.
3. **Discriminator stays `type:`** for consistency with the existing `AgentEvent` union.

## Compatibility

Additive on the wire — clients receive standard A2A v0.3 `FilePart` / `DataPart` artifacts, which `A2XClient` and `response-parser` already supported (`normalizeV03Part` was in place from the start). Existing text-only agents and clients continue to work unchanged.

The one caveat: TypeScript users with an exhaustive `switch (event.type)` over `AgentEvent` (no `default:`) will need to add `case 'file'` / `case 'data'` arms after this lands. Called out in the changeset.

## Out of scope

The bundled provider converters (Anthropic / OpenAI / Google) currently only emit text blocks from chat-completion responses — they have a symmetric `isTextPart` filter on the response side. Updating them to surface non-text response blocks (e.g. when image-output models become first-class on the chat-completion API) is a separate domain and a separate PR.

## Test plan

- [x] `pnpm test` — 483 tests pass, including 7 new tests in `agent-event-multimodal.test.ts` covering the `execute()` and `executeStream()` paths for `file`, `data`, and mixed text+file+data runs.
- [x] `pnpm typecheck` — clean across all 4 workspace projects.
- [x] `pnpm lint` — clean.
- [x] `pnpm -r build` — clean across `@a2x/sdk`, `@a2x/cli`, and both Next.js samples.

## Docs

- New "Multi-modal output: file and data artifacts" section in `packages/a2x/docs/guides/agent/streaming.md` covering the three data variants, the artifact mapping, and a note about LLM provider response surfaces.
- "Multi-modal artifacts" feature bullet added to both READMEs (root and `packages/a2x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)