### PR TITLE
refactor(sdk): consolidate x402 to @a2x/sdk root, drop subpath

### DIFF
--- a/.changeset/track-2-x402-path-consolidation.md
+++ b/.changeset/track-2-x402-path-consolidation.md
@@ -1,0 +1,5 @@
+---
+"@a2x/sdk": patch
+---
+
+Remove the redundant `@a2x/sdk/x402` subpath. All x402 symbols (`X402_EXTENSION_URI`, `x402RequestPayment`, `x402PaymentHook`, `readX402Settlement`, `signX402Payment`, `rejectX402Payment`, `getX402Receipts`, `getX402PaymentRequirements`, `getX402Status`, `X402_DOMAIN`, `resolveFacilitator`, `X402_DEFAULT_FACILITATOR_URL`, `X402PaymentRequiredError`, and the rest) remain available from the package root `@a2x/sdk` — only the duplicate subpath import is gone. Migration: replace `from '@a2x/sdk/x402'` with `from '@a2x/sdk'`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @a2x/sdk
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
 - **SSE streaming** — First-class support for `message/stream` via Server-Sent Events.
 - **Multi-modal artifacts** — Agents can yield `text`, `file`, and `data` `AgentEvent`s; the default executor maps each to a `TextPart` / `FilePart` / `DataPart` artifact on the wire.
-- **x402 payments** — Charge per call with on-chain cryptocurrency payments — declared inline in `agent.run()` via the `request-input` AgentEvent. Optional `@a2x/sdk/x402` subpath; uses the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension.
+- **x402 payments** — Charge per call with on-chain cryptocurrency payments — declared inline in `agent.run()` via the `request-input` AgentEvent. Uses the [a2a-x402 v0.2](https://github.com/google-agentic-commerce/a2a-x402) extension.
 - **Zero runtime dependencies** — Core module uses only Node.js built-in APIs.
 - **TypeScript-first** — Full type safety with types derived directly from A2A JSON Schema and proto definitions.
 

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -403,7 +403,6 @@ a2xAgentV03.getAgentCard(); // v0.3 card
 | `@a2x/sdk/anthropic` | `AnthropicProvider` |
 | `@a2x/sdk/openai` | `OpenAIProvider` |
 | `@a2x/sdk/google` | `GoogleProvider` |
-| `@a2x/sdk/x402` | a2a-x402 v0.2 payments (server + client) |
 
 ## Requirements
 

--- a/packages/a2x/docs/guides/advanced/extensions.md
+++ b/packages/a2x/docs/guides/advanced/extensions.md
@@ -83,7 +83,7 @@ class SensitiveAgent extends BaseAgent {
 }
 ```
 
-You can register a hook on the executor (`inputRoundTripHooks: [...]`) to centralize verification logic — see how `x402PaymentHook()` does verify+settle in `@a2x/sdk/x402` for the canonical pattern. Or, like the snippet above, inspect `context.input.resumeMetadata` directly when no out-of-band verification is needed. Either way the SDK core stays out of your extension's wire format.
+You can register a hook on the executor (`inputRoundTripHooks: [...]`) to centralize verification logic — see how `x402PaymentHook()` does verify+settle in `@a2x/sdk` for the canonical pattern. Or, like the snippet above, inspect `context.input.resumeMetadata` directly when no out-of-band verification is needed. Either way the SDK core stays out of your extension's wire format.
 
 ## When not to use extensions
 

--- a/packages/a2x/docs/guides/advanced/manual-wiring.md
+++ b/packages/a2x/docs/guides/advanced/manual-wiring.md
@@ -153,7 +153,7 @@ Most capability flags on the AgentCard are derived automatically:
 Two capabilities need explicit builder calls — both are append-only / boolean:
 
 ```ts
-import { X402_EXTENSION_URI } from '@a2x/sdk/x402';
+import { X402_EXTENSION_URI } from '@a2x/sdk';
 
 a2xAgent
   .addExtension({ uri: X402_EXTENSION_URI, required: true })

--- a/packages/a2x/docs/guides/advanced/migration-x402-v2.md
+++ b/packages/a2x/docs/guides/advanced/migration-x402-v2.md
@@ -7,7 +7,7 @@ This guide is for projects on `@a2x/sdk` 0.x that use `X402PaymentExecutor`. SDK
 | Item | 0.x | 1.x |
 |---|---|---|
 | Removed | `X402PaymentExecutor`, `X402PaymentExecutorOptions` | — |
-| Added | — | `request-input` AgentEvent variant; `x402RequestPayment()`, `x402PaymentHook()`, `readX402Settlement()`, `X402_DOMAIN` (all from `@a2x/sdk` and `@a2x/sdk/x402`) |
+| Added | — | `request-input` AgentEvent variant; `x402RequestPayment()`, `x402PaymentHook()`, `readX402Settlement()`, `X402_DOMAIN` (all from `@a2x/sdk`) |
 | Where the "is this call paid?" predicate lives | Executor option `requiresPayment` | Inside `agent.run()` |
 | Number of `extends` lines for x402 | 1 (`extends AgentExecutor` in custom case) | 0 |
 | Wire metadata keys, status values, error codes | unchanged | unchanged |

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -314,7 +314,7 @@ import { A2XClient } from '@a2x/sdk/client';
 import {
   signX402Payment,
   getX402PaymentRequirements,
-} from '@a2x/sdk/x402';
+} from '@a2x/sdk';
 
 const client = new A2XClient(url, {
   extensions: [X402_EXTENSION_URI], // still required for header activation
@@ -353,7 +353,7 @@ const signed = await signX402Payment(first, {
 Declining a payment manually — produces the metadata block to attach to a follow-up `message/send` call so the merchant terminates the task per spec §5.4.2 instead of leaving it stranded in `input-required`:
 
 ```ts
-import { rejectX402Payment } from '@a2x/sdk/x402';
+import { rejectX402Payment } from '@a2x/sdk';
 
 const rejection = rejectX402Payment(first);
 await client.sendMessage({
@@ -370,7 +370,7 @@ await client.sendMessage({
 ### Reading receipts
 
 ```ts
-import { getX402Receipts } from '@a2x/sdk/x402';
+import { getX402Receipts } from '@a2x/sdk';
 
 const receipts = getX402Receipts(task);
 for (const receipt of receipts) {

--- a/packages/a2x/package.json
+++ b/packages/a2x/package.json
@@ -38,11 +38,6 @@
       "types": "./dist/provider/google/index.d.ts",
       "import": "./dist/provider/google/index.js",
       "require": "./dist/provider/google/index.cjs"
-    },
-    "./x402": {
-      "types": "./dist/x402/index.d.ts",
-      "import": "./dist/x402/index.js",
-      "require": "./dist/x402/index.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/a2x/src/agent/base-agent.ts
+++ b/packages/a2x/src/agent/base-agent.ts
@@ -28,7 +28,7 @@ export type AgentEvent =
     /**
      * Domain key the SDK uses to look up a registered hook (verify/settle
      * etc.). For x402 this is the canonical `'x402'` literal exported from
-     * `@a2x/sdk/x402`. Custom domains supply their own.
+     * `@a2x/sdk`. Custom domains supply their own.
      */
     domain: string;
     /**

--- a/packages/a2x/src/index.ts
+++ b/packages/a2x/src/index.ts
@@ -61,8 +61,8 @@ export * from './client/index.js';
 // Remote
 export * from './remote/index.js';
 
-// x402 (a2a-x402 v0.2 payment support). Also available via the dedicated
-// `@a2x/sdk/x402` subpath for callers who want to isolate the payment
-// module; we re-export from the main entry so the types share nominal
-// identity across subpaths.
+// x402 (a2a-x402 v0.2 payment support). Imported from the package root —
+// types share nominal identity with the rest of the public surface and
+// modern bundlers tree-shake unused symbols when `viem` / `x402` peer deps
+// are absent.
 export * from './x402/index.js';

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@a2x/sdk/x402` — a2a-x402 v0.2 payment support.
+ * x402 — a2a-x402 v0.2 payment support, imported from `@a2x/sdk`.
  *
  * Adds on-chain payment gating to A2A agents using the Coinbase x402
  * protocol. See `specification/a2a-x402-v0.2.md` for the wire format.

--- a/packages/a2x/tsup.config.ts
+++ b/packages/a2x/tsup.config.ts
@@ -19,7 +19,6 @@ export default defineConfig([
       'provider/anthropic/index': 'src/provider/anthropic/index.ts',
       'provider/openai/index': 'src/provider/openai/index.ts',
       'provider/google/index': 'src/provider/google/index.ts',
-      'x402/index': 'src/x402/index.ts',
     },
     format: ['esm', 'cjs'],
     dts: true,


### PR DESCRIPTION
## Summary

Tracks **Track 2** of issue #156 (pre-1.0 public surface cleanup). Picks **root-only** as the canonical x402 import path and removes the redundant \`@a2x/sdk/x402\` subpath.

- Drops \`./x402\` from \`package.json#exports\` and the matching \`tsup\` entry. All x402 symbols remain exported from \`@a2x/sdk\`.
- Updates four guides (\`x402-payments.md\`, \`manual-wiring.md\`, \`extensions.md\`, \`migration-x402-v2.md\`), the package README's Exports table, the root README's x402 bullet, and two source-side JSDoc references that named the now-removed subpath.
- Patch-level changeset added with migration instruction (\`from '@a2x/sdk/x402'\` → \`from '@a2x/sdk'\`).

Rationale (Option A from the issue): the codebase's existing \`client\` / \`provider/*\` subpaths are also dual-exported from root, so root-only matches established convention. README, quickstart, and most samples already imported x402 from \`@a2x/sdk\` — the diff impact falls on the few doc sites that used the subpath. Tree-shaking is preserved by ESM \`export *\` on modern bundlers; \`viem\` and \`x402\` peer deps remain optional and uninstalled when not used.

## Test plan

- [x] \`pnpm -r build\` clean (including all samples)
- [x] \`pnpm typecheck\` clean (workspace + samples)
- [x] \`pnpm test\` clean (498 passed)
- [x] \`pnpm lint\` clean
- [x] Repo-wide grep for \`@a2x/sdk/x402\` returns nothing in source/docs/READMEs (only the migration line in the new changeset and historical CHANGELOG entries remain — both intentional)
- [x] \`dist/\` contains no \`x402/\` subdir post-build
- [x] Importing \`X402_EXTENSION_URI\`, \`x402RequestPayment\`, \`x402PaymentHook\`, \`readX402Settlement\`, \`signX402Payment\`, \`X402_DOMAIN\` from \`@a2x/sdk\` resolves
- [x] Subpath \`@a2x/sdk/x402\` no longer resolves (\`ERR_MODULE_NOT_FOUND\`)

Tracks 1 (Phase-2/3 stub modules) and 3 (server/client auth naming asymmetry) of #156 will land in separate PRs.