### PR TITLE
fix(sdk): expose taskId and contextId on InvocationContext

### DIFF
--- a/.changeset/fix-expose-task-context-id-invocation-context.md
+++ b/.changeset/fix-expose-task-context-id-invocation-context.md
@@ -1,0 +1,40 @@
+---
+'@a2x/sdk': patch
+---
+
+`InvocationContext` now exposes `taskId` and `contextId` so agent code
+has a stable per-task identifier to bind durable state to.
+
+Closes [#158](https://github.com/planetarium/a2x/issues/158).
+
+**Why.** The default `AgentExecutor` creates a fresh `Session` on every
+invocation (`runner.createSession()` runs on both the first turn and
+each resume turn), so `context.session.id` was a per-invocation UUID,
+not a per-task one. Agents that stored `task_id = context.session.id`
+on the `request-input` turn (e.g. an x402 payment intent row) saw a
+different `session.id` on the resume turn and could not recover the
+record. The A2A wire protocol's `Task.id` (and `contextId`) was the
+right identifier all along, but it wasn't surfaced on the agent's
+context.
+
+**What's new.**
+
+- `InvocationContext` gains two optional fields, set by the default
+  `AgentExecutor`:
+  - `taskId` — the A2A `Task.id`, stable across `request-input` →
+    resume turns of the same task.
+  - `contextId` — the A2A `contextId`, stable across every task in
+    the same conversation (1:N with `taskId`).
+- `Runner.runAsync()` accepts an optional fourth `taskScope`
+  argument carrying these identifiers. The default `AgentExecutor`
+  passes `{ taskId: task.id, contextId: task.contextId ?? task.id }`
+  on both `execute()` and `executeStream()` paths.
+- Agent authors should bind per-task durable state to
+  `context.taskId` (not `context.session.id`). `session.id` keeps its
+  existing per-invocation lifecycle and is intentionally unchanged.
+
+**Compatibility.** Additive on every public surface. Existing agents
+that read `context.session.id` continue to compile and run; the bug
+they hit (re-binding state across resume) is what this change fixes.
+Standalone `Runner` callers that don't go through the `AgentExecutor`
+leave `taskId` / `contextId` undefined, same as before.

--- a/packages/a2x/docs/guides/agent/build-an-agent.md
+++ b/packages/a2x/docs/guides/agent/build-an-agent.md
@@ -66,6 +66,28 @@ The `instruction` field is where most of your agent's behavior lives. A few prac
 - **Tell the model how to handle unknowns.** "If you don't know, say so" prevents hallucination more reliably than "be accurate".
 - **Keep tool usage hints here, not in the tool definitions.** "Always call `get_weather` before guessing a temperature" belongs in the instruction; the tool's own `description` should just describe the tool.
 
+## What the agent receives: `InvocationContext`
+
+Custom agents that extend `BaseAgent` directly are handed an `InvocationContext` on every turn:
+
+```ts
+class MyAgent extends BaseAgent {
+  async *run(context: InvocationContext): AsyncGenerator<AgentEvent> { /* … */ }
+}
+```
+
+The fields that matter most for everyday agent code:
+
+| Field | Use it for |
+|---|---|
+| `context.taskId` | The A2A `Task.id` of the current turn (wire-protocol identifier). **Stable across `request-input` → resume.** Bind per-task durable state (paid rows, approval tokens, …) to this — not to `session.id`. |
+| `context.contextId` | The A2A `contextId` of the current turn. One `contextId` umbrellas many tasks in the same conversation (1:N), so this is the right key for state that should outlive a single task but stay scoped to one conversation. |
+| `context.input` | Populated only on resume turns of a task that previously emitted `request-input`. Carries the prior turn's record and (optionally) a hook outcome. See [Protocol Extensions](../advanced/extensions.md). |
+| `context.session` | The runner's per-invocation `Session`. `session.id` is **regenerated on every turn** and is not safe to bind per-task state to — use `taskId` / `contextId` instead. |
+| `context.signal` | `AbortSignal` for the run. Listen if you do anything cancellable (e.g. external HTTP). |
+
+`taskId` and `contextId` are set by the default `AgentExecutor` whenever the agent is dispatched under an A2A task; they are `undefined` only when the `Runner` is invoked standalone, with no enclosing A2A task.
+
 ## AgentEvent variants
 
 Custom agents that extend `BaseAgent` directly express their output by yielding `AgentEvent`s. The default `AgentExecutor` knows how to map each variant onto an A2A artifact or task status update.

--- a/packages/a2x/src/__tests__/invocation-context-task-id.test.ts
+++ b/packages/a2x/src/__tests__/invocation-context-task-id.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for issue #158: `InvocationContext` must expose the
+ * A2A wire identifiers (`taskId` / `contextId`) and they must be stable
+ * across the `request-input` → resume cycle. The per-invocation
+ * `session.id` is not safe to bind durable per-task state to.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../types/common.js';
+import { TaskState, type Task } from '../types/task.js';
+import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
+import { InMemoryRunner } from '../runner/in-memory-runner.js';
+import { BaseAgent, type AgentEvent } from '../agent/base-agent.js';
+import type { InvocationContext } from '../runner/context.js';
+
+function newTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 't1',
+    contextId: 'c1',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+    ...overrides,
+  };
+}
+
+function newMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    messageId: 'm1',
+    role: 'user',
+    parts: [{ text: 'hi' }],
+    ...overrides,
+  };
+}
+
+/**
+ * Records every InvocationContext observed across runs so the test can
+ * assert taskId/contextId stability across the request-input → resume
+ * boundary.
+ */
+class IdentityRecordingAgent extends BaseAgent {
+  observations: Array<{
+    taskId: string | undefined;
+    contextId: string | undefined;
+    sessionId: string;
+  }> = [];
+
+  async *run(context: InvocationContext): AsyncGenerator<AgentEvent> {
+    this.observations.push({
+      taskId: context.taskId,
+      contextId: context.contextId,
+      sessionId: context.session.id,
+    });
+
+    if (!context.input) {
+      yield {
+        type: 'request-input',
+        domain: 'test.identity',
+        metadata: { 'test.identity.required': true },
+        payload: { foo: 'bar' },
+      };
+      return;
+    }
+
+    yield { type: 'text', role: 'agent', text: 'ok' };
+    yield { type: 'done' };
+  }
+}
+
+function makeExecutor(): {
+  agent: IdentityRecordingAgent;
+  executor: AgentExecutor;
+} {
+  const agent = new IdentityRecordingAgent({ name: 'identity-recorder' });
+  const runner = new InMemoryRunner({ agent, appName: 'identity-test' });
+  const executor = new AgentExecutor({
+    runner,
+    runConfig: { streamingMode: StreamingMode.SSE },
+  });
+  return { agent, executor };
+}
+
+describe('InvocationContext task/context identity (issue #158)', () => {
+  it('exposes task.id and task.contextId on the first turn (execute)', async () => {
+    const { agent, executor } = makeExecutor();
+    await executor.execute(newTask(), newMessage());
+
+    expect(agent.observations).toHaveLength(1);
+    expect(agent.observations[0]!.taskId).toBe('t1');
+    expect(agent.observations[0]!.contextId).toBe('c1');
+  });
+
+  it('exposes task.id and task.contextId on the first turn (executeStream)', async () => {
+    const { agent, executor } = makeExecutor();
+    for await (const _ of executor.executeStream(newTask(), newMessage())) {
+      // drain
+    }
+
+    expect(agent.observations).toHaveLength(1);
+    expect(agent.observations[0]!.taskId).toBe('t1');
+    expect(agent.observations[0]!.contextId).toBe('c1');
+  });
+
+  it('keeps taskId and contextId stable across request-input → resume (execute)', async () => {
+    const { agent, executor } = makeExecutor();
+
+    const first = await executor.execute(newTask(), newMessage());
+    expect(first.status.state).toBe(TaskState.INPUT_REQUIRED);
+
+    const completed = await executor.execute(
+      first,
+      newMessage({
+        messageId: 'm2',
+        metadata: { 'test.identity.granted': true },
+      }),
+    );
+    expect(completed.status.state).toBe(TaskState.COMPLETED);
+
+    expect(agent.observations).toHaveLength(2);
+    const [firstObs, resumeObs] = agent.observations;
+
+    // The wire identifiers must be stable: same A2A task, same contextId.
+    expect(resumeObs!.taskId).toBe(firstObs!.taskId);
+    expect(resumeObs!.contextId).toBe(firstObs!.contextId);
+    expect(resumeObs!.taskId).toBe('t1');
+    expect(resumeObs!.contextId).toBe('c1');
+
+    // Session id is per-invocation (intentionally), so agents must not
+    // bind durable per-task state to it.
+    expect(resumeObs!.sessionId).not.toBe(firstObs!.sessionId);
+  });
+
+  it('keeps taskId and contextId stable across request-input → resume (executeStream)', async () => {
+    const { agent, executor } = makeExecutor();
+
+    const first = newTask();
+    for await (const _ of executor.executeStream(first, newMessage())) {
+      // drain
+    }
+    expect(first.status.state).toBe(TaskState.INPUT_REQUIRED);
+
+    for await (const _ of executor.executeStream(
+      first,
+      newMessage({
+        messageId: 'm2',
+        metadata: { 'test.identity.granted': true },
+      }),
+    )) {
+      // drain
+    }
+    expect(first.status.state).toBe(TaskState.COMPLETED);
+
+    expect(agent.observations).toHaveLength(2);
+    const [firstObs, resumeObs] = agent.observations;
+
+    expect(resumeObs!.taskId).toBe(firstObs!.taskId);
+    expect(resumeObs!.contextId).toBe(firstObs!.contextId);
+    expect(resumeObs!.taskId).toBe('t1');
+    expect(resumeObs!.contextId).toBe('c1');
+    expect(resumeObs!.sessionId).not.toBe(firstObs!.sessionId);
+  });
+
+  it('falls back to task.id for contextId when task.contextId is unset', async () => {
+    const { agent, executor } = makeExecutor();
+    const task: Task = {
+      id: 'only-task-id',
+      status: {
+        state: TaskState.SUBMITTED,
+        timestamp: new Date().toISOString(),
+      },
+    };
+    await executor.execute(task, newMessage());
+
+    expect(agent.observations[0]!.taskId).toBe('only-task-id');
+    expect(agent.observations[0]!.contextId).toBe('only-task-id');
+  });
+
+  it('leaves taskId/contextId undefined when the Runner is used standalone (no enclosing A2A task)', async () => {
+    const agent = new IdentityRecordingAgent({ name: 'standalone' });
+    const runner = new InMemoryRunner({ agent, appName: 'standalone-test' });
+    const session = await runner.createSession();
+
+    for await (const _ of runner.runAsync(session, newMessage())) {
+      // drain
+    }
+
+    expect(agent.observations).toHaveLength(1);
+    expect(agent.observations[0]!.taskId).toBeUndefined();
+    expect(agent.observations[0]!.contextId).toBeUndefined();
+  });
+});

--- a/packages/a2x/src/a2x/agent-executor.ts
+++ b/packages/a2x/src/a2x/agent-executor.ts
@@ -95,6 +95,8 @@ export class AgentExecutor {
    * Returns the completed Task.
    */
   async execute(task: Task, message: Message): Promise<Task> {
+    const contextId = task.contextId ?? task.id;
+
     // Detect a resume turn by reading the round-trip record off the task's
     // status message metadata. Persisted by the prior turn's
     // applyInputRequired() call.
@@ -176,7 +178,10 @@ export class AgentExecutor {
     let inputRequested = false;
 
     try {
-      for await (const event of this.runner.runAsync(session, message, abortController.signal)) {
+      for await (const event of this.runner.runAsync(session, message, abortController.signal, {
+        taskId: task.id,
+        contextId,
+      })) {
         switch (event.type) {
           case 'text':
             textParts.push(event.text);
@@ -403,7 +408,10 @@ export class AgentExecutor {
       const nonTextArtifacts: Artifact[] = [];
       let nonTextSeq = 0;
 
-      for await (const event of this.runner.runAsync(session, message, abortController.signal)) {
+      for await (const event of this.runner.runAsync(session, message, abortController.signal, {
+        taskId: task.id,
+        contextId,
+      })) {
         switch (event.type) {
           case 'text':
             textParts.push(event.text);

--- a/packages/a2x/src/runner/context.ts
+++ b/packages/a2x/src/runner/context.ts
@@ -28,6 +28,27 @@ export interface InvocationContext {
   maxLlmCalls?: number;
   signal?: AbortSignal;
   /**
+   * A2A `Task.id` of the current turn (wire-protocol identifier). Stable
+   * across the `request-input` → resume cycle: the first turn and every
+   * resume turn of the same task see the same value. Set by the default
+   * `AgentExecutor` when dispatching under an A2A task; undefined when
+   * the Runner is used standalone (no enclosing A2A task).
+   *
+   * Prefer this over `session.id` for scoping per-task durable state
+   * (paid rows, approval tokens, …) — `session.id` is regenerated on
+   * every invocation and is not safe to bind state to across turns.
+   */
+  taskId?: string;
+  /**
+   * A2A `contextId` of the current turn (wire-protocol identifier). One
+   * `contextId` umbrellas many tasks in the same conversation (1:N), so
+   * this is the right key for state that should outlive a single task
+   * but stay scoped to one conversation. Set by the default
+   * `AgentExecutor` when dispatching under an A2A task; undefined when
+   * the Runner is used standalone.
+   */
+  contextId?: string;
+  /**
    * Populated only on resume turns of a task that previously emitted a
    * `request-input` AgentEvent. Carries (a) the `InputRoundTripRecord`
    * the agent emitted on the prior turn, (b) the optional outcome a

--- a/packages/a2x/src/runner/runner.ts
+++ b/packages/a2x/src/runner/runner.ts
@@ -37,8 +37,19 @@ export class Runner {
 
   /**
    * Run the agent asynchronously, yielding AgentEvents.
+   *
+   * `taskScope` carries the wire-protocol identifiers of the enclosing
+   * A2A task (set by the default `AgentExecutor`); when present they
+   * surface on `InvocationContext.taskId` / `contextId` so agent code
+   * can scope durable state to the A2A task instead of the
+   * per-invocation `session.id`.
    */
-  async *runAsync(session: Session, message: Message, signal?: AbortSignal): AsyncGenerator<AgentEvent> {
+  async *runAsync(
+    session: Session,
+    message: Message,
+    signal?: AbortSignal,
+    taskScope?: { taskId?: string; contextId?: string },
+  ): AsyncGenerator<AgentEvent> {
     // Store the incoming message in session events with user role
     session.events.push({ type: 'text', text: message.parts.map(p => ('text' in p ? p.text : '')).join(''), role: 'user' });
     await this.sessionService.updateSession(session);
@@ -63,6 +74,8 @@ export class Runner {
       agentName: this.agent.name,
       plugins: this.plugins,
       signal,
+      ...(taskScope?.taskId ? { taskId: taskScope.taskId } : {}),
+      ...(taskScope?.contextId ? { contextId: taskScope.contextId } : {}),
       ...(inputSentinel ? { input: inputSentinel } : {}),
     };
 


### PR DESCRIPTION
## Summary

- Surface the A2A wire identifiers `taskId` and `contextId` on `InvocationContext` so agent code has a stable per-task identifier to bind durable state to.
- `Runner.runAsync()` accepts an optional fourth `taskScope` argument; the default `AgentExecutor` passes `{ taskId: task.id, contextId: task.contextId ?? task.id }` from both `execute()` and `executeStream()`.
- Docs: documents the `InvocationContext` surface (incl. when `session.id` is and isn't safe to bind state to) in the Build an Agent guide.

Closes #158.

## Why

The default `AgentExecutor` calls `runner.createSession()` on every invocation — including the resume turn that follows a `request-input` event — so `context.session.id` was a per-invocation UUID. Agents that wrote `row.task_id = ctx.session.id` on the request-input turn saw a different `session.id` on the resume turn and could not look the row back up, even though the A2A task itself is the same. The A2A `Task.id` (and `contextId`) was the right identifier; it just wasn't exposed on the agent's context.

## API surface

Additive only:

- `InvocationContext` gains two optional fields, `taskId?: string` and `contextId?: string`.
- `Runner.runAsync()` gains an optional fourth `taskScope?: { taskId?: string; contextId?: string }` argument (preserves the existing `signal?` position for backward compat).
- No removals, no renames. Standalone `Runner` usage that bypasses the `AgentExecutor` continues to work — the new fields are left undefined.

## Test plan

- [x] `pnpm test` (504 tests passing, including 6 new regression tests in `invocation-context-task-id.test.ts` covering both `execute()` and `executeStream()` paths, the `request-input` → resume cycle, the `task.contextId` fallback, and the standalone-Runner path)
- [x] `pnpm typecheck`
- [x] `pnpm -r build`
- [x] `pnpm lint`