### PR TITLE
feat(samples): add express-noauth quickstart

### DIFF
--- a/samples/express-noauth/.dockerignore
+++ b/samples/express-noauth/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+.env.*
+*.log
+Dockerfile
+.dockerignore
+fly.toml

--- a/samples/express-noauth/Dockerfile
+++ b/samples/express-noauth/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install --no-audit --no-fund --no-package-lock
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=4000
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./package.json
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/samples/express-noauth/fly.toml
+++ b/samples/express-noauth/fly.toml
@@ -1,0 +1,18 @@
+app = "a2x-express-noauth"
+primary_region = "nrt"
+
+[build]
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/samples/express-noauth/package.json
+++ b/samples/express-noauth/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sample-express-noauth",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@a2x/sdk": "^0.13.1",
+    "@anthropic-ai/sdk": "^0.91.1",
+    "dotenv": "^16",
+    "express": "^5.1.0",
+    "viem": "^2.21.0",
+    "x402": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5",
+    "@types/node": "^20",
+    "tsx": "^4",
+    "typescript": "^5"
+  }
+}

--- a/samples/express-noauth/src/index.ts
+++ b/samples/express-noauth/src/index.ts
@@ -1,0 +1,146 @@
+import 'dotenv/config';
+import express from 'express';
+import {
+  LlmAgent,
+  InMemoryRunner,
+  AgentExecutor,
+  StreamingMode,
+  InMemoryTaskStore,
+  A2XAgent,
+  DefaultRequestHandler,
+  createSSEStream,
+} from '@a2x/sdk';
+import type {
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  RequestContext,
+} from '@a2x/sdk';
+import { AnthropicProvider } from '@a2x/sdk/anthropic';
+
+// ─── 1. Define your agent ───
+
+const agent = new LlmAgent({
+  name: 'echo-agent',
+  description: 'A simple echo agent that returns your message.',
+  provider: new AnthropicProvider({
+    model: 'claude-sonnet-4-6',
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+  }),
+  instruction: 'You are a helpful echo agent.',
+});
+
+// ─── 2. Wire up a2x ───
+
+const runner = new InMemoryRunner({ agent, appName: agent.name });
+const agentExecutor = new AgentExecutor({
+  runner,
+  runConfig: { streamingMode: StreamingMode.SSE },
+});
+const taskStore = new InMemoryTaskStore();
+const a2xAgent = new A2XAgent({
+  taskStore,
+  executor: agentExecutor,
+  protocolVersion: '1.0',
+});
+
+a2xAgent.setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:4000'}/a2a`);
+a2xAgent.addSkill({
+  id: 'echo',
+  name: 'Echo',
+  description: 'Echoes back the user message',
+  tags: ['echo'],
+  examples: ['Hello, agent!'],
+});
+
+const handler = new DefaultRequestHandler(a2xAgent);
+
+// ─── 3. Express app ───
+
+const app = express();
+app.use(express.json());
+
+app.use(
+  (err: unknown, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err instanceof SyntaxError && 'body' in err) {
+      res.status(200).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      });
+      return;
+    }
+    next(err);
+  },
+);
+
+app.get('/.well-known/agent.json', (_req, res) => {
+  try {
+    const card = handler.getAgentCard();
+    res.json(card);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Internal error',
+    });
+  }
+});
+
+app.post('/a2a', async (req, res) => {
+  const context: RequestContext = {
+    headers: req.headers as Record<string, string | string[] | undefined>,
+    query: req.query as Record<string, string | string[] | undefined>,
+  };
+
+  let result: Awaited<ReturnType<typeof handler.handle>>;
+  try {
+    result = await handler.handle(req.body, context);
+  } catch (err) {
+    const id = (req.body as { id?: unknown } | undefined)?.id ?? null;
+    res.status(200).json({
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32603,
+        message: err instanceof Error ? err.message : 'Internal error',
+      },
+    });
+    return;
+  }
+
+  if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    const stream = createSSEStream(
+      result as AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>,
+    );
+    const reader = stream.getReader();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(typeof value === 'string' ? value : new TextDecoder().decode(value));
+      }
+    } catch (error) {
+      const errorData = JSON.stringify({
+        error: error instanceof Error ? error.message : 'Internal error',
+      });
+      res.write(`event: error\ndata: ${errorData}\n\n`);
+    }
+    res.end();
+    return;
+  }
+
+  res.json(result);
+});
+
+// ─── 4. Start ───
+
+const PORT = Number(process.env.PORT) || 4000;
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`a2x Express (no-auth) sample running on http://0.0.0.0:${PORT}`);
+  console.log(`Agent card: http://0.0.0.0:${PORT}/.well-known/agent.json`);
+  console.log(`JSON-RPC:   POST http://0.0.0.0:${PORT}/a2a`);
+});

--- a/samples/express-noauth/tsconfig.json
+++ b/samples/express-noauth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- New `samples/express-noauth/` — minimal Express + `@a2x/sdk` quickstart using `AnthropicProvider` with **no security schemes** (anonymous JSON-RPC).
- Mirrors the existing `samples/express/` but strips the API-key / OAuth2 device-code wiring, so newcomers can stand up an A2A endpoint with the smallest possible surface.
- Includes `Dockerfile` + `fly.toml` so it can be deployed to Fly.io as-is. Deployed and verified at https://a2x-express-noauth.fly.dev.

## Notes
- No `@a2x/sdk` public-surface changes → no changeset, no docs update (per `AGENTS.md`: samples-only changes are out of scope for changesets).
- The sample lists `viem` and `x402` as direct dependencies. They are declared as optional peers in `@a2x/sdk`, but the SDK's main entry has a static `import "x402/verify"` that fails at runtime without them. Worth a follow-up to make that import lazy so consumers can skip x402 unless they opt in.

## Test plan
- [x] `npm install && npm run build` in `samples/express-noauth/`
- [x] Deployed to Fly (`vicoop-797` org, app `a2x-express-noauth`)
- [x] `GET /.well-known/agent.json` returns the agent card with the public URL
- [x] `POST /a2a` with `message/send` returns a Claude-generated reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)