### PR TITLE
refactor(sdk): rename A2XAgent to A2XServer

### DIFF
--- a/.changeset/rename-a2xagent-to-a2xserver.md
+++ b/.changeset/rename-a2xagent-to-a2xserver.md
@@ -1,0 +1,7 @@
+---
+"@a2x/sdk": minor
+---
+
+Rename `A2XAgent` to `A2XServer`. The class is the A2A protocol *server* wrapper (task store, executor, AgentCard builder), not an agent — the old name collided with `LlmAgent` and suggested that tools/skills belonged on it. `A2XServerOptions` replaces `A2XAgentOptions`, and `toA2x()` now returns `a2xServer` on its result.
+
+Backward compatible: `A2XAgent`, `A2XAgentOptions`, and `ToA2xResult.a2xAgent` remain as `@deprecated` aliases of the new names and will be removed in a future major. `A2XAgentSkill` and `A2XAgentState` (AgentCard types) are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ specification/      Canonical A2A JSON/proto specs (v0.3, v1.0)
 
 - New / changed / removed exports from `packages/a2x/src/index.ts` (or any subpath export declared in `packages/a2x/package.json`).
 - New / changed JSON-RPC methods wired in `DefaultRequestHandler._registerRoutes()` or the `handle()` special cases.
-- New / changed `A2XAgent` builder methods, constructor options, or accessors.
+- New / changed `A2XServer` builder methods, constructor options, or accessors.
 - New / changed `A2XClient` methods.
 - New / changed error codes exposed via `A2A_ERROR_CODES`.
 - Spec-conformance corrections (e.g. renaming an `A2A_METHODS` constant) even when functional behavior doesn't change.
@@ -32,7 +32,7 @@ Location map:
 | New JSON-RPC method on the server | `docs/guides/agent/streaming.md` or `docs/guides/agent/build-an-agent.md`, plus the matching client page |
 | New `A2XClient` method | `docs/guides/client/*.md` |
 | New security scheme | `docs/guides/advanced/authentication.md` |
-| New `A2XAgentOptions` field or builder method | `docs/guides/advanced/manual-wiring.md` |
+| New `A2XServerOptions` field or builder method | `docs/guides/advanced/manual-wiring.md` |
 | New AgentCard capability flag / version shape | `docs/guides/advanced/agent-card-versioning.md` |
 | New protocol extension | `docs/guides/advanced/extensions.md` |
 | Genuinely new feature with no matching page | Add a new `.md` under `docs/guides/...` and register it in `docs/manifest.json` |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ npm install @a2x/sdk
 
 ## Key Features
 
-- **Auto-extraction** — `A2XAgent` infers AgentCard fields (`name`, `description`, `capabilities.streaming`) from your runtime objects. No manual duplication.
-- **Multi-version AgentCard** — Speak A2A v0.3 or v1.0 by constructing `new A2XAgent({ ..., protocolVersion: '0.3' | '1.0' })`. Card and wire stay consistent for the chosen version.
+- **Auto-extraction** — `A2XServer` infers AgentCard fields (`name`, `description`, `capabilities.streaming`) from your runtime objects. No manual duplication.
+- **Multi-version AgentCard** — Speak A2A v0.3 or v1.0 by constructing `new A2XServer({ ..., protocolVersion: '0.3' | '1.0' })`. Card and wire stay consistent for the chosen version.
 - **Builder pattern** — Override any auto-extracted value with chainable methods (`setName()`, `addSkill()`, `addSecurityScheme()`, etc.).
 - **ADK-compatible patterns** — Familiar `LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, `FunctionTool`, `AgentTool`, `Runner`, and `Session` APIs.
 - **Client SDK** — `A2XClient` for interacting with any A2A-compliant agent, with built-in auth scheme support.
@@ -46,7 +46,7 @@ npm install @a2x/sdk
 ```typescript
 import {
   LlmAgent,
-  A2XAgent,
+  A2XServer,
   AgentExecutor,
   InMemoryRunner,
   InMemoryTaskStore,
@@ -71,8 +71,8 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-// 3. Create A2XAgent — name, description, and streaming are auto-extracted
-const a2xAgent = new A2XAgent({ taskStore, executor })
+// 3. Create A2XServer — name, description, and streaming are auto-extracted
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .addSkill({
     id: 'chat',
@@ -82,17 +82,17 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
   });
 
 // 4. Wire up the request handler
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 
 // 5. Render the AgentCard in the configured wire format
-const card = a2xAgent.getAgentCard();
+const card = a2xServer.getAgentCard();
 //   To serve v0.3 instead, construct with `protocolVersion: '0.3'`.
 ```
 
 ## How It Works
 
 ```
-A2XAgent
+A2XServer
 ├── taskStore (InMemoryTaskStore, etc.)
 └── agentExecutor
     ├── runner
@@ -103,7 +103,7 @@ A2XAgent
         └── streamingMode    → capabilities.streaming (auto-extracted)
 
 getAgentCard()
-└── A2XAgent.protocolVersion → matching mapper → AgentCard JSON
+└── A2XServer.protocolVersion → matching mapper → AgentCard JSON
 ```
 
 **Value resolution priority:**
@@ -178,7 +178,7 @@ export async function POST(request: Request) {
 }
 
 export async function GET() {
-  return Response.json(a2xAgent.getAgentCard());
+  return Response.json(a2xServer.getAgentCard());
 }
 ```
 

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -413,11 +413,11 @@ Migration from `x402PaymentHook` (SDK 0.13.x): [docs/guides/advanced/migration-x
 a2x handles the structural differences between A2A protocol versions transparently. Each agent is bound to one wire format at construction:
 
 ```typescript
-const a2xAgentV10 = new A2XServer({ taskStore, executor });                          // v1.0 (default)
-const a2xAgentV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });  // v0.3
+const a2xServerV10 = new A2XServer({ taskStore, executor });                          // v1.0 (default)
+const a2xServerV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });  // v0.3
 
-a2xAgentV10.getAgentCard(); // v1.0 card
-a2xAgentV03.getAgentCard(); // v0.3 card
+a2xServerV10.getAgentCard(); // v1.0 card
+a2xServerV03.getAgentCard(); // v0.3 card
 ```
 
 | Field | v0.3 | v1.0 |

--- a/packages/a2x/README.md
+++ b/packages/a2x/README.md
@@ -7,7 +7,7 @@ A self-contained TypeScript SDK for building [A2A (Agent-to-Agent)](https://a2a-
 
 ## Why a2x?
 
-- **Auto-extraction** — `A2XAgent` infers AgentCard fields from your runtime objects. No manual JSON authoring.
+- **Auto-extraction** — `A2XServer` infers AgentCard fields from your runtime objects. No manual JSON authoring.
 - **Multi-version AgentCard** — Generate v0.3 and v1.0 AgentCards from the same instance.
 - **Multi-provider** — Anthropic Claude, OpenAI GPT, and Google Gemini out of the box.
 - **Framework-agnostic** — Works with Express, Fastify, Hono, Next.js, or any HTTP framework.
@@ -105,7 +105,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   createSSEStream,
 } from '@a2x/sdk';
@@ -131,8 +131,8 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-// 3. Create A2XAgent (auto-extracts name, description, streaming from runtime)
-const a2xAgent = new A2XAgent({ taskStore, executor })
+// 3. Create A2XServer (auto-extracts name, description, streaming from runtime)
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .addSkill({
     id: 'chat',
@@ -142,7 +142,7 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
   });
 
 // 4. Create the request handler
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 ### Express
@@ -288,7 +288,7 @@ const mainAgent = new LlmAgent({
 ```typescript
 import { ApiKeyAuthorization, HttpBearerAuthorization } from '@a2x/sdk';
 
-a2xAgent
+a2xServer
   .addSecurityScheme('apiKey', new ApiKeyAuthorization({
     in: 'header',
     name: 'x-api-key',
@@ -387,7 +387,7 @@ const executor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 
-const agent = new A2XAgent({ taskStore, executor })
+const agent = new A2XServer({ taskStore, executor })
   .addExtension({ uri: X402_EXTENSION_URI, required: true });
 ```
 
@@ -413,8 +413,8 @@ Migration from `x402PaymentHook` (SDK 0.13.x): [docs/guides/advanced/migration-x
 a2x handles the structural differences between A2A protocol versions transparently. Each agent is bound to one wire format at construction:
 
 ```typescript
-const a2xAgentV10 = new A2XAgent({ taskStore, executor });                          // v1.0 (default)
-const a2xAgentV03 = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });  // v0.3
+const a2xAgentV10 = new A2XServer({ taskStore, executor });                          // v1.0 (default)
+const a2xAgentV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });  // v0.3
 
 a2xAgentV10.getAgentCard(); // v1.0 card
 a2xAgentV03.getAgentCard(); // v0.3 card

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -24,11 +24,11 @@ A2X models everything internally in a version-neutral shape and renders it throu
 Pass `protocolVersion` to the constructor. The choice is fixed for the life of the agent:
 
 ```ts
-const a2xAgentV10 = new A2XServer({ taskStore, executor }); // v1.0 (default)
-const a2xAgentV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });
+const a2xServerV10 = new A2XServer({ taskStore, executor }); // v1.0 (default)
+const a2xServerV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });
 
-a2xAgentV10.getAgentCard(); // → v1.0 card
-a2xAgentV03.getAgentCard(); // → v0.3 card
+a2xServerV10.getAgentCard(); // → v1.0 card
+a2xServerV03.getAgentCard(); // → v0.3 card
 ```
 
 To serve both versions from one deployment, run two `A2XServer` instances behind separate URLs and advertise each in the other's `additionalInterfaces`. One instance cannot lie about its wire format.

--- a/packages/a2x/docs/guides/advanced/agent-card-versioning.md
+++ b/packages/a2x/docs/guides/advanced/agent-card-versioning.md
@@ -1,6 +1,6 @@
 # AgentCard v0.3 vs v1.0
 
-A2A has two spec versions in active use. The **AgentCard** — the JSON your agent serves at `/.well-known/agent.json` — differs in shape between them. Each `A2XAgent` instance is bound to one wire format, chosen at construction time via `protocolVersion` (default `'1.0'`).
+A2A has two spec versions in active use. The **AgentCard** — the JSON your agent serves at `/.well-known/agent.json` — differs in shape between them. Each `A2XServer` instance is bound to one wire format, chosen at construction time via `protocolVersion` (default `'1.0'`).
 
 You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` render whatever `protocolVersion` was configured. The card shape, the JSON-RPC response shape, and the `pushNotificationConfig` param shape always match — so clients reading the card get a faithful contract for the wire underneath.
 
@@ -15,7 +15,7 @@ You usually don't pick. `toA2x()` and `DefaultRequestHandler.getAgentCard()` ren
 
 A2X models everything internally in a version-neutral shape and renders it through the configured wire format. This means:
 
-- Every declaration you make on `A2XAgent` (skills, security, default URL) works for both versions.
+- Every declaration you make on `A2XServer` (skills, security, default URL) works for both versions.
 - The card and the wire are always consistent — the SDK never publishes a card whose `protocolVersion` disagrees with what the server actually emits.
 - You don't write version branches in your own code.
 
@@ -24,14 +24,14 @@ A2X models everything internally in a version-neutral shape and renders it throu
 Pass `protocolVersion` to the constructor. The choice is fixed for the life of the agent:
 
 ```ts
-const a2xAgentV10 = new A2XAgent({ taskStore, executor }); // v1.0 (default)
-const a2xAgentV03 = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+const a2xAgentV10 = new A2XServer({ taskStore, executor }); // v1.0 (default)
+const a2xAgentV03 = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });
 
 a2xAgentV10.getAgentCard(); // → v1.0 card
 a2xAgentV03.getAgentCard(); // → v0.3 card
 ```
 
-To serve both versions from one deployment, run two `A2XAgent` instances behind separate URLs and advertise each in the other's `additionalInterfaces`. One instance cannot lie about its wire format.
+To serve both versions from one deployment, run two `A2XServer` instances behind separate URLs and advertise each in the other's `additionalInterfaces`. One instance cannot lie about its wire format.
 
 ## When this matters to you
 
@@ -47,7 +47,7 @@ OAuth 2.0 Device Code is a v1.0-native security flow. A2X extends it onto v0.3 c
 
 ### Advertising the authenticated extended card
 
-When you call `a2xAgent.setAuthenticatedExtendedCardProvider(...)`, A2X flips the version-specific capability flag on the base card automatically:
+When you call `a2xServer.setAuthenticatedExtendedCardProvider(...)`, A2X flips the version-specific capability flag on the base card automatically:
 
 - v0.3: top-level `supportsAuthenticatedExtendedCard: true`
 - v1.0: `capabilities.extendedAgentCard: true`

--- a/packages/a2x/docs/guides/advanced/authentication.md
+++ b/packages/a2x/docs/guides/advanced/authentication.md
@@ -6,13 +6,13 @@ A2X ships adapters for the auth schemes A2A defines plus OpenID Connect and Mutu
 
 Every scheme follows the same two-step pattern:
 
-1. Register the scheme with `a2xAgent.addSecurityScheme(id, scheme)`. This publishes it on the AgentCard so clients know what to expect.
-2. Add a `SecurityRequirement` with `a2xAgent.addSecurityRequirement({ id: [] })` to enforce it.
+1. Register the scheme with `a2xServer.addSecurityScheme(id, scheme)`. This publishes it on the AgentCard so clients know what to expect.
+2. Add a `SecurityRequirement` with `a2xServer.addSecurityRequirement({ id: [] })` to enforce it.
 
 Multiple requirements act as **OR** (any satisfies); multiple schemes inside one requirement act as **AND** (all required).
 
 ```ts
-a2xAgent
+a2xServer
   .addSecurityScheme('apiKey', apiKeyScheme)
   .addSecurityScheme('bearer', bearerScheme)
   // OR: either apiKey OR bearer is enough
@@ -27,7 +27,7 @@ Simplest scheme — a static secret in a header, query, or cookie.
 ```ts
 import { ApiKeyAuthorization } from '@a2x/sdk';
 
-a2xAgent
+a2xServer
   .addSecurityScheme('apiKey', new ApiKeyAuthorization({
     in: 'header',
     name: 'x-api-key',
@@ -45,7 +45,7 @@ Opaque tokens validated by your own logic — useful when you issue tokens from 
 ```ts
 import { HttpBearerAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('bearer', new HttpBearerAuthorization({
+a2xServer.addSecurityScheme('bearer', new HttpBearerAuthorization({
   validator: async (token) => {
     const session = await lookupSession(token);
     return session
@@ -66,7 +66,7 @@ Three standard flows are supported out of the box.
 ```ts
 import { OAuth2AuthorizationCodeAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('oauthCode', new OAuth2AuthorizationCodeAuthorization({
+a2xServer.addSecurityScheme('oauthCode', new OAuth2AuthorizationCodeAuthorization({
   authorizationUrl: 'https://auth.example.com/authorize',
   tokenUrl: 'https://auth.example.com/token',
   scopes: { read: 'Read access', write: 'Write access' },
@@ -81,7 +81,7 @@ Use this for user-driven flows where the client can open a browser.
 ```ts
 import { OAuth2ClientCredentialsAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('oauthService', new OAuth2ClientCredentialsAuthorization({
+a2xServer.addSecurityScheme('oauthService', new OAuth2ClientCredentialsAuthorization({
   tokenUrl: 'https://auth.example.com/token',
   scopes: { api: 'API access' },
   validator: async (token) => { /* verify */ },
@@ -97,7 +97,7 @@ For headless devices / CLIs without a browser.
 ```ts
 import { OAuth2DeviceCodeAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('deviceCode', new OAuth2DeviceCodeAuthorization({
+a2xServer.addSecurityScheme('deviceCode', new OAuth2DeviceCodeAuthorization({
   deviceAuthorizationUrl: 'https://auth.example.com/device/code',
   tokenUrl: 'https://auth.example.com/token',
   scopes: { api: 'API access' },
@@ -114,7 +114,7 @@ Standard OIDC discovery endpoint.
 ```ts
 import { OpenIdConnectAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('oidc', new OpenIdConnectAuthorization({
+a2xServer.addSecurityScheme('oidc', new OpenIdConnectAuthorization({
   openIdConnectUrl: 'https://auth.example.com/.well-known/openid-configuration',
   validator: async (token) => { /* verify id_token or access_token */ },
 }));
@@ -127,7 +127,7 @@ Client-certificate-based auth.
 ```ts
 import { MutualTlsAuthorization } from '@a2x/sdk';
 
-a2xAgent.addSecurityScheme('mtls', new MutualTlsAuthorization({
+a2xServer.addSecurityScheme('mtls', new MutualTlsAuthorization({
   validator: async (context) => {
     const cert = context.clientCertificate;
     return cert && isTrusted(cert)

--- a/packages/a2x/docs/guides/advanced/extended-agent-card.md
+++ b/packages/a2x/docs/guides/advanced/extended-agent-card.md
@@ -14,13 +14,13 @@ Register a provider callback that, given the resolved `AuthResult`, returns a pa
 
 ```ts
 import {
-  A2XAgent,
+  A2XServer,
   ApiKeyAuthorization,
   type AuthResult,
   type A2XAgentState,
 } from '@a2x/sdk';
 
-const a2xAgent = new A2XAgent({ taskStore, executor })
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('https://agent.example.com/a2a')
   .setName('acme-agent')
   .setDescription('Public description of Acme Agent.')
@@ -68,7 +68,7 @@ If you only want to *add* skills rather than replace them, build the merged arra
 
 ```ts
 .setAuthenticatedExtendedCardProvider(async (auth) => {
-  const base = a2xAgent.getAgentCard();   // current public card
+  const base = a2xServer.getAgentCard();   // current public card
   return {
     skills: [...base.skills, { id: 'premium', ... }],
   };

--- a/packages/a2x/docs/guides/advanced/extensions.md
+++ b/packages/a2x/docs/guides/advanced/extensions.md
@@ -11,7 +11,7 @@ A2X emits `oauth2.flows.deviceCode` on v0.3 cards as a non-standard extension, a
 ```ts
 import { OAuth2DeviceCodeAuthorization } from '@a2x/sdk';
 
-a2xAgent
+a2xServer
   .addSecurityScheme('deviceCode', new OAuth2DeviceCodeAuthorization({ /* ... */ }))
   .addSecurityRequirement({ deviceCode: [] });
 ```
@@ -25,7 +25,7 @@ You'll see a warning in logs when emitting this on a v0.3 card; it's information
 Extensions live on the AgentCard as additional JSON properties. Pick a namespace you control (a domain you own, a prefix like `x-<team>-`) to avoid collisions.
 
 ```ts
-const a2xAgent = new A2XAgent({ taskStore, executor })
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('...')
   .setExtension('x-acme-pricing', {
     tier: 'enterprise',

--- a/packages/a2x/docs/guides/advanced/manual-wiring.md
+++ b/packages/a2x/docs/guides/advanced/manual-wiring.md
@@ -1,6 +1,6 @@
 # Manual Wiring
 
-`toA2x()` is a convenience wrapper. Underneath, it composes five pieces: the agent, a **runner**, an **executor**, a **task store**, and an **A2XAgent** that binds everything to a **request handler**. This guide unpacks that stack so you can customize any of it.
+`toA2x()` is a convenience wrapper. Underneath, it composes five pieces: the agent, a **runner**, an **executor**, a **task store**, and an **A2XServer** that binds everything to a **request handler**. This guide unpacks that stack so you can customize any of it.
 
 Reach for manual wiring when you need to:
 
@@ -18,7 +18,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
 } from '@a2x/sdk';
 import { GoogleProvider } from '@a2x/sdk/google';
@@ -46,8 +46,8 @@ const executor = new AgentExecutor({
 // 4. Task store — persists task state across calls (getTask, cancelTask).
 const taskStore = new InMemoryTaskStore();
 
-// 5. A2XAgent — emits the AgentCard and owns skills, security, versioning.
-const a2xAgent = new A2XAgent({ taskStore, executor })
+// 5. A2XServer — emits the AgentCard and owns skills, security, versioning.
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .addSkill({
     id: 'chat',
@@ -57,7 +57,7 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
   });
 
 // 6. Request handler — the thing your HTTP layer calls.
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 `handler.getAgentCard()` returns the AgentCard JSON. `handler.handle(body, context)` processes a JSON-RPC request and returns either a plain object or an async iterable (for streams).
@@ -79,12 +79,12 @@ const handler = new DefaultRequestHandler(a2xAgent);
 
 ### Task event bus
 
-The bus fans `message/stream` events out to any `tasks/resubscribe` subscribers. `A2XAgent` creates a default `InMemoryTaskEventBus` when you don't pass one — sufficient for single-process deployments.
+The bus fans `message/stream` events out to any `tasks/resubscribe` subscribers. `A2XServer` creates a default `InMemoryTaskEventBus` when you don't pass one — sufficient for single-process deployments.
 
 Swap it when you need cross-process fan-out (e.g. multiple worker nodes behind a load balancer):
 
 ```ts
-import { A2XAgent, type TaskEventBus } from '@a2x/sdk';
+import { A2XServer, type TaskEventBus } from '@a2x/sdk';
 
 class RedisTaskEventBus implements TaskEventBus {
   publish(taskId, event) { /* PUBLISH a2x:task:<taskId> */ }
@@ -93,7 +93,7 @@ class RedisTaskEventBus implements TaskEventBus {
   hasSubscribers(taskId) { /* SUBSCRIBERS count */ }
 }
 
-const a2xAgent = new A2XAgent({
+const a2xServer = new A2XServer({
   taskStore,
   executor,
   taskEventBus: new RedisTaskEventBus(),
@@ -105,7 +105,7 @@ The default implementation's queue is unbounded — fine for most agents, but co
 ### AgentCard skills and metadata
 
 ```ts
-a2xAgent
+a2xServer
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .setIconUrl('https://my-agent.example.com/icon.png')
   .addSkill({
@@ -129,7 +129,7 @@ Skills are how other agents and directories understand what yours does. Prefer d
 ```ts
 import { ApiKeyAuthorization } from '@a2x/sdk';
 
-a2xAgent
+a2xServer
   .addSecurityScheme('apiKey', new ApiKeyAuthorization({
     in: 'header',
     name: 'x-api-key',
@@ -155,7 +155,7 @@ Two capabilities need explicit builder calls — both are append-only / boolean:
 ```ts
 import { X402_EXTENSION_URI } from '@a2x/sdk/x402';
 
-a2xAgent
+a2xServer
   .addExtension({ uri: X402_EXTENSION_URI, required: true })
   // or: .addExtension('https://example.com/ext', { required: true })
   .setStateTransitionHistory(true); // v0.3 only; dropped on v1.0 cards

--- a/packages/a2x/docs/guides/advanced/task-store.md
+++ b/packages/a2x/docs/guides/advanced/task-store.md
@@ -68,7 +68,7 @@ Wire it in:
 
 ```ts
 const taskStore = new RedisTaskStore(new Redis(process.env.REDIS_URL!));
-const a2xAgent = new A2XAgent({ taskStore, executor });
+const a2xServer = new A2XServer({ taskStore, executor });
 ```
 
 ## Choosing a TTL

--- a/packages/a2x/docs/guides/advanced/x402-payments.md
+++ b/packages/a2x/docs/guides/advanced/x402-payments.md
@@ -26,7 +26,7 @@ No method bundles `verify` + `settle` — they stay separate so the agent can do
 
 ```ts
 import {
-  A2XAgent,
+  A2XServer,
   AgentExecutor,
   BaseAgent,
   StreamingMode,
@@ -116,7 +116,7 @@ const executor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 
-const agent = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor })
+const agent = new A2XServer({ taskStore: new InMemoryTaskStore(), executor })
   .setName('Paid Agent')
   .setDescription('Charges per call')
   .addExtension({ uri: X402_EXTENSION_URI, required: true });

--- a/packages/a2x/docs/guides/agent/framework-integration.md
+++ b/packages/a2x/docs/guides/agent/framework-integration.md
@@ -15,7 +15,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   createSSEStream,
 } from '@a2x/sdk';
@@ -39,7 +39,7 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-const a2xAgent = new A2XAgent({ taskStore, executor })
+const a2xServer = new A2XServer({ taskStore, executor })
   .setDefaultUrl('https://my-agent.example.com/a2a')
   .addSkill({
     id: 'chat',
@@ -48,7 +48,7 @@ const a2xAgent = new A2XAgent({ taskStore, executor })
     tags: ['chat'],
   });
 
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 `handler` is what you mount. See [Manual Wiring](../advanced/manual-wiring.md) for why each step exists.

--- a/packages/a2x/src/__tests__/a2x-agent.test.ts
+++ b/packages/a2x/src/__tests__/a2x-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer, A2XAgent } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { InMemoryPushNotificationConfigStore } from '../a2x/push-notification-config-store.js';
@@ -41,10 +41,10 @@ function createA2XAgent(
   });
   const taskStore = new InMemoryTaskStore();
 
-  return new A2XAgent({ taskStore, executor, protocolVersion });
+  return new A2XServer({ taskStore, executor, protocolVersion });
 }
 
-describe('Layer 3: A2XAgent', () => {
+describe('Layer 3: A2XServer', () => {
   describe('Constructor - options object', () => {
     it('should construct with required options', () => {
       const a2x = createA2XAgent();
@@ -66,7 +66,7 @@ describe('Layer 3: A2XAgent', () => {
       });
       const taskStore = new InMemoryTaskStore();
 
-      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      const a2x = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });
       expect(a2x.protocolVersion).toBe('0.3');
     });
 
@@ -84,7 +84,7 @@ describe('Layer 3: A2XAgent', () => {
       });
       const taskStore = new InMemoryTaskStore();
 
-      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' });
+      const a2x = new A2XServer({ taskStore, executor, protocolVersion: '1.0' });
       expect(a2x.protocolVersion).toBe('1.0');
     });
 
@@ -108,19 +108,19 @@ describe('Layer 3: A2XAgent', () => {
       const taskStore = new InMemoryTaskStore();
 
       expect(
-        () => new A2XAgent({ taskStore, executor, protocolVersion: '2.0' as '0.3' }),
+        () => new A2XServer({ taskStore, executor, protocolVersion: '2.0' as '0.3' }),
       ).toThrow("unsupported protocolVersion '2.0'");
     });
 
     it('should throw when taskStore is missing', () => {
       expect(
-        () => new A2XAgent({ taskStore: null as never, executor: {} as never }),
+        () => new A2XServer({ taskStore: null as never, executor: {} as never }),
       ).toThrow('taskStore is required');
     });
 
     it('should throw when executor is missing', () => {
       expect(
-        () => new A2XAgent({ taskStore: {} as never, executor: null as never }),
+        () => new A2XServer({ taskStore: {} as never, executor: null as never }),
       ).toThrow('executor is required');
     });
   });
@@ -322,7 +322,7 @@ describe('Layer 3: A2XAgent', () => {
       });
       const taskStore = new InMemoryTaskStore();
 
-      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '0.3' });
+      const a2x = new A2XServer({ taskStore, executor, protocolVersion: '0.3' });
       a2x.setDefaultUrl('https://example.com/a2a');
 
       const card = a2x.getAgentCard() as AgentCardV03;
@@ -343,7 +343,7 @@ describe('Layer 3: A2XAgent', () => {
       });
       const taskStore = new InMemoryTaskStore();
 
-      const a2x = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' });
+      const a2x = new A2XServer({ taskStore, executor, protocolVersion: '1.0' });
       a2x.setDefaultUrl('https://example.com/a2a');
 
       const card = a2x.getAgentCard() as AgentCardV10;
@@ -364,7 +364,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor });
+      const a2x = new A2XServer({ taskStore: new InMemoryTaskStore(), executor });
 
       expect(() => a2x.getAgentCard()).toThrow('name is required');
     });
@@ -381,7 +381,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor });
+      const a2x = new A2XServer({ taskStore: new InMemoryTaskStore(), executor });
 
       expect(() => a2x.getAgentCard()).toThrow('description is required');
     });
@@ -459,7 +459,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({
+      const a2x = new A2XServer({
         taskStore: new InMemoryTaskStore(),
         executor,
         pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
@@ -482,7 +482,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({
+      const a2x = new A2XServer({
         taskStore: new InMemoryTaskStore(),
         executor,
         pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
@@ -512,7 +512,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({
+      const a2x = new A2XServer({
         taskStore: new InMemoryTaskStore(),
         executor,
         pushNotificationConfigStore: new InMemoryPushNotificationConfigStore(),
@@ -536,7 +536,7 @@ describe('Layer 3: A2XAgent', () => {
         runner,
         runConfig: { streamingMode: StreamingMode.NONE },
       });
-      const a2x = new A2XAgent({
+      const a2x = new A2XServer({
         taskStore: new InMemoryTaskStore(),
         executor,
         protocolVersion: '0.3',
@@ -562,6 +562,28 @@ describe('Layer 3: A2XAgent', () => {
       const card3 = a2x.getAgentCard();
       expect(card3).not.toBe(card1); // New object (cache invalidated)
       expect((card3 as AgentCardV10).version).toBe('2.0.0');
+    });
+  });
+
+  describe('deprecated A2XAgent alias', () => {
+    it('is the same constructor as A2XServer', () => {
+      expect(A2XAgent).toBe(A2XServer);
+    });
+
+    it('constructs a working server instance', () => {
+      const agent = new LlmAgent({
+        name: 'alias-agent',
+        provider: mockProvider,
+        description: 'alias test',
+        instruction: 'x',
+      });
+      const runner = new InMemoryRunner({ agent, appName: 'test' });
+      const executor = new AgentExecutor({
+        runner,
+        runConfig: { streamingMode: StreamingMode.SSE },
+      });
+      const server = new A2XAgent({ taskStore: new InMemoryTaskStore(), executor });
+      expect(server).toBeInstanceOf(A2XServer);
     });
   });
 });

--- a/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
+++ b/packages/a2x/src/__tests__/authenticated-extended-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DefaultRequestHandler } from '../transport/request-handler.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
@@ -51,15 +51,15 @@ function createHandler(options: HandlerBuildOptions = {}): DefaultRequestHandler
     runConfig: { streamingMode: StreamingMode.SSE },
   });
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent({
+  const a2xServer = new A2XServer({
     taskStore,
     executor,
     protocolVersion: options.protocolVersion,
   });
-  a2xAgent.setDefaultUrl('https://example.com/a2a');
+  a2xServer.setDefaultUrl('https://example.com/a2a');
 
   if (options.withAuth) {
-    a2xAgent
+    a2xServer
       .addSecurityScheme(
         'apiKey',
         new ApiKeyAuthorization({
@@ -72,10 +72,10 @@ function createHandler(options: HandlerBuildOptions = {}): DefaultRequestHandler
   }
 
   if (options.withProvider) {
-    a2xAgent.setAuthenticatedExtendedCardProvider(options.withProvider);
+    a2xServer.setAuthenticatedExtendedCardProvider(options.withProvider);
   }
 
-  return new DefaultRequestHandler(a2xAgent);
+  return new DefaultRequestHandler(a2xServer);
 }
 
 function isAsyncGenerator(value: unknown): value is AsyncGenerator {

--- a/packages/a2x/src/__tests__/push-notification-delivery.test.ts
+++ b/packages/a2x/src/__tests__/push-notification-delivery.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { DefaultRequestHandler } from '../transport/request-handler.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
@@ -46,7 +46,7 @@ function createTestAgent(sender: PushNotificationSender) {
     runConfig: { streamingMode: StreamingMode.SSE },
   });
   const pushStore = new InMemoryPushNotificationConfigStore();
-  const a2x = new A2XAgent({
+  const a2x = new A2XServer({
     taskStore: new InMemoryTaskStore(),
     executor,
     protocolVersion: '1.0',

--- a/packages/a2x/src/__tests__/request-handler.test.ts
+++ b/packages/a2x/src/__tests__/request-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DefaultRequestHandler } from '../transport/request-handler.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
@@ -48,10 +48,10 @@ function createHandlerWithStore(protocolVersion?: ProtocolVersion): {
     runConfig: { streamingMode: StreamingMode.SSE },
   });
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion });
-  a2xAgent.setDefaultUrl('https://example.com/a2a');
+  const a2xServer = new A2XServer({ taskStore, executor, protocolVersion });
+  a2xServer.setDefaultUrl('https://example.com/a2a');
 
-  return { handler: new DefaultRequestHandler(a2xAgent), taskStore };
+  return { handler: new DefaultRequestHandler(a2xServer), taskStore };
 }
 
 function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
@@ -72,15 +72,15 @@ function createHandlerWithPushNotification(protocolVersion?: ProtocolVersion): {
   });
   const taskStore = new InMemoryTaskStore();
   const pushStore = new InMemoryPushNotificationConfigStore();
-  const a2xAgent = new A2XAgent({
+  const a2xServer = new A2XServer({
     taskStore,
     executor,
     protocolVersion,
     pushNotificationConfigStore: pushStore,
   });
-  a2xAgent.setDefaultUrl('https://example.com/a2a');
+  a2xServer.setDefaultUrl('https://example.com/a2a');
 
-  return { handler: new DefaultRequestHandler(a2xAgent), pushStore };
+  return { handler: new DefaultRequestHandler(a2xServer), pushStore };
 }
 
 function isAsyncGenerator(value: unknown): value is AsyncGenerator {
@@ -511,9 +511,9 @@ describe('Layer 4: DefaultRequestHandler', () => {
         runConfig: { streamingMode: StreamingMode.SSE },
       });
       const taskStore = new InMemoryTaskStore();
-      const a2xAgent = new A2XAgent({ taskStore, executor });
-      a2xAgent.setDefaultUrl('https://example.com/a2a');
-      const handler = new DefaultRequestHandler(a2xAgent);
+      const a2xServer = new A2XServer({ taskStore, executor });
+      a2xServer.setDefaultUrl('https://example.com/a2a');
+      const handler = new DefaultRequestHandler(a2xServer);
 
       // Create a task and set it to WORKING state directly
       const task = await taskStore.createTask({});
@@ -682,7 +682,7 @@ describe('Layer 4: DefaultRequestHandler', () => {
 
   describe('Authentication', () => {
     function createAuthHandler(
-      schemeSetup: (agent: A2XAgent) => void,
+      schemeSetup: (agent: A2XServer) => void,
     ): DefaultRequestHandler {
       const agent = new LlmAgent({
         name: 'auth-test-agent',
@@ -697,11 +697,11 @@ describe('Layer 4: DefaultRequestHandler', () => {
         runConfig: { streamingMode: StreamingMode.SSE },
       });
       const taskStore = new InMemoryTaskStore();
-      const a2xAgent = new A2XAgent({ taskStore, executor });
-      a2xAgent.setDefaultUrl('https://example.com/a2a');
-      schemeSetup(a2xAgent);
+      const a2xServer = new A2XServer({ taskStore, executor });
+      a2xServer.setDefaultUrl('https://example.com/a2a');
+      schemeSetup(a2xServer);
 
-      return new DefaultRequestHandler(a2xAgent);
+      return new DefaultRequestHandler(a2xServer);
     }
 
     const validRequest = {

--- a/packages/a2x/src/__tests__/task-resubscribe.test.ts
+++ b/packages/a2x/src/__tests__/task-resubscribe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DefaultRequestHandler } from '../transport/request-handler.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
@@ -45,9 +45,9 @@ function createSlowHandler(
     runConfig: { streamingMode: StreamingMode.SSE },
   });
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion });
-  a2xAgent.setDefaultUrl('https://example.com/a2a');
-  return { handler: new DefaultRequestHandler(a2xAgent), taskStore };
+  const a2xServer = new A2XServer({ taskStore, executor, protocolVersion });
+  a2xServer.setDefaultUrl('https://example.com/a2a');
+  return { handler: new DefaultRequestHandler(a2xServer), taskStore };
 }
 
 // Each chunk in a streaming response is a JSON-RPC success envelope per

--- a/packages/a2x/src/__tests__/x402-e2e-sample.test.ts
+++ b/packages/a2x/src/__tests__/x402-e2e-sample.test.ts
@@ -26,7 +26,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import {
   AgentExecutor,
-  A2XAgent,
+  A2XServer,
   BaseAgent,
   DefaultRequestHandler,
   InMemoryRunner,
@@ -163,7 +163,7 @@ function buildSampleStack(baseUrl: string): {
     runConfig: { streamingMode: StreamingMode.SSE },
   });
 
-  const a2xAgent = new A2XAgent({
+  const a2xServer = new A2XServer({
     taskStore: new InMemoryTaskStore(),
     executor,
     protocolVersion: '1.0',
@@ -179,7 +179,7 @@ function buildSampleStack(baseUrl: string): {
     })
     .addExtension({ uri: X402_EXTENSION_URI, required: true });
 
-  return { handler: new DefaultRequestHandler(a2xAgent), x402 };
+  return { handler: new DefaultRequestHandler(a2xServer), x402 };
 }
 
 /**
@@ -373,7 +373,7 @@ describe('x402 e2e — sample agent + real A2XClient over HTTP', () => {
       runner,
       runConfig: { streamingMode: StreamingMode.SSE },
     });
-    const a2xAgent = new A2XAgent({
+    const a2xServer = new A2XServer({
       taskStore: new InMemoryTaskStore(),
       executor,
       protocolVersion: '1.0',
@@ -384,7 +384,7 @@ describe('x402 e2e — sample agent + real A2XClient over HTTP', () => {
       .addExtension({ uri: X402_EXTENSION_URI, required: true });
     placeholderServer.on(
       'request',
-      createA2xRequestListener(new DefaultRequestHandler(a2xAgent)),
+      createA2xRequestListener(new DefaultRequestHandler(a2xServer)),
     );
 
     try {

--- a/packages/a2x/src/__tests__/x402-extension-activation.test.ts
+++ b/packages/a2x/src/__tests__/x402-extension-activation.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { privateKeyToAccount } from 'viem/accounts';
 import { A2XClient } from '../client/a2x-client.js';
 import { X402_EXTENSION_URI } from '../x402/index.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { BaseAgent, type AgentEvent } from '../agent/base-agent.js';
@@ -154,7 +154,7 @@ describe('DefaultRequestHandler — extension activation enforcement (spec §3.1
       runner,
       runConfig: { streamingMode: StreamingMode.SSE },
     });
-    const a2x = new A2XAgent({
+    const a2x = new A2XServer({
       taskStore: new InMemoryTaskStore(),
       executor,
       protocolVersion: '0.3',

--- a/packages/a2x/src/a2x/a2x-agent.ts
+++ b/packages/a2x/src/a2x/a2x-agent.ts
@@ -1,5 +1,5 @@
 /**
- * Layer 3: A2XAgent - the main integration class that bridges
+ * Layer 3: A2XServer - the main integration class that bridges
  * the agent system with the A2A protocol.
  */
 
@@ -33,7 +33,7 @@ const SUPPORTED_PROTOCOL_VERSIONS: ReadonlySet<string> = new Set<string>([
   '1.0',
 ]);
 
-export interface A2XAgentOptions {
+export interface A2XServerOptions {
   taskStore: TaskStore;
   executor: AgentExecutor;
   protocolVersion?: ProtocolVersion;
@@ -49,7 +49,7 @@ export interface A2XAgentOptions {
   taskEventBus?: TaskEventBus;
 }
 
-export class A2XAgent {
+export class A2XServer {
   private readonly _taskStore: TaskStore;
   private readonly _agentExecutor: AgentExecutor;
   private readonly _protocolVersion: ProtocolVersion;
@@ -84,19 +84,19 @@ export class A2XAgent {
   // (see issue #133).
   private _cachedCard?: AgentCardV03 | AgentCardV10;
 
-  constructor(options: A2XAgentOptions) {
+  constructor(options: A2XServerOptions) {
     if (!options.taskStore) {
-      throw new Error('A2XAgent: taskStore is required');
+      throw new Error('A2XServer: taskStore is required');
     }
     if (!options.executor) {
-      throw new Error('A2XAgent: executor is required');
+      throw new Error('A2XServer: executor is required');
     }
     if (
       options.protocolVersion !== undefined &&
       !SUPPORTED_PROTOCOL_VERSIONS.has(options.protocolVersion)
     ) {
       throw new Error(
-        `A2XAgent: unsupported protocolVersion '${options.protocolVersion}'. Supported versions: ${Array.from(SUPPORTED_PROTOCOL_VERSIONS).join(', ')}`,
+        `A2XServer: unsupported protocolVersion '${options.protocolVersion}'. Supported versions: ${Array.from(SUPPORTED_PROTOCOL_VERSIONS).join(', ')}`,
       );
     }
 
@@ -130,7 +130,7 @@ export class A2XAgent {
 
   setDefaultUrl(url: string): this {
     if (!url || url.trim() === '') {
-      throw new Error('A2XAgent.setDefaultUrl: url must not be empty');
+      throw new Error('A2XServer.setDefaultUrl: url must not be empty');
     }
     this._defaultUrl = url;
     this._invalidateCache();
@@ -146,7 +146,7 @@ export class A2XAgent {
   addSecurityScheme(name: string, scheme: BaseSecurityScheme): this {
     if (this._securitySchemes.has(name)) {
       console.warn(
-        `A2XAgent.addSecurityScheme: overwriting existing scheme '${name}'`,
+        `A2XServer.addSecurityScheme: overwriting existing scheme '${name}'`,
       );
     }
     this._securitySchemes.set(name, scheme);
@@ -163,7 +163,7 @@ export class A2XAgent {
   addInterface(iface: A2XInterfaceEntry): this {
     if (!iface.url || !iface.protocol) {
       throw new Error(
-        'A2XAgent.addInterface: url and protocol are required',
+        'A2XServer.addInterface: url and protocol are required',
       );
     }
     this._interfaces.push(iface);
@@ -326,7 +326,7 @@ export class A2XAgent {
    * give clients a false contract: the response shapes, role/part encoding,
    * and `pushNotificationConfig` param shape are all bound to the
    * configured protocol version. To serve a different version, construct a
-   * separate `A2XAgent` with that `protocolVersion`.
+   * separate `A2XServer` with that `protocolVersion`.
    */
   getAgentCard(): AgentCardV03 | AgentCardV10 {
     if (this._cachedCard) {
@@ -339,12 +339,12 @@ export class A2XAgent {
     // Validate required fields
     if (!state.name) {
       throw new Error(
-        'A2XAgent.getAgentCard: name is required. Use setName() or ensure the agent has a name.',
+        'A2XServer.getAgentCard: name is required. Use setName() or ensure the agent has a name.',
       );
     }
     if (!state.description) {
       throw new Error(
-        'A2XAgent.getAgentCard: description is required. Use setDescription() or ensure the agent has a description.',
+        'A2XServer.getAgentCard: description is required. Use setDescription() or ensure the agent has a description.',
       );
     }
 
@@ -353,7 +353,7 @@ export class A2XAgent {
       for (const schemeName of Object.keys(req)) {
         if (!state.securitySchemes.has(schemeName)) {
           throw new Error(
-            `A2XAgent.getAgentCard: security requirement references unregistered scheme '${schemeName}'`,
+            `A2XServer.getAgentCard: security requirement references unregistered scheme '${schemeName}'`,
           );
         }
       }
@@ -366,7 +366,7 @@ export class A2XAgent {
           for (const schemeName of Object.keys(req)) {
             if (!state.securitySchemes.has(schemeName)) {
               throw new Error(
-                `A2XAgent.getAgentCard: skill '${skill.id}' security requirement references unregistered scheme '${schemeName}'`,
+                `A2XServer.getAgentCard: skill '${skill.id}' security requirement references unregistered scheme '${schemeName}'`,
               );
             }
           }
@@ -466,12 +466,12 @@ export class A2XAgent {
 
     if (!mergedState.name) {
       throw new Error(
-        'A2XAgent.getAuthenticatedExtendedCard: name is required on the merged state',
+        'A2XServer.getAuthenticatedExtendedCard: name is required on the merged state',
       );
     }
     if (!mergedState.description) {
       throw new Error(
-        'A2XAgent.getAuthenticatedExtendedCard: description is required on the merged state',
+        'A2XServer.getAuthenticatedExtendedCard: description is required on the merged state',
       );
     }
 
@@ -556,3 +556,17 @@ export class A2XAgent {
     };
   }
 }
+
+// ─── Deprecated aliases ───
+//
+// `A2XServer` was originally named `A2XAgent`. The class is the A2A protocol
+// *server* wrapper (task store, executor, AgentCard builder) — not an agent —
+// so it was renamed to remove the confusion with `LlmAgent`. These aliases
+// keep existing imports working and will be removed in a future major.
+
+/** @deprecated Renamed to {@link A2XServer}. Import `A2XServer` instead. */
+export const A2XAgent = A2XServer;
+/** @deprecated Renamed to {@link A2XServer}. Use `A2XServer` instead. */
+export type A2XAgent = A2XServer;
+/** @deprecated Renamed to {@link A2XServerOptions}. Use `A2XServerOptions` instead. */
+export type A2XAgentOptions = A2XServerOptions;

--- a/packages/a2x/src/a2x/index.ts
+++ b/packages/a2x/src/a2x/index.ts
@@ -5,8 +5,11 @@
 
 export { AgentExecutor, StreamingMode } from './agent-executor.js';
 export type { AgentExecutorOptions, RunConfig } from './agent-executor.js';
+export { A2XServer } from './a2x-agent.js';
+export type { ProtocolVersion, A2XServerOptions } from './a2x-agent.js';
+// Deprecated aliases (A2XAgent → A2XServer). Removed in a future major.
 export { A2XAgent } from './a2x-agent.js';
-export type { ProtocolVersion, A2XAgentOptions } from './a2x-agent.js';
+export type { A2XAgentOptions } from './a2x-agent.js';
 export { AgentCardMapperFactory } from './agent-card-mapper.js';
 export type { AgentCardMapper } from './agent-card-mapper.js';
 export { V03AgentCardMapper } from './v03-mapper.js';

--- a/packages/a2x/src/transport/request-handler.ts
+++ b/packages/a2x/src/transport/request-handler.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { A2XAgent } from '../a2x/a2x-agent.js';
+import type { A2XServer } from '../a2x/a2x-agent.js';
 import type {
   JSONRPCRequest,
   JSONRPCResponse,
@@ -55,14 +55,14 @@ export type HandleResult =
   | AsyncGenerator<unknown>;
 
 export class DefaultRequestHandler {
-  private readonly a2xAgent: A2XAgent;
+  private readonly a2xServer: A2XServer;
   private readonly router: JsonRpcRouter;
   private readonly responseMapper: ResponseMapper;
 
-  constructor(a2xAgent: A2XAgent) {
-    this.a2xAgent = a2xAgent;
+  constructor(a2xServer: A2XServer) {
+    this.a2xServer = a2xServer;
     this.router = new JsonRpcRouter();
-    this.responseMapper = ResponseMapperFactory.getMapper(a2xAgent.protocolVersion);
+    this.responseMapper = ResponseMapperFactory.getMapper(a2xServer.protocolVersion);
     this._registerRoutes();
   }
 
@@ -134,7 +134,7 @@ export class DefaultRequestHandler {
     // emit an auth-required task. Other methods don't have a task-shaped
     // response, so they fall back to `-32600 InvalidRequest`.
     let authResult: AuthResult | undefined;
-    if (context && this.a2xAgent.securityRequirements.length > 0) {
+    if (context && this.a2xServer.securityRequirements.length > 0) {
       authResult = await this._authenticate(context);
       if (!authResult.authenticated) {
         const reason = authResult.error ?? 'Authentication required';
@@ -176,7 +176,7 @@ export class DefaultRequestHandler {
     // route via JsonRpcRouter because that layer has no access to auth.
     if (request.method === A2A_METHODS.GET_EXTENDED_CARD) {
       try {
-        if (!this.a2xAgent.hasAuthenticatedExtendedCardProvider) {
+        if (!this.a2xServer.hasAuthenticatedExtendedCardProvider) {
           throw new AuthenticatedExtendedCardNotConfiguredError();
         }
         if (!authResult || !authResult.authenticated) {
@@ -184,7 +184,7 @@ export class DefaultRequestHandler {
             'Authentication is required for the authenticated extended card',
           );
         }
-        const card = await this.a2xAgent.getAuthenticatedExtendedCard(authResult);
+        const card = await this.a2xServer.getAuthenticatedExtendedCard(authResult);
         return {
           jsonrpc: '2.0',
           id: request.id,
@@ -221,7 +221,7 @@ export class DefaultRequestHandler {
    * `protocolVersion` to match the wire format the server actually speaks.
    */
   getAgentCard(): AgentCardV03 | AgentCardV10 {
-    return this.a2xAgent.getAgentCard();
+    return this.a2xServer.getAgentCard();
   }
 
   // ─── Private: auth-required Task synthesis ───
@@ -310,8 +310,8 @@ export class DefaultRequestHandler {
    * Passes if ANY requirement group is fully satisfied.
    */
   private async _authenticate(context: RequestContext): Promise<AuthResult> {
-    const requirements = this.a2xAgent.securityRequirements;
-    const schemes = this.a2xAgent.securitySchemes;
+    const requirements = this.a2xServer.securityRequirements;
+    const schemes = this.a2xServer.securitySchemes;
 
     const errors: string[] = [];
 
@@ -403,7 +403,7 @@ export class DefaultRequestHandler {
   private _validateExtensionActivation(
     context: RequestContext,
   ): InvalidRequestError | null {
-    const required = this.a2xAgent.extensions.filter((ext) => ext.required);
+    const required = this.a2xServer.extensions.filter((ext) => ext.required);
     if (required.length === 0) return null;
 
     const activated = parseActivatedExtensions(context.headers);
@@ -518,12 +518,12 @@ export class DefaultRequestHandler {
   private async _resolveTaskForMessage(params: SendMessageParams) {
     const messageTaskId = (params.message as { taskId?: unknown }).taskId;
     if (typeof messageTaskId === 'string' && messageTaskId.length > 0) {
-      const existing = await this.a2xAgent.taskStore.getTask(messageTaskId);
+      const existing = await this.a2xServer.taskStore.getTask(messageTaskId);
       if (existing && !TERMINAL_STATES.has(existing.status.state)) {
         return existing;
       }
     }
-    return this.a2xAgent.taskStore.createTask({
+    return this.a2xServer.taskStore.createTask({
       contextId: params.message.contextId,
       metadata: params.metadata,
     });
@@ -540,7 +540,7 @@ export class DefaultRequestHandler {
     // events can find the config when delivery is wired.
     await this._registerInlinePushConfig(task.id, params.configuration);
 
-    const completedTask = await this.a2xAgent.agentExecutor.execute(
+    const completedTask = await this.a2xServer.agentExecutor.execute(
       task,
       params.message,
     );
@@ -568,7 +568,7 @@ export class DefaultRequestHandler {
     const pushConfig = config?.pushNotificationConfig;
     if (!pushConfig) return;
 
-    const store = this.a2xAgent.pushNotificationConfigStore;
+    const store = this.a2xServer.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
@@ -591,8 +591,8 @@ export class DefaultRequestHandler {
    * `Task` is only used inside the SDK and must not leak onto the wire.
    */
   private async _dispatchPushNotifications(task: Task): Promise<void> {
-    const store = this.a2xAgent.pushNotificationConfigStore;
-    const sender = this.a2xAgent.pushNotificationSender;
+    const store = this.a2xServer.pushNotificationConfigStore;
+    const sender = this.a2xServer.pushNotificationSender;
     if (!store || !sender) return;
     let configs;
     try {
@@ -610,7 +610,7 @@ export class DefaultRequestHandler {
     params: SendMessageParams,
   ): AsyncGenerator<unknown> {
     if (
-      this.a2xAgent.agentExecutor.runConfig.streamingMode ===
+      this.a2xServer.agentExecutor.runConfig.streamingMode ===
       StreamingMode.NONE
     ) {
       throw new UnsupportedOperationError(
@@ -625,12 +625,12 @@ export class DefaultRequestHandler {
     // §MessageSendConfiguration.
     await this._registerInlinePushConfig(task.id, params.configuration);
 
-    const eventStream = this.a2xAgent.agentExecutor.executeStream(
+    const eventStream = this.a2xServer.agentExecutor.executeStream(
       task,
       params.message,
     );
 
-    const bus = this.a2xAgent.taskEventBus;
+    const bus = this.a2xServer.taskEventBus;
 
     let reachedTerminal = false;
 
@@ -645,7 +645,7 @@ export class DefaultRequestHandler {
           if (TERMINAL_STATES.has(event.status.state)) {
             reachedTerminal = true;
           } else {
-            await this.a2xAgent.taskStore.updateTask(task.id, {
+            await this.a2xServer.taskStore.updateTask(task.id, {
               status: event.status,
             });
           }
@@ -662,7 +662,7 @@ export class DefaultRequestHandler {
       if (reachedTerminal) {
         // Re-fetch the task so the webhook body reflects the final
         // store state (artifacts accumulated during streaming, etc).
-        const final = await this.a2xAgent.taskStore.getTask(task.id);
+        const final = await this.a2xServer.taskStore.getTask(task.id);
         if (final) void this._dispatchPushNotifications(final);
       }
     }
@@ -671,7 +671,7 @@ export class DefaultRequestHandler {
   private async *_handleResubscribe(
     params: TaskIdParams,
   ): AsyncGenerator<unknown> {
-    const task = await this.a2xAgent.taskStore.getTask(params.id);
+    const task = await this.a2xServer.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
     }
@@ -688,7 +688,7 @@ export class DefaultRequestHandler {
       return;
     }
 
-    const bus = this.a2xAgent.taskEventBus;
+    const bus = this.a2xServer.taskEventBus;
     for await (const event of bus.subscribe(params.id)) {
       if ('status' in event) {
         yield this.responseMapper.mapStatusUpdateEvent(event as TaskStatusUpdateEvent);
@@ -699,7 +699,7 @@ export class DefaultRequestHandler {
   }
 
   private async _handleGetTask(params: TaskQueryParams): Promise<unknown> {
-    const task = await this.a2xAgent.taskStore.getTask(params.id);
+    const task = await this.a2xServer.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
     }
@@ -708,7 +708,7 @@ export class DefaultRequestHandler {
   }
 
   private async _handleCancelTask(params: TaskIdParams): Promise<unknown> {
-    const task = await this.a2xAgent.taskStore.getTask(params.id);
+    const task = await this.a2xServer.taskStore.getTask(params.id);
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${params.id}`);
     }
@@ -719,7 +719,7 @@ export class DefaultRequestHandler {
       );
     }
 
-    const canceledTask = await this.a2xAgent.agentExecutor.cancel(task);
+    const canceledTask = await this.a2xServer.agentExecutor.cancel(task);
 
     return this.responseMapper.mapTask(canceledTask);
   }
@@ -727,7 +727,7 @@ export class DefaultRequestHandler {
   private async _handleDeletePushNotificationConfig(
     params: DeletePushNotificationConfigParams,
   ): Promise<null> {
-    const store = this.a2xAgent.pushNotificationConfigStore;
+    const store = this.a2xServer.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
@@ -745,7 +745,7 @@ export class DefaultRequestHandler {
   private async _handleSetPushNotificationConfig(
     params: TaskPushNotificationConfig,
   ): Promise<unknown> {
-    const store = this.a2xAgent.pushNotificationConfigStore;
+    const store = this.a2xServer.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
@@ -757,7 +757,7 @@ export class DefaultRequestHandler {
   private async _handleGetPushNotificationConfig(
     params: GetPushNotificationConfigParams,
   ): Promise<unknown> {
-    const store = this.a2xAgent.pushNotificationConfigStore;
+    const store = this.a2xServer.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
@@ -788,7 +788,7 @@ export class DefaultRequestHandler {
   private async _handleListPushNotificationConfigs(
     params: ListPushNotificationConfigsParams,
   ): Promise<unknown> {
-    const store = this.a2xAgent.pushNotificationConfigStore;
+    const store = this.a2xServer.pushNotificationConfigStore;
     if (!store) {
       throw new PushNotificationNotSupportedError();
     }
@@ -926,7 +926,7 @@ export class DefaultRequestHandler {
     let taskId: string;
     let configId: string;
 
-    if (this.a2xAgent.protocolVersion === '0.3') {
+    if (this.a2xServer.protocolVersion === '0.3') {
       // v0.3: { id: taskId, pushNotificationConfigId: configId }
       if (typeof p.id !== 'string' || p.id.trim() === '') {
         throw new InvalidParamsError(
@@ -1002,7 +1002,7 @@ export class DefaultRequestHandler {
     // top-level `url` is what disambiguates flat from nested — a v0.3
     // request never has top-level `url`, only `pushNotificationConfig`.
     const isFlat =
-      this.a2xAgent.protocolVersion === '1.0' &&
+      this.a2xServer.protocolVersion === '1.0' &&
       typeof p.url === 'string';
 
     const source: Record<string, unknown> = isFlat
@@ -1086,7 +1086,7 @@ export class DefaultRequestHandler {
     }
 
     let schemes: string[];
-    if (this.a2xAgent.protocolVersion === '1.0') {
+    if (this.a2xServer.protocolVersion === '1.0') {
       if (typeof auth.scheme !== 'string' || auth.scheme.trim() === '') {
         throw new InvalidParamsError(
           'SetPushNotificationConfig: "pushNotificationConfig.authentication.scheme" must be a non-empty string',
@@ -1140,7 +1140,7 @@ export class DefaultRequestHandler {
     let taskId: string;
     let configId: string | undefined;
 
-    if (this.a2xAgent.protocolVersion === '0.3') {
+    if (this.a2xServer.protocolVersion === '0.3') {
       // v0.3: { id: taskId, pushNotificationConfigId?: configId }
       if (typeof p.id !== 'string' || p.id.trim() === '') {
         throw new InvalidParamsError(
@@ -1202,7 +1202,7 @@ export class DefaultRequestHandler {
     const p = params as Record<string, unknown>;
     let taskId: string;
 
-    if (this.a2xAgent.protocolVersion === '0.3') {
+    if (this.a2xServer.protocolVersion === '0.3') {
       // v0.3: { id: taskId }
       if (typeof p.id !== 'string' || p.id.trim() === '') {
         throw new InvalidParamsError(

--- a/packages/a2x/src/transport/to-a2x.ts
+++ b/packages/a2x/src/transport/to-a2x.ts
@@ -10,7 +10,7 @@ import type { ProtocolVersion } from '../a2x/a2x-agent.js';
 import { InMemoryRunner } from '../runner/in-memory-runner.js';
 import { AgentExecutor, StreamingMode } from '../a2x/agent-executor.js';
 import { InMemoryTaskStore } from '../a2x/task-store.js';
-import { A2XAgent } from '../a2x/a2x-agent.js';
+import { A2XServer } from '../a2x/a2x-agent.js';
 import { DefaultRequestHandler } from './request-handler.js';
 import { createSSEStream } from './sse-handler.js';
 import type { RequestContext } from '../types/auth.js';
@@ -27,7 +27,9 @@ export interface ToA2xOptions {
 
 export interface ToA2xResult {
   handler: DefaultRequestHandler;
-  a2xAgent: A2XAgent;
+  a2xServer: A2XServer;
+  /** @deprecated Renamed to {@link ToA2xResult.a2xServer}. Use `a2xServer`. */
+  a2xAgent: A2XServer;
   listen(port?: number): Promise<void>;
 }
 
@@ -51,38 +53,40 @@ export function toA2x(
   });
 
   const taskStore = new InMemoryTaskStore();
-  const a2xAgent = new A2XAgent({
+  const a2xServer = new A2XServer({
     taskStore,
     executor: agentExecutor,
     protocolVersion: options.protocolVersion,
   });
 
   // Apply configuration
-  a2xAgent.setDefaultUrl(options.defaultUrl);
+  a2xServer.setDefaultUrl(options.defaultUrl);
 
   if (options.skills) {
     for (const skill of options.skills) {
-      a2xAgent.addSkill(skill);
+      a2xServer.addSkill(skill);
     }
   }
 
   if (options.securitySchemes) {
     for (const [name, scheme] of Object.entries(options.securitySchemes)) {
-      a2xAgent.addSecurityScheme(name, scheme);
+      a2xServer.addSecurityScheme(name, scheme);
     }
   }
 
   if (options.securityRequirements) {
     for (const req of options.securityRequirements) {
-      a2xAgent.addSecurityRequirement(req);
+      a2xServer.addSecurityRequirement(req);
     }
   }
 
-  const handler = new DefaultRequestHandler(a2xAgent);
+  const handler = new DefaultRequestHandler(a2xServer);
 
   return {
     handler,
-    a2xAgent,
+    a2xServer,
+    // Deprecated alias — same instance, kept for backward compatibility.
+    a2xAgent: a2xServer,
     async listen(port?: number): Promise<void> {
       const listenPort = port ?? options.port ?? 3000;
 

--- a/packages/a2x/src/x402/index.ts
+++ b/packages/a2x/src/x402/index.ts
@@ -15,7 +15,7 @@
  *
  * ```ts
  * import {
- *   A2XAgent, AgentExecutor, BaseAgent, StreamingMode,
+ *   A2XServer, AgentExecutor, BaseAgent, StreamingMode,
  *   x402RequestPayment, parseX402PaymentSubmission, pickX402Requirement,
  *   validateX402PayloadShape, normalizeX402Accept,
  *   buildX402PaymentCompletedMetadata, buildX402PaymentFailedMetadata,
@@ -111,7 +111,7 @@
  * }
  *
  * const facilitator = resolveFacilitator();
- * const agent = new A2XAgent({ taskStore, executor })
+ * const agent = new A2XServer({ taskStore, executor })
  *   .setName('Paid Agent')
  *   .addExtension({ uri: X402_EXTENSION_URI, required: true });
  * ```

--- a/samples/express-noauth/src/index.ts
+++ b/samples/express-noauth/src/index.ts
@@ -6,7 +6,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   createSSEStream,
 } from '@a2x/sdk';
@@ -37,14 +37,14 @@ const agentExecutor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 const taskStore = new InMemoryTaskStore();
-const a2xAgent = new A2XAgent({
+const a2xServer = new A2XServer({
   taskStore,
   executor: agentExecutor,
   protocolVersion: '1.0',
 });
 
-a2xAgent.setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:4000'}/a2a`);
-a2xAgent.addSkill({
+a2xServer.setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:4000'}/a2a`);
+a2xServer.addSkill({
   id: 'echo',
   name: 'Echo',
   description: 'Echoes back the user message',
@@ -52,7 +52,7 @@ a2xAgent.addSkill({
   examples: ['Hello, agent!'],
 });
 
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 
 // ─── 3. Express app ───
 

--- a/samples/express/src/index.ts
+++ b/samples/express/src/index.ts
@@ -6,7 +6,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   createSSEStream,
   ApiKeyAuthorization,
@@ -36,14 +36,14 @@ const agentExecutor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 const taskStore = new InMemoryTaskStore();
-const a2xAgent = new A2XAgent({
+const a2xServer = new A2XServer({
   taskStore,
   executor: agentExecutor,
   protocolVersion: '1.0',
 });
 
-a2xAgent.setDefaultUrl(`${process.env.BASE_URL}/a2a`);
-a2xAgent.addSkill({
+a2xServer.setDefaultUrl(`${process.env.BASE_URL}/a2a`);
+a2xServer.addSkill({
   id: 'echo',
   name: 'Echo',
   description: 'Echoes back the user message',
@@ -53,7 +53,7 @@ a2xAgent.addSkill({
 
 // ─── 3. Security: API Key + OAuth2 Device Code (OR logic) ───
 
-a2xAgent
+a2xServer
   .addSecurityScheme(
     'apiKey',
     new ApiKeyAuthorization({
@@ -93,7 +93,7 @@ a2xAgent
   .addSecurityRequirement({ apiKey: [] })
   .addSecurityRequirement({ deviceCode: ['agent:invoke'] });
 
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 
 // ─── 4. Express app ───
 

--- a/samples/nextjs-skill/src/app/.well-known/handler.ts
+++ b/samples/nextjs-skill/src/app/.well-known/handler.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { a2xAgent } from "@/lib/a2x-setup";
+import { a2xServer } from "@/lib/a2x-setup";
 
 export async function AgentCardHandler(_: NextRequest) {
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     return NextResponse.json(card);
   } catch (error) {
     return NextResponse.json(

--- a/samples/nextjs-skill/src/lib/a2x-setup.ts
+++ b/samples/nextjs-skill/src/lib/a2x-setup.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import {
-  A2XAgent,
+  A2XServer,
   AgentExecutor,
   DefaultRequestHandler,
   InMemoryRunner,
@@ -64,7 +64,7 @@ const executor = new AgentExecutor({
 
 const taskStore = new InMemoryTaskStore();
 
-export const a2xAgent = new A2XAgent({
+export const a2xServer = new A2XServer({
   taskStore,
   executor,
   protocolVersion: "1.0",
@@ -78,4 +78,4 @@ export const a2xAgent = new A2XAgent({
     tags: ["demo", "skills"],
   });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);

--- a/samples/nextjs-x402-agent-driven/src/app/.well-known/handler.ts
+++ b/samples/nextjs-x402-agent-driven/src/app/.well-known/handler.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { a2xAgent } from '@/lib/a2x-setup';
+import { a2xServer } from '@/lib/a2x-setup';
 
 export async function AgentCardHandler(_: NextRequest) {
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     return NextResponse.json(card);
   } catch (error) {
     return NextResponse.json(

--- a/samples/nextjs-x402-agent-driven/src/lib/a2x-setup.ts
+++ b/samples/nextjs-x402-agent-driven/src/lib/a2x-setup.ts
@@ -1,6 +1,6 @@
 import {
   AgentExecutor,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   InMemoryPushNotificationConfigStore,
   InMemoryRunner,
@@ -106,7 +106,7 @@ const executor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 
-export const a2xAgent = new A2XAgent({
+export const a2xServer = new A2XServer({
   taskStore: new InMemoryTaskStore(),
   executor,
   protocolVersion: '1.0',
@@ -124,4 +124,4 @@ export const a2xAgent = new A2XAgent({
   })
   .addExtension({ uri: X402_EXTENSION_URI, required: true });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);

--- a/samples/nextjs-x402/src/app/.well-known/handler.ts
+++ b/samples/nextjs-x402/src/app/.well-known/handler.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { a2xAgent } from '@/lib/a2x-setup';
+import { a2xServer } from '@/lib/a2x-setup';
 
 export async function AgentCardHandler(_: NextRequest) {
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     return NextResponse.json(card);
   } catch (error) {
     return NextResponse.json(

--- a/samples/nextjs-x402/src/lib/a2x-setup.ts
+++ b/samples/nextjs-x402/src/lib/a2x-setup.ts
@@ -1,6 +1,6 @@
 import {
   AgentExecutor,
-  A2XAgent,
+  A2XServer,
   BaseAgent,
   DefaultRequestHandler,
   InMemoryPushNotificationConfigStore,
@@ -155,7 +155,7 @@ const executor = new AgentExecutor({
   runConfig: { streamingMode: StreamingMode.SSE },
 });
 
-export const a2xAgent = new A2XAgent({
+export const a2xServer = new A2XServer({
   taskStore: new InMemoryTaskStore(),
   executor,
   protocolVersion: '1.0',
@@ -170,4 +170,4 @@ export const a2xAgent = new A2XAgent({
   })
   .addExtension({ uri: X402_EXTENSION_URI, required: true });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);

--- a/samples/nextjs/src/app/.well-known/handler.ts
+++ b/samples/nextjs/src/app/.well-known/handler.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { a2xAgent } from "@/lib/a2x-setup";
+import { a2xServer } from "@/lib/a2x-setup";
 
 export async function AgentCardHandler(_: NextRequest) {
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     return NextResponse.json(card);
   } catch (error) {
     return NextResponse.json(

--- a/samples/nextjs/src/lib/a2x-setup.ts
+++ b/samples/nextjs/src/lib/a2x-setup.ts
@@ -5,7 +5,7 @@ import {
   StreamingMode,
   InMemoryTaskStore,
   InMemoryPushNotificationConfigStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   OAuth2DeviceCodeAuthorization,
 } from "@a2x/sdk";
@@ -30,7 +30,7 @@ const executor = new AgentExecutor({
 const taskStore = new InMemoryTaskStore();
 const pushNotificationConfigStore = new InMemoryPushNotificationConfigStore();
 
-export const a2xAgent = new A2XAgent({
+export const a2xServer = new A2XServer({
   taskStore,
   executor,
   protocolVersion: '1.0',
@@ -64,4 +64,4 @@ export const a2xAgent = new A2XAgent({
   )
   .addSecurityRequirement({ deviceCode: ['agent:invoke'] });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);

--- a/skills/a2x-agent-integration/SKILL.md
+++ b/skills/a2x-agent-integration/SKILL.md
@@ -99,7 +99,7 @@ Look for these key exports:
 | `InMemoryRunner` | Agent execution runtime |
 | `AgentExecutor` | Bridges runner with A2A task lifecycle |
 | `InMemoryTaskStore` | In-memory task storage |
-| `A2XAgent` | A2A protocol integration (AgentCard, skills, security) |
+| `A2XServer` | A2A protocol integration (AgentCard, skills, security) |
 | `DefaultRequestHandler` | Framework-agnostic JSON-RPC handler |
 | `createSSEStream` | SSE streaming helper |
 | `FunctionTool` | Wrap async functions as tools |
@@ -140,7 +140,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
 } from '@a2x/sdk';
 // Choose your provider — see wiki/providers.md
@@ -168,8 +168,8 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-// 3. Create the A2XAgent (A2A protocol bridge)
-export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+// 3. Create the A2XServer (A2A protocol bridge)
+export const a2xServer = new A2XServer({ taskStore, executor, protocolVersion: '1.0' })
   .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/a2a`)
   .addSkill({
     id: 'chat',
@@ -182,7 +182,7 @@ export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.
 // .addSecurityRequirement({ apiKey: [] })
 
 // 4. Create the request handler
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 **Customization points for the user:**
@@ -251,7 +251,7 @@ if (result && typeof result === 'object' && Symbol.asyncIterator in result) {
 | `/.well-known/agent.json` | GET | AgentCard discovery (A2A standard) |
 | `/a2a` | POST | JSON-RPC 2.0 endpoint for A2A messages |
 
-The paths can be customized — update `setDefaultUrl()` on the A2XAgent to match.
+The paths can be customized — update `setDefaultUrl()` on the A2XServer to match.
 
 ---
 
@@ -264,7 +264,7 @@ This skill uses `@a2x/sdk` instead of `@a2a-js/sdk` + `@google/adk`. Key differe
 | Dependencies | Single package | Two packages |
 | LLM Providers | Google, Anthropic, OpenAI built-in | Google only (via ADK) |
 | Protocol Versions | v0.3 + v1.0 from single definition | v1.0 only |
-| AgentCard | Auto-generated via `A2XAgent` builder | Manual JSON object |
+| AgentCard | Auto-generated via `A2XServer` builder | Manual JSON object |
 | Authentication | Built-in security scheme classes | Manual implementation |
 | Handler | `DefaultRequestHandler` (framework-agnostic) | `JsonRpcTransportHandler` |
 | Quick Start | `toA2x()` helper with built-in HTTP server | Not available |

--- a/skills/a2x-agent-integration/wiki/concepts.md
+++ b/skills/a2x-agent-integration/wiki/concepts.md
@@ -8,7 +8,7 @@
 
 ```
 Layer 4: Transport        — DefaultRequestHandler, createSSEStream, toA2x
-Layer 3: A2X Integration  — A2XAgent, AgentExecutor, TaskStore, AgentCard mappers
+Layer 3: A2X Integration  — A2XServer, AgentExecutor, TaskStore, AgentCard mappers
 Layer 2: Agent Runtime    — LlmAgent, Tools, Runner, Session, Providers
 Layer 1: Types & Security — A2A protocol types, SecurityScheme classes
 ```
@@ -97,14 +97,14 @@ interface TaskStore {
 }
 ```
 
-### A2XAgent
+### A2XServer
 
 The central integration class. Bridges agent runtime with A2A protocol. Auto-generates AgentCards for both v0.3 and v1.0 from a single definition.
 
 ```typescript
-import { A2XAgent } from '@a2x/sdk';
+import { A2XServer } from '@a2x/sdk';
 
-const a2xAgent = new A2XAgent({
+const a2xServer = new A2XServer({
   taskStore,
   executor,
   protocolVersion: '1.0',  // Default protocol version: '0.3' | '1.0'
@@ -114,7 +114,7 @@ const a2xAgent = new A2XAgent({
 **Builder methods** (all chainable):
 
 ```typescript
-a2xAgent
+a2xServer
   .setName('My Agent')              // Override auto-extracted name
   .setDescription('Agent desc')     // Override auto-extracted description
   .setVersion('1.0.0')              // Agent version
@@ -134,9 +134,9 @@ a2xAgent
 **Getting AgentCards:**
 
 ```typescript
-const cardV10 = a2xAgent.getAgentCard();       // Default version
-const cardV03 = a2xAgent.getAgentCard('0.3');   // Explicit v0.3
-const cardV10 = a2xAgent.getAgentCard('1.0');   // Explicit v1.0
+const cardV10 = a2xServer.getAgentCard();       // Default version
+const cardV03 = a2xServer.getAgentCard('0.3');   // Explicit v0.3
+const cardV10 = a2xServer.getAgentCard('1.0');   // Explicit v1.0
 ```
 
 ### DefaultRequestHandler
@@ -146,7 +146,7 @@ Framework-agnostic JSON-RPC handler. Routes A2A methods to the appropriate logic
 ```typescript
 import { DefaultRequestHandler } from '@a2x/sdk';
 
-const handler = new DefaultRequestHandler(a2xAgent);
+const handler = new DefaultRequestHandler(a2xServer);
 
 // Handle a JSON-RPC request
 const result = await handler.handle(body, context);
@@ -176,7 +176,7 @@ const card = handler.getAgentCard('0.3');     // Specific version
 | Security | `security[]` + `securitySchemes{}` | `securityRequirements[]` (OpenAPI 3.2) |
 | Device Code OAuth | Not supported | Supported |
 
-You define your agent once, and `A2XAgent.getAgentCard(version)` outputs the correct format.
+You define your agent once, and `A2XServer.getAgentCard(version)` outputs the correct format.
 
 ---
 

--- a/skills/a2x-agent-integration/wiki/express.md
+++ b/skills/a2x-agent-integration/wiki/express.md
@@ -37,7 +37,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   ApiKeyAuthorization,
 } from '@a2x/sdk';
@@ -60,7 +60,7 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+export const a2xServer = new A2XServer({ taskStore, executor, protocolVersion: '1.0' })
   .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:4000'}/a2a`)
   .addSkill({
     id: 'chat',
@@ -76,7 +76,7 @@ export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.
   }))
   .addSecurityRequirement({ apiKey: [] });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 ---
@@ -86,7 +86,7 @@ export const handler = new DefaultRequestHandler(a2xAgent);
 ```typescript
 import 'dotenv/config';
 import express from 'express';
-import { handler, a2xAgent } from './lib/a2x-setup';
+import { handler, a2xServer } from './lib/a2x-setup';
 import { createSSEStream } from '@a2x/sdk';
 import type { RequestContext } from '@a2x/sdk';
 

--- a/skills/a2x-agent-integration/wiki/nestjs.md
+++ b/skills/a2x-agent-integration/wiki/nestjs.md
@@ -30,7 +30,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
   createSSEStream,
 } from '@a2x/sdk';
@@ -42,7 +42,7 @@ import { GoogleProvider } from '@a2x/sdk/google';
 @Injectable()
 export class A2aService implements OnModuleInit {
   private handler!: DefaultRequestHandler;
-  private a2xAgent!: A2XAgent;
+  private a2xServer!: A2XServer;
 
   onModuleInit() {
     const agent = new LlmAgent({
@@ -62,7 +62,7 @@ export class A2aService implements OnModuleInit {
     });
     const taskStore = new InMemoryTaskStore();
 
-    this.a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+    this.a2xServer = new A2XServer({ taskStore, executor, protocolVersion: '1.0' })
       .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/a2a`)
       .addSkill({
         id: 'chat',
@@ -71,7 +71,7 @@ export class A2aService implements OnModuleInit {
         tags: ['chat', 'general'],
       });
 
-    this.handler = new DefaultRequestHandler(this.a2xAgent);
+    this.handler = new DefaultRequestHandler(this.a2xServer);
   }
 
   getAgentCard() {

--- a/skills/a2x-agent-integration/wiki/nextjs-app-router.md
+++ b/skills/a2x-agent-integration/wiki/nextjs-app-router.md
@@ -34,7 +34,7 @@ import {
   AgentExecutor,
   StreamingMode,
   InMemoryTaskStore,
-  A2XAgent,
+  A2XServer,
   DefaultRequestHandler,
 } from '@a2x/sdk';
 import { AnthropicProvider } from '@a2x/sdk/anthropic';
@@ -58,7 +58,7 @@ const executor = new AgentExecutor({
 });
 const taskStore = new InMemoryTaskStore();
 
-export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.0' })
+export const a2xServer = new A2XServer({ taskStore, executor, protocolVersion: '1.0' })
   .setDefaultUrl(`${process.env.BASE_URL ?? 'http://localhost:3000'}/api/a2a`)
   .addSkill({
     id: 'chat',
@@ -67,7 +67,7 @@ export const a2xAgent = new A2XAgent({ taskStore, executor, protocolVersion: '1.
     tags: ['chat', 'general'],
   });
 
-export const handler = new DefaultRequestHandler(a2xAgent);
+export const handler = new DefaultRequestHandler(a2xServer);
 ```
 
 ### globalThis Singleton for HMR
@@ -78,15 +78,15 @@ In dev mode, Next.js HMR re-evaluates server modules. If you need stable singlet
 const GLOBAL_KEY = Symbol.for('a2x-handler');
 
 function getOrCreate() {
-  const g = globalThis as Record<symbol, { handler: DefaultRequestHandler; a2xAgent: A2XAgent } | undefined>;
+  const g = globalThis as Record<symbol, { handler: DefaultRequestHandler; a2xServer: A2XServer } | undefined>;
   if (!g[GLOBAL_KEY]) {
-    // ... create agent, runner, executor, taskStore, a2xAgent, handler ...
-    g[GLOBAL_KEY] = { handler, a2xAgent };
+    // ... create agent, runner, executor, taskStore, a2xServer, handler ...
+    g[GLOBAL_KEY] = { handler, a2xServer };
   }
   return g[GLOBAL_KEY]!;
 }
 
-export const { handler, a2xAgent } = getOrCreate();
+export const { handler, a2xServer } = getOrCreate();
 ```
 
 This is the same pattern Next.js recommends for Prisma and other singleton clients.
@@ -99,11 +99,11 @@ This is the same pattern Next.js recommends for Prisma and other singleton clien
 
 ```typescript
 import { NextResponse } from 'next/server';
-import { a2xAgent } from '@/lib/a2x-setup';
+import { a2xServer } from '@/lib/a2x-setup';
 
 export async function GET(): Promise<Response> {
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     return NextResponse.json(card, {
       headers: { 'Cache-Control': 'public, max-age=3600' },
     });

--- a/skills/a2x-agent-integration/wiki/nextjs-pages-router.md
+++ b/skills/a2x-agent-integration/wiki/nextjs-pages-router.md
@@ -33,7 +33,7 @@ src/
 
 ```typescript
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { a2xAgent } from '@/lib/a2x-setup';
+import { a2xServer } from '@/lib/a2x-setup';
 
 export default function agentCardHandler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -42,7 +42,7 @@ export default function agentCardHandler(req: NextApiRequest, res: NextApiRespon
   }
 
   try {
-    const card = a2xAgent.getAgentCard();
+    const card = a2xServer.getAgentCard();
     res.setHeader('Cache-Control', 'public, max-age=3600');
     res.json(card);
   } catch (error) {

--- a/skills/a2x-agent-integration/wiki/quick-start.md
+++ b/skills/a2x-agent-integration/wiki/quick-start.md
@@ -20,7 +20,7 @@ const agent = new LlmAgent({
   instruction: 'You are a helpful assistant.',
 });
 
-const { handler, a2xAgent, listen } = toA2x(agent, {
+const { handler, a2xServer, listen } = toA2x(agent, {
   defaultUrl: 'http://localhost:3000/a2a',
 });
 
@@ -53,7 +53,7 @@ const agent = new LlmAgent({
   instruction: 'You are a helpful, secure assistant.',
 });
 
-const { handler, a2xAgent, listen } = toA2x(agent, {
+const { handler, a2xServer, listen } = toA2x(agent, {
   defaultUrl: 'http://localhost:4000/a2a',
   port: 4000,
   streamingMode: StreamingMode.SSE,
@@ -102,12 +102,12 @@ interface ToA2xOptions {
 ```typescript
 interface ToA2xResult {
   handler: DefaultRequestHandler;   // For custom HTTP integration
-  a2xAgent: A2XAgent;              // For further configuration
+  a2xServer: A2XServer;              // For further configuration
   listen(port?: number): Promise<void>;  // Start the built-in HTTP server
 }
 ```
 
-You can use `handler` and `a2xAgent` directly if you want to integrate into an existing server, or call `listen()` for the built-in server.
+You can use `handler` and `a2xServer` directly if you want to integrate into an existing server, or call `listen()` for the built-in server.
 
 ---
 

--- a/skills/a2x-agent-integration/wiki/security.md
+++ b/skills/a2x-agent-integration/wiki/security.md
@@ -91,10 +91,10 @@ import {
 
 ---
 
-## Registering Schemes on A2XAgent
+## Registering Schemes on A2XServer
 
 ```typescript
-a2xAgent
+a2xServer
   .addSecurityScheme('apiKey', apiKeyScheme)
   .addSecurityScheme('bearer', bearerScheme)
   .addSecurityScheme('deviceCode', deviceCodeScheme);
@@ -110,7 +110,7 @@ Security requirements define which schemes must be satisfied. Multiple requireme
 
 ```typescript
 // User can authenticate with EITHER api key OR bearer token
-a2xAgent
+a2xServer
   .addSecurityRequirement({ apiKey: [] })
   .addSecurityRequirement({ bearer: ['agent:invoke'] });
 ```
@@ -119,7 +119,7 @@ a2xAgent
 
 ```typescript
 // User must provide BOTH api key AND bearer token
-a2xAgent
+a2xServer
   .addSecurityRequirement({ apiKey: [], bearer: ['agent:invoke'] });
 ```
 


### PR DESCRIPTION
## What

Renames the `A2XAgent` class to **`A2XServer`**.

`A2XAgent` is the A2A protocol *server* wrapper — it owns the task store, the executor, and the AgentCard builder, and is consumed by `DefaultRequestHandler`. It never runs an LLM (that is `LlmAgent`). The `*Agent` name sat confusingly next to `LlmAgent` and led users to think tools/skills should be added to it. `A2XServer` names it for what it is.

## Changes

- `A2XAgent` → **`A2XServer`** (class)
- `A2XAgentOptions` → **`A2XServerOptions`**
- `toA2x()` result field `a2xAgent` → **`a2xServer`**
- Internal references renamed (`DefaultRequestHandler`, `toA2x`, tests)
- All first-party references updated: **samples** (express, express-noauth, nextjs, nextjs-x402, nextjs-x402-agent-driven, nextjs-skill), **docs guides**, **skill wiki**, and **AGENTS.md**

## Backward compatibility (non-breaking → `minor`)

These remain as `@deprecated` aliases of the new names and will be removed in a future major:

- `A2XAgent` (alias of `A2XServer`)
- `A2XAgentOptions` (alias of `A2XServerOptions`)
- `ToA2xResult.a2xAgent` (same instance as `a2xServer`)

Existing code keeps working unchanged. A test asserts `A2XAgent === A2XServer`.

## Out of scope (intentionally unchanged)

- **`A2XAgentSkill` / `A2XAgentState`** — these describe the *AgentCard / agent being advertised*, not the server, so the `Agent` term is correct. Renaming them would balloon into the card-mapper layer (`v03/v10-mapper`) for no semantic gain.
- **Source filename** `a2x-agent.ts` kept as-is to avoid import-path churn; can be renamed to `a2x-server.ts` in a follow-up if desired.

## Verification

- `pnpm typecheck` ✅ (after `pnpm --filter @a2x/sdk build` so workspace nextjs samples resolve the new `dist` types)
- `pnpm lint` ✅
- `pnpm test` — all suites pass **except** 2 pre-existing failures in `skills-script.test.ts` (child-process script execution), confirmed failing on `main` too in this environment and unrelated to this rename.

Changeset: `minor`.
