### PR TITLE
feat(sdk): export TaskEventBus and resync docs with current surface

### DIFF
--- a/.changeset/sync-public-surface-and-docs.md
+++ b/.changeset/sync-public-surface-and-docs.md
@@ -1,0 +1,7 @@
+---
+"@a2x/sdk": minor
+---
+
+Export `TaskEventBus` and `InMemoryTaskEventBus` from the package entry. The `taskEventBus` constructor option on `A2XServer` was already public, but its supporting types were not exported, so callers could not type a custom bus (as the manual-wiring guide showed). They are now importable from `@a2x/sdk`.
+
+Also re-syncs documentation with the current public surface: corrects the `request-input` / resume model in the agent guide (the SDK keeps no cross-turn state — agents read `context.message`), fixes the client error-handling guide (auth failures surface as a `Task` in `auth-required` state, not a removed `AuthenticationRequiredError`; the JSON-RPC error-code table now matches `A2A_ERROR_CODES`), and drops references to non-existent security scheme classes.

--- a/packages/a2x/docs/guides/agent/build-an-agent.md
+++ b/packages/a2x/docs/guides/agent/build-an-agent.md
@@ -82,7 +82,7 @@ The fields that matter most for everyday agent code:
 |---|---|
 | `context.taskId` | The A2A `Task.id` of the current turn (wire-protocol identifier). **Stable across `request-input` → resume.** Bind per-task durable state (paid rows, approval tokens, …) to this — not to `session.id`. |
 | `context.contextId` | The A2A `contextId` of the current turn. One `contextId` umbrellas many tasks in the same conversation (1:N), so this is the right key for state that should outlive a single task but stay scoped to one conversation. |
-| `context.input` | Populated only on resume turns of a task that previously emitted `request-input`. Carries the prior turn's record and (optionally) a hook outcome. See [Protocol Extensions](../advanced/extensions.md). |
+| `context.message` | The incoming A2A `Message` for the current turn. On a resume turn (after the agent emitted `request-input`), read `context.message.metadata` to recover what the client submitted — the SDK keeps **no** cross-turn state, so the agent re-derives its own context. See [Protocol Extensions](../advanced/extensions.md). |
 | `context.session` | The runner's per-invocation `Session`. `session.id` is **regenerated on every turn** and is not safe to bind per-task state to — use `taskId` / `contextId` instead. |
 | `context.signal` | `AbortSignal` for the run. Listen if you do anything cancellable (e.g. external HTTP). |
 
@@ -98,7 +98,7 @@ Custom agents that extend `BaseAgent` directly express their output by yielding 
 | `file` | An attached file (URL or base64 raw). One artifact per event. |
 | `data` | A structured non-text payload (`mediaType` indicates the shape). One artifact per event. |
 | `toolCall` / `toolResult` | LLM-style tool turns (consumed by `LlmAgent` plumbing; surface only when you're modeling the round-trip yourself). |
-| `request-input` | Halt the agent and ask the client for input — most often a payment (via `x402RequestPayment`) or an approval. The executor sets the task to `input-required` and persists a small bookkeeping record so the resume turn can read what was asked for. See [Protocol Extensions](../advanced/extensions.md) and [x402 Payments](../advanced/x402-payments.md). |
+| `request-input` | Halt the agent and ask the client for input — most often a payment (via `x402RequestPayment`) or an approval. The executor sets the task to `input-required` and merges the agent-supplied metadata onto the status message. The SDK keeps **no** cross-turn bookkeeping — on the resume turn the agent re-derives what it asked for from `context.message` (and any state it persisted itself, keyed by `taskId`). See [Protocol Extensions](../advanced/extensions.md) and [x402 Payments](../advanced/x402-payments.md). |
 | `done` | Mark the run finished. Required at the end of every successful run. |
 | `error` | Mark the task failed with the given `Error`. |
 

--- a/packages/a2x/src/a2x/index.ts
+++ b/packages/a2x/src/a2x/index.ts
@@ -36,6 +36,8 @@ export type {
   PushNotificationSender,
   FetchPushNotificationSenderOptions,
 } from './push-notification-sender.js';
+export { InMemoryTaskEventBus } from './task-event-bus.js';
+export type { TaskEventBus } from './task-event-bus.js';
 
 // ─── Register default agent-card mappers ───
 

--- a/skills/a2x-agent-integration/wiki/security.md
+++ b/skills/a2x-agent-integration/wiki/security.md
@@ -79,11 +79,8 @@ const deviceCodeScheme = new OAuth2DeviceCodeAuthorization({
 
 ```typescript
 import {
-  HttpBasicAuthorization,
   OAuth2AuthorizationCodeAuthorization,
   OAuth2ClientCredentialsAuthorization,
-  OAuth2PasswordAuthorization,
-  OAuth2ImplicitAuthorization,
   OpenIdConnectAuthorization,
   MutualTlsAuthorization,
 } from '@a2x/sdk';

--- a/skills/a2x-client-integration/SKILL.md
+++ b/skills/a2x-client-integration/SKILL.md
@@ -327,5 +327,5 @@ Remind the user to:
 
 1. Set any environment variables the `AuthProvider` needs (API keys, bearer tokens, OAuth client IDs).
 2. Audit the token storage location if they enabled persistence — a world-readable file with bearer tokens is a security hazard.
-3. Add a **connection error** path distinct from **auth error** path — the SDK throws `InternalError` for HTTP-level failures and typed `A2AError` subclasses (e.g. `AuthenticationRequiredError`) for protocol-level failures. See [wiki/error-handling.md](./wiki/error-handling.md).
+3. Add a **connection error** path distinct from an **auth** path — the SDK throws `InternalError` for HTTP-level failures and typed `A2AError` subclasses (e.g. `TaskNotFoundError`) for protocol-level failures, while auth failures surface as a `Task` in the `auth-required` state (not a thrown error). See [wiki/error-handling.md](./wiki/error-handling.md).
 4. Consider retry / backoff for idempotent operations (`getTask`, `cancelTask`) — the SDK itself does no retrying beyond the single 401 refresh.

--- a/skills/a2x-client-integration/wiki/client-architecture.md
+++ b/skills/a2x-client-integration/wiki/client-architecture.md
@@ -56,9 +56,9 @@ Consequence: if the `AuthProvider` has side effects (prompting the user, opening
 
 ### Refresh is the only re-auth path
 
-The SDK only re-invokes the auth provider under one condition: a non-streaming request returned **HTTP 401** and `authProvider.refresh` is defined. Even then it retries exactly once. Protocol-level `AuthenticationRequiredError` (JSON-RPC error code `-32004`) does **not** trigger a refresh — it surfaces as a thrown error.
+The SDK re-invokes the auth provider under two conditions, each retried exactly once: (1) a non-streaming request returned **HTTP 401** and `authProvider.refresh` is defined, or (2) a response came back as a `Task` in the **`auth-required`** state. There is no thrown auth error — if the single retry is still `auth-required`, that task is returned to you as-is.
 
-If you want to retry on protocol-level auth errors too, wrap the calls yourself and construct a new client on failure.
+If you want to retry further on auth failures, inspect `task.status.state` yourself and construct a new client on failure.
 
 ---
 

--- a/skills/a2x-client-integration/wiki/error-handling.md
+++ b/skills/a2x-client-integration/wiki/error-handling.md
@@ -10,7 +10,9 @@
 |-------|--------|---------|
 | **Transport** | `fetch` threw, DNS failure, connection refused | `TypeError` (often with `code === 'ECONNREFUSED'`), `AbortError`, `fetch` spec errors |
 | **HTTP** | Non-2xx HTTP response outside the 401-refresh path | `InternalError('HTTP <status>: <statusText>')` |
-| **Protocol** | Valid HTTP response containing a JSON-RPC error | Subclass of `A2AError` (e.g. `AuthenticationRequiredError`, `TaskNotFoundError`) |
+| **Protocol** | Valid HTTP response containing a JSON-RPC error | Subclass of `A2AError` (e.g. `TaskNotFoundError`, `InvalidParamsError`) |
+
+> **Auth failures are not thrown.** Per the A2A spec, an authentication failure surfaces as a returned `Task` in the `auth-required` state — *not* a JSON-RPC error. `A2XClient` refreshes credentials once and retries; if it is still `auth-required`, it returns that task as-is. Check `task.status.state === 'auth-required'` rather than catching an error. See [The Auth-Required Path](#the-auth-required-path).
 
 Importable error types:
 
@@ -29,7 +31,6 @@ import {
   ContentTypeNotSupportedError,
   InvalidAgentResponseError,
   AuthenticatedExtendedCardNotConfiguredError,
-  AuthenticationRequiredError,
   A2A_ERROR_CODES,
 } from '@a2x/sdk';
 ```
@@ -50,15 +51,14 @@ This is the mapping the client uses internally when it sees a JSON-RPC error:
 | `-32001` | `TaskNotFoundError` | `getTask` / `cancelTask` with unknown id |
 | `-32002` | `TaskNotCancelableError` | `cancelTask` on a terminal task |
 | `-32003` | `PushNotificationNotSupportedError` | Server doesn't support push config |
-| `-32004` | `AuthenticationRequiredError` | Authentication required or failed |
-| `-32005` | `AuthenticatedExtendedCardNotConfiguredError` | Extended card requested but not configured |
-| `-32006` | `ContentTypeNotSupportedError` | Unsupported content type |
-| `-32007` | `UnsupportedOperationError` | Operation not allowed here |
-| `-32008` | `InvalidAgentResponseError` | Agent returned something invalid |
+| `-32004` | `UnsupportedOperationError` | Operation not allowed here |
+| `-32005` | `ContentTypeNotSupportedError` | Unsupported content type |
+| `-32006` | `InvalidAgentResponseError` | Agent returned something invalid |
+| `-32007` | `AuthenticatedExtendedCardNotConfiguredError` | Extended card requested but not configured |
 
 The mapping uses `A2A_ERROR_CODES` constants — consult `@a2x/sdk` source if you need the numeric values.
 
-Unknown codes fall through to `InternalError`.
+Unknown codes fall through to `InternalError`. **There is no auth-failure error code** — authentication failures are modeled as a `Task` in the `auth-required` state, not a JSON-RPC error (see below).
 
 ---
 
@@ -67,20 +67,20 @@ Unknown codes fall through to `InternalError`.
 ```typescript
 import {
   A2AError,
-  AuthenticationRequiredError,
   TaskNotFoundError,
   InternalError,
 } from '@a2x/sdk';
 
 try {
   const task = await client.sendMessage(params);
-  // …
-} catch (err) {
-  if (err instanceof AuthenticationRequiredError) {
-    // Protocol-level auth failure. Unlike HTTP 401, the SDK did NOT retry.
-    // Surface to user / log / trigger re-auth UI.
+  // Auth failure is NOT thrown — it comes back as a task state.
+  if (task.status.state === 'auth-required') {
+    // The client already refreshed once and retried; still auth-required.
+    // Surface to user / trigger re-auth UI.
     return { ok: false, reason: 'auth' };
   }
+  // …
+} catch (err) {
   if (err instanceof TaskNotFoundError) {
     return { ok: false, reason: 'task_missing' };
   }
@@ -107,6 +107,14 @@ try {
 
 ---
 
+<a id="the-auth-required-path"></a>
+## The Auth-Required Path
+
+Authentication is modeled at **two** layers, both handled by the client:
+
+1. **`auth-required` task state (protocol layer).** When `sendMessage` returns a `Task` in `auth-required` state, the client calls `authProvider.refresh` once and retries the same request. If the retry is still `auth-required`, that task is returned to you as-is — inspect `task.status.state`. No error is thrown.
+2. **HTTP 401 (transport layer).** See below.
+
 ## The 401 Refresh Path
 
 For **non-streaming** requests, the client retries exactly once on HTTP 401 — but only if:
@@ -132,7 +140,7 @@ Points to remember:
 
 - The retry happens **once**. If the refresh itself throws or the retry also fails, the error is propagated.
 - **Streaming requests do not retry.** See [streaming.md](./streaming.md).
-- **Protocol-level `AuthenticationRequiredError` (code `-32004`) does not trigger a refresh.** It's a JSON-RPC error, not an HTTP 401. If your agent sends this instead of a 401, wrap your calls to retry manually or reconfigure the server.
+- **The `auth-required` task state triggers its own one-shot refresh+retry** (see above), independent of the HTTP 401 path. It is not a JSON-RPC error and never surfaces as a thrown `A2AError`.
 
 ---
 
@@ -167,7 +175,8 @@ Only retry **idempotent** calls (`getTask`, `cancelTask`, `getAgentCard`). Never
 
 ```typescript
 function a2aErrorToHttpStatus(err: unknown): number {
-  if (err instanceof AuthenticationRequiredError) return 401;
+  // Note: auth failures are a task state (`auth-required`), not a thrown
+  // error — map those to 401 where you read the returned task, not here.
   if (err instanceof InvalidParamsError) return 400;
   if (err instanceof MethodNotFoundError) return 501;
   if (err instanceof TaskNotFoundError) return 404;

--- a/skills/a2x-client-integration/wiki/host-nextjs.md
+++ b/skills/a2x-client-integration/wiki/host-nextjs.md
@@ -94,7 +94,6 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { agentClientFor } from '@/lib/agent';
 import crypto from 'node:crypto';
-import { AuthenticationRequiredError } from '@a2x/sdk';
 import type { SendMessageParams } from '@a2x/sdk';
 
 export async function POST(request: Request) {
@@ -115,11 +114,12 @@ export async function POST(request: Request) {
       },
     };
     const task = await client.sendMessage(params);
-    return NextResponse.json(task);
-  } catch (err) {
-    if (err instanceof AuthenticationRequiredError) {
+    // Auth failure surfaces as a task state, not a thrown error.
+    if (task.status.state === 'auth-required') {
       return NextResponse.json({ error: 'reauth_required' }, { status: 401 });
     }
+    return NextResponse.json(task);
+  } catch (err) {
     if (err instanceof Error && err.message === 'REAUTH_REQUIRED') {
       return NextResponse.json({ error: 'reauth_required' }, { status: 401 });
     }

--- a/skills/a2x-client-integration/wiki/streaming.md
+++ b/skills/a2x-client-integration/wiki/streaming.md
@@ -126,10 +126,11 @@ If the server returns `application/json` instead of `text/event-stream` (e.g. be
 try {
   for await (const event of client.sendMessageStream(params)) { /* … */ }
 } catch (err) {
-  if (err instanceof AuthenticationRequiredError) { /* handle */ }
-  else if (err instanceof InvalidParamsError) { /* … */ }
+  if (err instanceof InvalidParamsError) { /* … */ }
   else throw err;
 }
+// Auth failure is not thrown — it arrives as a streamed task in the
+// `auth-required` state. Inspect `event.status.state` rather than catching.
 ```
 
 All error classes importable from `@a2x/sdk`. See [error-handling.md](./error-handling.md) for the full list.


### PR DESCRIPTION
Re-sync of docs/public surface (originally #170, recreated after its stacked base branch was deleted on #169 merge).

Exports `TaskEventBus`/`InMemoryTaskEventBus` (the `taskEventBus` A2XServer option was public but its types weren't exported) and fixes doc drift from removed surface: `context.input`→`context.message` and the no-cross-turn-state `request-input` model (build-an-agent); auth-required is a Task state, not a removed `AuthenticationRequiredError`, with a corrected JSON-RPC error-code table (client skill); dropped non-existent security scheme classes (security wiki).

Verified: typecheck + lint pass; tests pass except 2 pre-existing skills-script failures (fail on main too). Changeset: minor.